### PR TITLE
Allow completing tasks with existing comments

### DIFF
--- a/apps/backend/src/taskeroo/taskeroo.service.ts
+++ b/apps/backend/src/taskeroo/taskeroo.service.ts
@@ -264,8 +264,12 @@ export class TaskerooService {
       );
     }
 
-    if (input.status === TaskStatus.DONE && !input.comment) {
-      throw new CommentRequiredError();
+    if (input.status === TaskStatus.DONE) {
+      const hasExistingComments = task.comments?.length > 0;
+
+      if (!input.comment && !hasExistingComments) {
+        throw new CommentRequiredError();
+      }
     }
 
     // If changing to DONE and comment is provided, add the comment

--- a/apps/backend/test/taskeroo.e2e-spec.ts
+++ b/apps/backend/test/taskeroo.e2e-spec.ts
@@ -175,6 +175,18 @@ describe('Taskeroo E2E Tests', () => {
       expect(response.body.status).toBe('IN_PROGRESS');
       expect(response.body.assignee).toBe('john.doe@example.com');
     });
+
+    it('should fail to move task to Done without comment when no comments exist', async () => {
+      const response = await request(httpServer)
+        .patch(`/api/v1/taskeroo/tasks/${taskWithAssigneeId}/status`)
+        .send({
+          status: 'DONE',
+        })
+        .expect(400);
+
+      expect(response.body).toHaveProperty('status', 400);
+      expect(response.body.detail.toLowerCase()).toContain('comment');
+    });
   });
 
   describe('Task Comments', () => {
@@ -191,6 +203,18 @@ describe('Taskeroo E2E Tests', () => {
       expect(response.body.commenterName).toBe('Jane Smith');
       expect(response.body.content).toBe('This is a test comment on the task');
       expect(response.body.taskId).toBe(taskWithAssigneeId);
+    });
+
+    it('should allow moving task to Done without new comment when comments exist', async () => {
+      const response = await request(httpServer)
+        .patch(`/api/v1/taskeroo/tasks/${taskWithAssigneeId}/status`)
+        .send({
+          status: 'DONE',
+        })
+        .expect(200);
+
+      expect(response.body.status).toBe('DONE');
+      expect(response.body.comments.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## Summary
- allow Taskeroo tasks to be marked as done without supplying a new comment when prior comments exist
- keep the comment requirement when no comments are present and extend E2E coverage for both scenarios

## Testing
- npm run test:e2e *(fails: `nest` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_690997276dfc832fbfd8334fb1c0ab61