### PR TITLE
feat: tailor client registration for MCP clients (feature/07)

### DIFF
--- a/apps/backend/src/authorization-server/client-registration.service.ts
+++ b/apps/backend/src/authorization-server/client-registration.service.ts
@@ -139,17 +139,13 @@ export class ClientRegistrationService {
       throw new InvalidRedirectUriError('At least one redirect URI is required');
     }
 
-    // Validate that all URIs are HTTPS (except localhost for development)
+    // More lax validation for MCP clients - allow localhost and http
     for (const uri of redirectUris) {
       try {
         const url = new URL(uri);
 
-        // Require HTTPS unless it's localhost
-        if (url.protocol !== 'https:' && url.hostname !== 'localhost') {
-          throw new InvalidRedirectUriError(
-            `Redirect URI must use HTTPS: ${uri}`,
-          );
-        }
+        // Just validate it's a valid URI, no protocol restrictions
+        // MCP clients can use localhost and http URIs
       } catch {
         throw new InvalidRedirectUriError(`Invalid URI format: ${uri}`);
       }

--- a/apps/backend/src/authorization-server/dto/client-registration-response.dto.ts
+++ b/apps/backend/src/authorization-server/dto/client-registration-response.dto.ts
@@ -22,8 +22,8 @@ export class ClientRegistrationResponseDto {
   client_name!: string;
 
   @ApiProperty({
-    description: 'Array of redirect URIs for authorization callbacks',
-    example: ['https://example.com/callback'],
+    description: 'Array of redirect URIs for authorization callbacks (supports http and localhost for MCP clients)',
+    example: ['http://localhost:3000/callback', 'https://example.com/callback'],
     type: [String],
   })
   redirect_uris!: string[];
@@ -37,8 +37,8 @@ export class ClientRegistrationResponseDto {
   grant_types!: GrantType[];
 
   @ApiProperty({
-    description: 'Authentication method for the token endpoint',
-    example: TokenEndpointAuthMethod.CLIENT_SECRET_BASIC,
+    description: 'Authentication method for the token endpoint (MCP clients use "none")',
+    example: TokenEndpointAuthMethod.NONE,
     enum: TokenEndpointAuthMethod,
   })
   token_endpoint_auth_method!: TokenEndpointAuthMethod;

--- a/apps/backend/src/authorization-server/dto/register-client.dto.ts
+++ b/apps/backend/src/authorization-server/dto/register-client.dto.ts
@@ -21,13 +21,13 @@ export class RegisterClientDto {
   client_name!: string;
 
   @ApiProperty({
-    description: 'Array of redirect URIs for authorization callbacks',
-    example: ['https://example.com/callback'],
+    description: 'Array of redirect URIs for authorization callbacks (supports http and localhost for MCP clients)',
+    example: ['http://localhost:3000/callback', 'https://example.com/callback'],
     type: [String],
   })
   @IsArray()
   @ArrayNotEmpty()
-  @IsUrl({}, { each: true })
+  @IsUrl({ require_tld: false, require_protocol: true }, { each: true })
   redirect_uris!: string[];
 
   @ApiProperty({
@@ -43,8 +43,8 @@ export class RegisterClientDto {
   grant_types!: GrantType[];
 
   @ApiProperty({
-    description: 'Authentication method for the token endpoint',
-    example: TokenEndpointAuthMethod.CLIENT_SECRET_BASIC,
+    description: 'Authentication method for the token endpoint (MCP clients use "none")',
+    example: TokenEndpointAuthMethod.NONE,
     enum: TokenEndpointAuthMethod,
   })
   @IsEnum(TokenEndpointAuthMethod)

--- a/apps/backend/src/authorization-server/enums/grant-type.enum.ts
+++ b/apps/backend/src/authorization-server/enums/grant-type.enum.ts
@@ -1,5 +1,4 @@
 export enum GrantType {
   AUTHORIZATION_CODE = 'authorization_code',
   REFRESH_TOKEN = 'refresh_token',
-  CLIENT_CREDENTIALS = 'client_credentials',
 }

--- a/apps/backend/src/authorization-server/enums/token-endpoint-auth-method.enum.ts
+++ b/apps/backend/src/authorization-server/enums/token-endpoint-auth-method.enum.ts
@@ -1,5 +1,3 @@
 export enum TokenEndpointAuthMethod {
-  CLIENT_SECRET_BASIC = 'client_secret_basic',
-  CLIENT_SECRET_POST = 'client_secret_post',
   NONE = 'none',
 }

--- a/apps/backend/test/client-registration.e2e-spec.ts
+++ b/apps/backend/test/client-registration.e2e-spec.ts
@@ -1,0 +1,195 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { RegisterClientDto } from '../src/authorization-server/dto/register-client.dto';
+import { GrantType, TokenEndpointAuthMethod } from '../src/authorization-server/enums';
+
+describe('ClientRegistrationController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('POST /register', () => {
+    it('should successfully register a new MCP client with localhost redirect URI', async () => {
+      const registerDto: RegisterClientDto = {
+        client_name: `MCP Test Client ${Math.random()}`,
+        redirect_uris: ['http://localhost:3000/callback'],
+        grant_types: [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN],
+        token_endpoint_auth_method: TokenEndpointAuthMethod.NONE,
+        code_challenge_method: 'S256',
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/register')
+        .send(registerDto)
+        .expect(201);
+
+      expect(response.body).toBeDefined();
+      expect(response.body.client_id).toBeDefined();
+      expect(response.body.client_name).toEqual(registerDto.client_name);
+      expect(response.body.redirect_uris).toEqual(registerDto.redirect_uris);
+      expect(response.body.grant_types).toEqual(registerDto.grant_types);
+      expect(response.body.token_endpoint_auth_method).toEqual(
+        TokenEndpointAuthMethod.NONE,
+      );
+      // Client secret should be null for 'none' auth method
+      expect(response.body.client_secret).toBeNull();
+    });
+
+    it('should successfully register a client with HTTP redirect URI', async () => {
+      const registerDto: RegisterClientDto = {
+        client_name: `HTTP Test Client ${Math.random()}`,
+        redirect_uris: ['http://example.com/callback'],
+        grant_types: [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN],
+        token_endpoint_auth_method: TokenEndpointAuthMethod.NONE,
+        code_challenge_method: 'S256',
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/register')
+        .send(registerDto)
+        .expect(201);
+
+      expect(response.body).toBeDefined();
+      expect(response.body.client_id).toBeDefined();
+      expect(response.body.redirect_uris).toEqual(registerDto.redirect_uris);
+    });
+
+    it('should successfully register a client with multiple redirect URIs', async () => {
+      const registerDto: RegisterClientDto = {
+        client_name: `Multi URI Client ${Math.random()}`,
+        redirect_uris: [
+          'http://localhost:3000/callback',
+          'https://app.example.com/callback',
+          'http://127.0.0.1:8080/oauth/callback',
+        ],
+        grant_types: [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN],
+        token_endpoint_auth_method: TokenEndpointAuthMethod.NONE,
+        code_challenge_method: 'S256',
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/register')
+        .send(registerDto)
+        .expect(201);
+
+      expect(response.body).toBeDefined();
+      expect(response.body.redirect_uris).toHaveLength(3);
+      expect(response.body.redirect_uris).toEqual(registerDto.redirect_uris);
+    });
+
+    it('should reject registration without required grant types', async () => {
+      const registerDto = {
+        client_name: 'Invalid Client',
+        redirect_uris: ['http://localhost:3000/callback'],
+        grant_types: [GrantType.AUTHORIZATION_CODE], // Missing refresh_token
+        token_endpoint_auth_method: TokenEndpointAuthMethod.NONE,
+        code_challenge_method: 'S256',
+      };
+
+      await request(app.getHttpServer())
+        .post('/register')
+        .send(registerDto)
+        .expect(400);
+    });
+
+    it('should reject registration with invalid redirect URI', async () => {
+      const registerDto = {
+        client_name: 'Invalid URI Client',
+        redirect_uris: ['not-a-valid-uri'],
+        grant_types: [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN],
+        token_endpoint_auth_method: TokenEndpointAuthMethod.NONE,
+        code_challenge_method: 'S256',
+      };
+
+      await request(app.getHttpServer())
+        .post('/register')
+        .send(registerDto)
+        .expect(400);
+    });
+
+    it('should reject registration without PKCE for authorization_code grant', async () => {
+      const registerDto = {
+        client_name: 'No PKCE Client',
+        redirect_uris: ['http://localhost:3000/callback'],
+        grant_types: [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN],
+        token_endpoint_auth_method: TokenEndpointAuthMethod.NONE,
+        // Missing code_challenge_method
+      };
+
+      await request(app.getHttpServer())
+        .post('/register')
+        .send(registerDto)
+        .expect(400);
+    });
+
+    it('should reject duplicate client registration', async () => {
+      const registerDto: RegisterClientDto = {
+        client_name: `Duplicate Client ${Math.random()}`,
+        redirect_uris: ['http://localhost:3000/callback'],
+        grant_types: [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN],
+        token_endpoint_auth_method: TokenEndpointAuthMethod.NONE,
+        code_challenge_method: 'S256',
+      };
+
+      // First registration should succeed
+      await request(app.getHttpServer())
+        .post('/register')
+        .send(registerDto)
+        .expect(201);
+
+      // Second registration with same name should fail
+      await request(app.getHttpServer())
+        .post('/register')
+        .send(registerDto)
+        .expect(409);
+    });
+  });
+
+  describe('GET /register/:client_id', () => {
+    it('should retrieve a registered client', async () => {
+      const registerDto: RegisterClientDto = {
+        client_name: `Retrieve Test Client ${Math.random()}`,
+        redirect_uris: ['http://localhost:3000/callback'],
+        grant_types: [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN],
+        token_endpoint_auth_method: TokenEndpointAuthMethod.NONE,
+        code_challenge_method: 'S256',
+      };
+
+      const createResponse = await request(app.getHttpServer())
+        .post('/register')
+        .send(registerDto)
+        .expect(201);
+
+      const clientId = createResponse.body.client_id;
+
+      const response = await request(app.getHttpServer())
+        .get(`/register/${clientId}`)
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+      expect(response.body.client_id).toEqual(clientId);
+      expect(response.body.client_name).toEqual(registerDto.client_name);
+      // Client secret should NOT be returned on retrieval
+      expect(response.body.client_secret).toBeUndefined();
+    });
+
+    it('should return 404 for non-existent client', async () => {
+      await request(app.getHttpServer())
+        .get('/register/non-existent-client-id')
+        .expect(404);
+    });
+  });
+});

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -966,8 +966,9 @@
             "example": "My OAuth Client"
           },
           "redirect_uris": {
-            "description": "Array of redirect URIs for authorization callbacks",
+            "description": "Array of redirect URIs for authorization callbacks (supports http and localhost for MCP clients)",
             "example": [
+              "http://localhost:3000/callback",
               "https://example.com/callback"
             ],
             "type": "array",
@@ -986,18 +987,15 @@
               "type": "string",
               "enum": [
                 "authorization_code",
-                "refresh_token",
-                "client_credentials"
+                "refresh_token"
               ]
             }
           },
           "token_endpoint_auth_method": {
             "type": "string",
-            "description": "Authentication method for the token endpoint",
-            "example": "client_secret_basic",
+            "description": "Authentication method for the token endpoint (MCP clients use \"none\")",
+            "example": "none",
             "enum": [
-              "client_secret_basic",
-              "client_secret_post",
               "none"
             ]
           },
@@ -1056,8 +1054,9 @@
             "example": "My OAuth Client"
           },
           "redirect_uris": {
-            "description": "Array of redirect URIs for authorization callbacks",
+            "description": "Array of redirect URIs for authorization callbacks (supports http and localhost for MCP clients)",
             "example": [
+              "http://localhost:3000/callback",
               "https://example.com/callback"
             ],
             "type": "array",
@@ -1076,18 +1075,15 @@
               "type": "string",
               "enum": [
                 "authorization_code",
-                "refresh_token",
-                "client_credentials"
+                "refresh_token"
               ]
             }
           },
           "token_endpoint_auth_method": {
             "type": "string",
-            "description": "Authentication method for the token endpoint",
-            "example": "client_secret_basic",
+            "description": "Authentication method for the token endpoint (MCP clients use \"none\")",
+            "example": "none",
             "enum": [
-              "client_secret_basic",
-              "client_secret_post",
               "none"
             ]
           },

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -469,8 +469,9 @@ export interface components {
              */
             client_name: string;
             /**
-             * @description Array of redirect URIs for authorization callbacks
+             * @description Array of redirect URIs for authorization callbacks (supports http and localhost for MCP clients)
              * @example [
+             *       "http://localhost:3000/callback",
              *       "https://example.com/callback"
              *     ]
              */
@@ -482,13 +483,13 @@ export interface components {
              *       "refresh_token"
              *     ]
              */
-            grant_types: ("authorization_code" | "refresh_token" | "client_credentials")[];
+            grant_types: ("authorization_code" | "refresh_token")[];
             /**
-             * @description Authentication method for the token endpoint
-             * @example client_secret_basic
+             * @description Authentication method for the token endpoint (MCP clients use "none")
+             * @example none
              * @enum {string}
              */
-            token_endpoint_auth_method: "client_secret_basic" | "client_secret_post" | "none";
+            token_endpoint_auth_method: "none";
             /**
              * @description Requested scopes for the client
              * @example [
@@ -528,8 +529,9 @@ export interface components {
              */
             client_name: string;
             /**
-             * @description Array of redirect URIs for authorization callbacks
+             * @description Array of redirect URIs for authorization callbacks (supports http and localhost for MCP clients)
              * @example [
+             *       "http://localhost:3000/callback",
              *       "https://example.com/callback"
              *     ]
              */
@@ -541,13 +543,13 @@ export interface components {
              *       "refresh_token"
              *     ]
              */
-            grant_types: ("authorization_code" | "refresh_token" | "client_credentials")[];
+            grant_types: ("authorization_code" | "refresh_token")[];
             /**
-             * @description Authentication method for the token endpoint
-             * @example client_secret_basic
+             * @description Authentication method for the token endpoint (MCP clients use "none")
+             * @example none
              * @enum {string}
              */
-            token_endpoint_auth_method: "client_secret_basic" | "client_secret_post" | "none";
+            token_endpoint_auth_method: "none";
             /**
              * @description Scopes granted to the client
              * @example [

--- a/packages/shared/src/client/models/ClientRegistrationResponseDto.ts
+++ b/packages/shared/src/client/models/ClientRegistrationResponseDto.ts
@@ -16,15 +16,15 @@ export type ClientRegistrationResponseDto = {
      */
     client_name: string;
     /**
-     * Array of redirect URIs for authorization callbacks
+     * Array of redirect URIs for authorization callbacks (supports http and localhost for MCP clients)
      */
     redirect_uris: Array<string>;
     /**
      * Grant types the client is authorized to use
      */
-    grant_types: Array<'authorization_code' | 'refresh_token' | 'client_credentials'>;
+    grant_types: Array<'authorization_code' | 'refresh_token'>;
     /**
-     * Authentication method for the token endpoint
+     * Authentication method for the token endpoint (MCP clients use "none")
      */
     token_endpoint_auth_method: ClientRegistrationResponseDto.token_endpoint_auth_method;
     /**
@@ -46,11 +46,9 @@ export type ClientRegistrationResponseDto = {
 };
 export namespace ClientRegistrationResponseDto {
     /**
-     * Authentication method for the token endpoint
+     * Authentication method for the token endpoint (MCP clients use "none")
      */
     export enum token_endpoint_auth_method {
-        CLIENT_SECRET_BASIC = 'client_secret_basic',
-        CLIENT_SECRET_POST = 'client_secret_post',
         NONE = 'none',
     }
 }

--- a/packages/shared/src/client/models/RegisterClientDto.ts
+++ b/packages/shared/src/client/models/RegisterClientDto.ts
@@ -8,15 +8,15 @@ export type RegisterClientDto = {
      */
     client_name: string;
     /**
-     * Array of redirect URIs for authorization callbacks
+     * Array of redirect URIs for authorization callbacks (supports http and localhost for MCP clients)
      */
     redirect_uris: Array<string>;
     /**
      * Grant types the client will use. Must include authorization_code and refresh_token per MCP requirements.
      */
-    grant_types: Array<'authorization_code' | 'refresh_token' | 'client_credentials'>;
+    grant_types: Array<'authorization_code' | 'refresh_token'>;
     /**
-     * Authentication method for the token endpoint
+     * Authentication method for the token endpoint (MCP clients use "none")
      */
     token_endpoint_auth_method: RegisterClientDto.token_endpoint_auth_method;
     /**
@@ -34,11 +34,9 @@ export type RegisterClientDto = {
 };
 export namespace RegisterClientDto {
     /**
-     * Authentication method for the token endpoint
+     * Authentication method for the token endpoint (MCP clients use "none")
      */
     export enum token_endpoint_auth_method {
-        CLIENT_SECRET_BASIC = 'client_secret_basic',
-        CLIENT_SECRET_POST = 'client_secret_post',
         NONE = 'none',
     }
 }


### PR DESCRIPTION
## Summary
- Relaxed redirect URI validation to support localhost and HTTP URIs for development
- Restricted grant types to only `authorization_code` and `refresh_token` per MCP spec
- Restricted `token_endpoint_auth_method` to only `none` per MCP specification
- Added comprehensive e2e test coverage for client registration flows

## Changes
- Updated `RegisterClientDto` to allow more flexible redirect URIs
- Removed `CLIENT_CREDENTIALS` from `GrantType` enum
- Removed `CLIENT_SECRET_BASIC` and `CLIENT_SECRET_POST` from `TokenEndpointAuthMethod` enum
- Updated service validation logic to remove HTTPS requirement
- Added 9 e2e tests covering various registration scenarios

## Test plan
- [x] Build passes (`npm run build:prod`)
- [x] All tests added for create/retrieve client flows
- [x] Validates localhost and HTTP redirect URIs
- [x] Validates required MCP grant types
- [x] Validates PKCE requirement
- [ ] CI checks pass

Implements feature/07 - Client registration v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)