### PR TITLE
Add nested validation to response DTOs

### DIFF
--- a/apps/backend/src/taskeroo/dto/task-list-response.dto.ts
+++ b/apps/backend/src/taskeroo/dto/task-list-response.dto.ts
@@ -1,4 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
 import { TaskResponseDto } from './task-response.dto';
 
 export class TaskListResponseDto {
@@ -6,6 +8,8 @@ export class TaskListResponseDto {
     description: 'List of tasks',
     type: () => [TaskResponseDto],
   })
+  @ValidateNested({ each: true })
+  @Type(() => TaskResponseDto)
   items!: TaskResponseDto[];
 
   @ApiProperty({

--- a/apps/backend/src/taskeroo/dto/task-response.dto.ts
+++ b/apps/backend/src/taskeroo/dto/task-response.dto.ts
@@ -1,4 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
 import { TaskStatus } from '../task.entity';
 import { CommentResponseDto } from './comment-response.dto';
 
@@ -55,6 +57,8 @@ export class TaskResponseDto {
       },
     ],
   })
+  @ValidateNested({ each: true })
+  @Type(() => CommentResponseDto)
   comments!: CommentResponseDto[];
 
   @ApiProperty({

--- a/apps/backend/src/wikiroo/dto/page-list-response.dto.ts
+++ b/apps/backend/src/wikiroo/dto/page-list-response.dto.ts
@@ -1,4 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
 import { PageSummaryDto } from './page-summary.dto';
 
 export class PageListResponseDto {
@@ -6,5 +8,7 @@ export class PageListResponseDto {
     description: 'List of wiki pages',
     type: [PageSummaryDto],
   })
+  @ValidateNested({ each: true })
+  @Type(() => PageSummaryDto)
   items!: PageSummaryDto[];
 }


### PR DESCRIPTION
## Summary
Added `@ValidateNested()` and `@Type()` decorators to response DTOs with nested arrays to ensure proper validation of nested objects:

- **TaskResponseDto.comments**: Added nested validation for `CommentResponseDto[]`
- **TaskListResponseDto.items**: Added nested validation for `TaskResponseDto[]`
- **PageListResponseDto.items**: Added nested validation for `PageSummaryDto[]`

## Changes Made
1. Imported `Type` from `class-transformer` and `ValidateNested` from `class-validator`
2. Added `@ValidateNested({ each: true })` decorator to validate each item in arrays
3. Added `@Type(() => DtoClass)` decorator for proper type transformation

## Benefits
- Ensures nested objects are properly validated according to their DTO schemas
- Improves data integrity and API reliability
- Provides better error messages when nested data is invalid

## Test Plan
- [x] Build passes: `npm run build:prod` completed successfully
- [ ] CI checks pass (monitoring)
- [ ] Manual testing of API endpoints with nested data

🤖 Generated with [Claude Code](https://claude.com/claude-code)