### PR TITLE
Improve Swagger documentation for PageListResponseDto

### DIFF
--- a/apps/backend/src/wikiroo/dto/page-list-response.dto.ts
+++ b/apps/backend/src/wikiroo/dto/page-list-response.dto.ts
@@ -2,6 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 import { PageSummaryDto } from './page-summary.dto';
 
 export class PageListResponseDto {
-  @ApiProperty({ type: [PageSummaryDto] })
+  @ApiProperty({
+    description: 'List of wiki pages',
+    type: [PageSummaryDto],
+  })
   items!: PageSummaryDto[];
 }


### PR DESCRIPTION
## Summary
- Added description to PageListResponseDto items property to improve API documentation
- Verified TaskResponseDto nullable fields are correctly using ApiPropertyOptional

## Changes Made
- Updated `PageListResponseDto` to include a description for the `items` property
- Confirmed `TaskResponseDto` already follows best practices with `@ApiPropertyOptional` for nullable fields (`assignee` and `sessionId`)

## Test Plan
- [x] Build passes: `npm run build:prod` completed successfully
- [x] OpenAPI spec generated without errors
- [x] All nullable fields in TaskResponseDto use `@ApiPropertyOptional` decorator
- [x] PageListResponseDto items property now has descriptive documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)