### PR TITLE
feat: Add review shortcuts for FOR_REVIEW tasks

### DIFF
--- a/apps/ui/src/taskeroo/TaskBoard.css
+++ b/apps/ui/src/taskeroo/TaskBoard.css
@@ -714,6 +714,64 @@ form {
   font-weight: 500;
 }
 
+/* Review Shortcuts */
+.task-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.review-shortcuts {
+  display: flex;
+  gap: 12px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #ecf0f1;
+}
+
+.btn-review-done {
+  flex: 1;
+  background: linear-gradient(135deg, #27ae60 0%, #2ecc71 100%);
+  color: white;
+  border: none;
+  padding: 14px 24px;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(39, 174, 96, 0.2);
+}
+
+.btn-review-done:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(39, 174, 96, 0.3);
+  background: linear-gradient(135deg, #229954 0%, #27ae60 100%);
+}
+
+.btn-review-needs-work {
+  flex: 1;
+  background: white;
+  color: #f57f17;
+  border: 2px solid #f57f17;
+  padding: 14px 24px;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-review-needs-work:hover {
+  background: #fffde7;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(245, 127, 23, 0.2);
+}
+
+.delete-confirm {
+  display: flex;
+  gap: 12px;
+}
+
 /* Responsive */
 @media (max-width: 1200px) {
   .kanban-board {
@@ -730,5 +788,9 @@ form {
     flex-direction: column;
     gap: 15px;
     align-items: flex-start;
+  }
+
+  .review-shortcuts {
+    flex-direction: column;
   }
 }

--- a/apps/ui/src/taskeroo/TaskDetail.tsx
+++ b/apps/ui/src/taskeroo/TaskDetail.tsx
@@ -238,20 +238,38 @@ export function TaskDetail({ task, onClose, onUpdate }: TaskDetailProps) {
         </div>
 
         <div className="detail-section">
-          {showDeleteConfirm ? (
-            <div>
-              <button onClick={handleDelete} className="btn-danger">
-                Confirm Delete
+          <div className="task-actions">
+            {task.status === TaskStatus.FOR_REVIEW && (
+              <div className="review-shortcuts">
+                <button
+                  onClick={() => handleChangeStatus(TaskStatus.DONE)}
+                  className="btn-review-done"
+                >
+                  ✓ Done
+                </button>
+                <button
+                  onClick={() => handleChangeStatus(TaskStatus.IN_PROGRESS)}
+                  className="btn-review-needs-work"
+                >
+                  ← Needs work
+                </button>
+              </div>
+            )}
+            {showDeleteConfirm ? (
+              <div className="delete-confirm">
+                <button onClick={handleDelete} className="btn-danger">
+                  Confirm Delete
+                </button>
+                <button onClick={() => setShowDeleteConfirm(false)} className="btn-secondary">
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button onClick={() => setShowDeleteConfirm(true)} className="btn-danger">
+                Delete Task
               </button>
-              <button onClick={() => setShowDeleteConfirm(false)} className="btn-secondary">
-                Cancel
-              </button>
-            </div>
-          ) : (
-            <button onClick={() => setShowDeleteConfirm(true)} className="btn-danger">
-              Delete Task
-            </button>
-          )}
+            )}
+          </div>
         </div>
 
 


### PR DESCRIPTION
## Summary
- Added "Done" and "Needs work" shortcut buttons to TaskDetail component
- Buttons only appear when task status is FOR_REVIEW
- Done button: Green gradient, prominent styling (logical next step)
- Needs work button: Yellow bordered, sends task back to IN_PROGRESS
- Responsive design: buttons stack vertically on mobile

This helps reviewers quickly approve or send tasks back for revision without navigating through the full status dropdown.

## Test plan
- [x] Review shortcuts only appear for FOR_REVIEW tasks
- [x] Done button changes status to DONE
- [x] Needs work button changes status to IN_PROGRESS
- [x] Buttons styled appropriately (Done is prominent and comforting)
- [x] Responsive design works on mobile
- [x] Production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)