### PR TITLE
Adjust frontend API base paths for shared clients

### DIFF
--- a/apps/ui/src/taskeroo/api.ts
+++ b/apps/ui/src/taskeroo/api.ts
@@ -1,6 +1,6 @@
 import { OpenAPI, TaskService } from 'shared';
 
 // Use relative URL in production, absolute URL in development
-OpenAPI.BASE = import.meta.env.PROD ? "/api/v1" : "http://localhost:3000/api/v1";
+OpenAPI.BASE = import.meta.env.PROD ? '' : 'http://localhost:3000';
 
 export { TaskService as TaskerooService };

--- a/apps/ui/src/wikiroo/api.ts
+++ b/apps/ui/src/wikiroo/api.ts
@@ -1,6 +1,6 @@
 import { OpenAPI, WikirooService } from 'shared';
 
 // Use relative URL in production, absolute URL in development
-OpenAPI.BASE = import.meta.env.PROD ? "/api/v1" : "http://localhost:3000/api/v1";
+OpenAPI.BASE = import.meta.env.PROD ? '' : 'http://localhost:3000';
 
 export { WikirooService };


### PR DESCRIPTION
## Summary
- update the Taskeroo and Wikiroo OpenAPI client base URLs to rely on the shared client prefixing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69092d275f8c832fa7afe280f374027b