### PR TITLE
Add MCP Registry UI

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import { TaskBoard } from './taskeroo/TaskBoard';
 import { WikirooHomePage } from './wikiroo/WikirooHomePage';
 import { WikirooPageView } from './wikiroo/WikirooPageView';
+import { McpRegistryDashboard } from './mcp-registry/McpRegistryDashboard';
+import { McpServerDetail } from './mcp-registry/McpServerDetail';
 import { usePageTitle } from './hooks/usePageTitle';
 
 export default function App() {
@@ -12,6 +14,8 @@ export default function App() {
         <Route path="/taskeroo" element={<TaskBoard />} />
         <Route path="/wikiroo" element={<WikirooHomePage />} />
         <Route path="/wikiroo/:pageId" element={<WikirooPageView />} />
+        <Route path="/mcp-registry" element={<McpRegistryDashboard />} />
+        <Route path="/mcp-registry/:serverId" element={<McpServerDetail />} />
       </Routes>
     </BrowserRouter>
   );
@@ -50,6 +54,19 @@ function Home() {
           }}
         >
           Go to Wikiroo
+        </Link>
+        <Link
+          to="/mcp-registry"
+          style={{
+            padding: '10px 20px',
+            background: '#9b59b6',
+            color: 'white',
+            textDecoration: 'none',
+            borderRadius: '8px',
+            display: 'inline-block',
+          }}
+        >
+          Go to MCP Registry
         </Link>
       </nav>
     </div>

--- a/apps/ui/src/mcp-registry/McpRegistry.css
+++ b/apps/ui/src/mcp-registry/McpRegistry.css
@@ -1,0 +1,334 @@
+/* MCP Registry Styles - Following TaskBoard patterns */
+
+.mcp-registry {
+  min-height: 100vh;
+  background: #f8f9fa;
+  padding: 20px;
+}
+
+.mcp-registry-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 20px;
+  padding: 10px 0;
+}
+
+.mcp-registry-header h1 {
+  margin: 0 0 6px 0;
+  color: #2c3e50;
+  font-size: 32px;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0;
+  color: #95a5a6;
+  font-size: 15px;
+  font-weight: 400;
+}
+
+.server-id {
+  margin: 4px 0;
+  color: #7f8c8d;
+  font-size: 13px;
+  font-family: 'Monaco', 'Courier New', monospace;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+/* Buttons */
+.btn-primary {
+  background: #3498db;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-primary:hover {
+  background: #2980b9;
+}
+
+.btn-primary:disabled {
+  background: #95a5a6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: white;
+  color: #3498db;
+  border: 1px solid #3498db;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-secondary:hover {
+  background: #ecf7fd;
+}
+
+.btn-back {
+  background: transparent;
+  color: #3498db;
+  border: none;
+  padding: 8px 0;
+  font-size: 14px;
+  cursor: pointer;
+  margin-bottom: 10px;
+  transition: color 0.2s;
+}
+
+.btn-back:hover {
+  color: #2980b9;
+}
+
+.btn-delete {
+  background: #e74c3c;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-delete:hover {
+  background: #c0392b;
+}
+
+/* Servers Grid */
+.servers-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.server-card {
+  background: white;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.server-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
+.server-card h3 {
+  margin: 0 0 8px 0;
+  color: #2c3e50;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.server-card .server-id {
+  margin: 4px 0 8px 0;
+}
+
+.server-description {
+  margin: 0;
+  color: #7f8c8d;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+/* Detail Sections */
+.detail-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.detail-section {
+  background: white;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid #ecf0f1;
+}
+
+.section-header h2 {
+  margin: 0;
+  color: #2c3e50;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.items-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.item-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 15px;
+  background: #f8f9fa;
+  border-radius: 8px;
+  gap: 15px;
+}
+
+.item-content {
+  flex: 1;
+}
+
+.item-content h3 {
+  margin: 0 0 6px 0;
+  color: #2c3e50;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.item-content p {
+  margin: 4px 0;
+  color: #7f8c8d;
+  font-size: 14px;
+}
+
+.small-text {
+  font-size: 12px;
+  color: #95a5a6;
+}
+
+.empty-text {
+  color: #95a5a6;
+  font-size: 14px;
+  text-align: center;
+  padding: 20px;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 12px;
+  padding: 30px;
+  max-width: 500px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.modal-content h2 {
+  margin: 0 0 20px 0;
+  color: #2c3e50;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+/* Form */
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 6px;
+  color: #2c3e50;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+  outline: none;
+  border-color: #3498db;
+}
+
+.form-group small {
+  display: block;
+  margin-top: 4px;
+  color: #95a5a6;
+  font-size: 12px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+/* Empty State */
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.empty-state p {
+  margin: 0 0 20px 0;
+  color: #95a5a6;
+  font-size: 16px;
+}
+
+/* Loading & Error */
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: #7f8c8d;
+  font-size: 16px;
+}
+
+.error-message {
+  background: #fadbd8;
+  color: #c0392b;
+  padding: 15px 20px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  font-size: 14px;
+}

--- a/apps/ui/src/mcp-registry/McpRegistryDashboard.tsx
+++ b/apps/ui/src/mcp-registry/McpRegistryDashboard.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMcpRegistry } from './useMcpRegistry';
+import { usePageTitle } from '../hooks/usePageTitle';
+import './McpRegistry.css';
+
+export function McpRegistryDashboard() {
+  usePageTitle('MCP Registry');
+
+  const { servers, isLoading, error, createServer } = useMcpRegistry();
+  const navigate = useNavigate();
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [formData, setFormData] = useState({
+    providedId: '',
+    name: '',
+    description: '',
+  });
+
+  const handleCreateServer = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createServer(formData);
+      setShowCreateForm(false);
+      setFormData({ providedId: '', name: '', description: '' });
+    } catch (err) {
+      // Error is handled by the hook
+      console.error('Failed to create server', err);
+    }
+  };
+
+  return (
+    <div className="mcp-registry">
+      <div className="mcp-registry-header">
+        <div>
+          <h1>MCP Registry</h1>
+          <p className="subtitle">Manage Model Context Protocol servers and their configurations</p>
+        </div>
+        <div className="header-actions">
+          <button onClick={() => setShowCreateForm(true)} className="btn-primary">
+            + Add Server
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="error-message">
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="loading">Loading servers...</div>
+      ) : (
+        <div className="servers-grid">
+          {servers.length === 0 ? (
+            <div className="empty-state">
+              <p>No MCP servers registered yet.</p>
+              <button onClick={() => setShowCreateForm(true)} className="btn-primary">
+                Create your first server
+              </button>
+            </div>
+          ) : (
+            servers.map((server) => (
+              <div
+                key={server.id}
+                className="server-card"
+                onClick={() => navigate(`/mcp-registry/${server.id}`)}
+              >
+                <h3>{server.name}</h3>
+                <p className="server-id">ID: {server.providedId}</p>
+                <p className="server-description">{server.description}</p>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {showCreateForm && (
+        <div className="modal-overlay" onClick={() => setShowCreateForm(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h2>Create MCP Server</h2>
+            <form onSubmit={handleCreateServer}>
+              <div className="form-group">
+                <label htmlFor="providedId">Server ID</label>
+                <input
+                  type="text"
+                  id="providedId"
+                  value={formData.providedId}
+                  onChange={(e) => setFormData({ ...formData, providedId: e.target.value })}
+                  placeholder="e.g., my-mcp-server"
+                  required
+                />
+                <small>Unique identifier for this server</small>
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="name">Name</label>
+                <input
+                  type="text"
+                  id="name"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  placeholder="e.g., My MCP Server"
+                  required
+                />
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="description">Description</label>
+                <textarea
+                  id="description"
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  placeholder="Brief description of this server"
+                  rows={3}
+                  required
+                />
+              </div>
+
+              <div className="form-actions">
+                <button type="button" onClick={() => setShowCreateForm(false)} className="btn-secondary">
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary">
+                  Create Server
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/mcp-registry/McpServerDetail.tsx
+++ b/apps/ui/src/mcp-registry/McpServerDetail.tsx
@@ -1,0 +1,436 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useMcpRegistry } from './useMcpRegistry';
+import { usePageTitle } from '../hooks/usePageTitle';
+import './McpRegistry.css';
+
+type FormType = 'scope' | 'connection' | 'mapping' | null;
+
+export function McpServerDetail() {
+  const { serverId } = useParams<{ serverId: string }>();
+  const navigate = useNavigate();
+  const {
+    selectedServer,
+    scopes,
+    connections,
+    mappings,
+    isLoading,
+    error,
+    loadServerDetails,
+    createScope,
+    createConnection,
+    createMapping,
+    deleteScope,
+    deleteConnection,
+    deleteMapping,
+  } = useMcpRegistry();
+
+  const [activeForm, setActiveForm] = useState<FormType>(null);
+  const [scopeForm, setScopeForm] = useState({ scopeId: '', description: '' });
+  const [connectionForm, setConnectionForm] = useState({
+    clientId: '',
+    clientSecret: '',
+    authorizeUrl: '',
+    tokenUrl: '',
+    friendlyName: '',
+  });
+  const [mappingForm, setMappingForm] = useState({
+    scopeId: '',
+    connectionId: '',
+    downstreamScope: '',
+  });
+
+  usePageTitle(selectedServer ? `${selectedServer.name} - MCP Registry` : 'MCP Registry');
+
+  useEffect(() => {
+    if (serverId) {
+      loadServerDetails(serverId);
+    }
+  }, [serverId]);
+
+  const handleCreateScope = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!serverId) return;
+    try {
+      await createScope(serverId, scopeForm.scopeId, scopeForm.description);
+      setActiveForm(null);
+      setScopeForm({ scopeId: '', description: '' });
+    } catch (err) {
+      console.error('Failed to create scope', err);
+    }
+  };
+
+  const handleCreateConnection = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!serverId) return;
+    try {
+      await createConnection(serverId, connectionForm);
+      setActiveForm(null);
+      setConnectionForm({
+        clientId: '',
+        clientSecret: '',
+        authorizeUrl: '',
+        tokenUrl: '',
+        friendlyName: '',
+      });
+    } catch (err) {
+      console.error('Failed to create connection', err);
+    }
+  };
+
+  const handleCreateMapping = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!serverId) return;
+    try {
+      await createMapping(serverId, mappingForm);
+      setActiveForm(null);
+      setMappingForm({ scopeId: '', connectionId: '', downstreamScope: '' });
+    } catch (err) {
+      console.error('Failed to create mapping', err);
+    }
+  };
+
+  const handleDeleteScope = async (scopeId: string) => {
+    if (!serverId || !confirm('Are you sure you want to delete this scope?')) return;
+    try {
+      await deleteScope(serverId, scopeId);
+    } catch (err) {
+      console.error('Failed to delete scope', err);
+    }
+  };
+
+  const handleDeleteConnection = async (connectionId: string) => {
+    if (!confirm('Are you sure you want to delete this connection?')) return;
+    try {
+      await deleteConnection(connectionId);
+    } catch (err) {
+      console.error('Failed to delete connection', err);
+    }
+  };
+
+  const handleDeleteMapping = async (mappingId: string) => {
+    if (!confirm('Are you sure you want to delete this mapping?')) return;
+    try {
+      await deleteMapping(mappingId);
+    } catch (err) {
+      console.error('Failed to delete mapping', err);
+    }
+  };
+
+  if (isLoading && !selectedServer) {
+    return <div className="loading">Loading server details...</div>;
+  }
+
+  if (!selectedServer) {
+    return <div className="error-message">Server not found</div>;
+  }
+
+  return (
+    <div className="mcp-registry">
+      <div className="mcp-registry-header">
+        <div>
+          <button onClick={() => navigate('/mcp-registry')} className="btn-back">
+            ← Back to Registry
+          </button>
+          <h1>{selectedServer.name}</h1>
+          <p className="subtitle">{selectedServer.description}</p>
+          <p className="server-id">ID: {selectedServer.providedId}</p>
+        </div>
+      </div>
+
+      {error && <div className="error-message">{error}</div>}
+
+      <div className="detail-sections">
+        {/* Scopes Section */}
+        <div className="detail-section">
+          <div className="section-header">
+            <h2>Scopes</h2>
+            <button onClick={() => setActiveForm('scope')} className="btn-secondary">
+              + Add Scope
+            </button>
+          </div>
+          <div className="items-list">
+            {scopes.length === 0 ? (
+              <p className="empty-text">No scopes defined</p>
+            ) : (
+              scopes.map((scope) => (
+                <div key={scope.id} className="item-card">
+                  <div className="item-content">
+                    <h3>{scope.scopeId}</h3>
+                    <p>{scope.description}</p>
+                  </div>
+                  <button
+                    onClick={() => handleDeleteScope(scope.scopeId)}
+                    className="btn-delete"
+                  >
+                    Delete
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Connections Section */}
+        <div className="detail-section">
+          <div className="section-header">
+            <h2>OAuth Connections</h2>
+            <button onClick={() => setActiveForm('connection')} className="btn-secondary">
+              + Add Connection
+            </button>
+          </div>
+          <div className="items-list">
+            {connections.length === 0 ? (
+              <p className="empty-text">No connections configured</p>
+            ) : (
+              connections.map((connection) => (
+                <div key={connection.id} className="item-card">
+                  <div className="item-content">
+                    <h3>{connection.friendlyName}</h3>
+                    <p>Client ID: {connection.clientId}</p>
+                    <p className="small-text">Authorize: {connection.authorizeUrl}</p>
+                    <p className="small-text">Token: {connection.tokenUrl}</p>
+                  </div>
+                  <button
+                    onClick={() => handleDeleteConnection(connection.id)}
+                    className="btn-delete"
+                  >
+                    Delete
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Mappings Section */}
+        <div className="detail-section">
+          <div className="section-header">
+            <h2>Scope Mappings</h2>
+            <button
+              onClick={() => setActiveForm('mapping')}
+              className="btn-secondary"
+              disabled={scopes.length === 0 || connections.length === 0}
+            >
+              + Add Mapping
+            </button>
+          </div>
+          <div className="items-list">
+            {mappings.length === 0 ? (
+              <p className="empty-text">No mappings configured</p>
+            ) : (
+              mappings.map((mapping) => {
+                const scope = scopes.find((s) => s.scopeId === mapping.scopeId);
+                const connection = connections.find((c) => c.id === mapping.connectionId);
+                return (
+                  <div key={mapping.id} className="item-card">
+                    <div className="item-content">
+                      <h3>{scope?.scopeId || mapping.scopeId}</h3>
+                      <p>→ {mapping.downstreamScope}</p>
+                      <p className="small-text">via {connection?.friendlyName || 'Unknown'}</p>
+                    </div>
+                    <button
+                      onClick={() => handleDeleteMapping(mapping.id)}
+                      className="btn-delete"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Create Scope Modal */}
+      {activeForm === 'scope' && (
+        <div className="modal-overlay" onClick={() => setActiveForm(null)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h2>Create Scope</h2>
+            <form onSubmit={handleCreateScope}>
+              <div className="form-group">
+                <label htmlFor="scopeId">Scope ID</label>
+                <input
+                  type="text"
+                  id="scopeId"
+                  value={scopeForm.scopeId}
+                  onChange={(e) => setScopeForm({ ...scopeForm, scopeId: e.target.value })}
+                  placeholder="e.g., tool:read"
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="scopeDescription">Description</label>
+                <textarea
+                  id="scopeDescription"
+                  value={scopeForm.description}
+                  onChange={(e) => setScopeForm({ ...scopeForm, description: e.target.value })}
+                  placeholder="What does this scope provide?"
+                  rows={3}
+                  required
+                />
+              </div>
+              <div className="form-actions">
+                <button type="button" onClick={() => setActiveForm(null)} className="btn-secondary">
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary">
+                  Create Scope
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Create Connection Modal */}
+      {activeForm === 'connection' && (
+        <div className="modal-overlay" onClick={() => setActiveForm(null)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h2>Create OAuth Connection</h2>
+            <form onSubmit={handleCreateConnection}>
+              <div className="form-group">
+                <label htmlFor="friendlyName">Friendly Name</label>
+                <input
+                  type="text"
+                  id="friendlyName"
+                  value={connectionForm.friendlyName}
+                  onChange={(e) =>
+                    setConnectionForm({ ...connectionForm, friendlyName: e.target.value })
+                  }
+                  placeholder="e.g., GitHub OAuth"
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="clientId">Client ID</label>
+                <input
+                  type="text"
+                  id="clientId"
+                  value={connectionForm.clientId}
+                  onChange={(e) =>
+                    setConnectionForm({ ...connectionForm, clientId: e.target.value })
+                  }
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="clientSecret">Client Secret</label>
+                <input
+                  type="password"
+                  id="clientSecret"
+                  value={connectionForm.clientSecret}
+                  onChange={(e) =>
+                    setConnectionForm({ ...connectionForm, clientSecret: e.target.value })
+                  }
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="authorizeUrl">Authorize URL</label>
+                <input
+                  type="url"
+                  id="authorizeUrl"
+                  value={connectionForm.authorizeUrl}
+                  onChange={(e) =>
+                    setConnectionForm({ ...connectionForm, authorizeUrl: e.target.value })
+                  }
+                  placeholder="https://..."
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="tokenUrl">Token URL</label>
+                <input
+                  type="url"
+                  id="tokenUrl"
+                  value={connectionForm.tokenUrl}
+                  onChange={(e) =>
+                    setConnectionForm({ ...connectionForm, tokenUrl: e.target.value })
+                  }
+                  placeholder="https://..."
+                  required
+                />
+              </div>
+              <div className="form-actions">
+                <button type="button" onClick={() => setActiveForm(null)} className="btn-secondary">
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary">
+                  Create Connection
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Create Mapping Modal */}
+      {activeForm === 'mapping' && (
+        <div className="modal-overlay" onClick={() => setActiveForm(null)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h2>Create Scope Mapping</h2>
+            <form onSubmit={handleCreateMapping}>
+              <div className="form-group">
+                <label htmlFor="mappingScopeId">MCP Scope</label>
+                <select
+                  id="mappingScopeId"
+                  value={mappingForm.scopeId}
+                  onChange={(e) => setMappingForm({ ...mappingForm, scopeId: e.target.value })}
+                  required
+                >
+                  <option value="">Select a scope</option>
+                  {scopes.map((scope) => (
+                    <option key={scope.id} value={scope.scopeId}>
+                      {scope.scopeId}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-group">
+                <label htmlFor="mappingConnectionId">Connection</label>
+                <select
+                  id="mappingConnectionId"
+                  value={mappingForm.connectionId}
+                  onChange={(e) =>
+                    setMappingForm({ ...mappingForm, connectionId: e.target.value })
+                  }
+                  required
+                >
+                  <option value="">Select a connection</option>
+                  {connections.map((connection) => (
+                    <option key={connection.id} value={connection.id}>
+                      {connection.friendlyName}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-group">
+                <label htmlFor="downstreamScope">Downstream Scope</label>
+                <input
+                  type="text"
+                  id="downstreamScope"
+                  value={mappingForm.downstreamScope}
+                  onChange={(e) =>
+                    setMappingForm({ ...mappingForm, downstreamScope: e.target.value })
+                  }
+                  placeholder="e.g., repo:read"
+                  required
+                />
+              </div>
+              <div className="form-actions">
+                <button type="button" onClick={() => setActiveForm(null)} className="btn-secondary">
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary">
+                  Create Mapping
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/mcp-registry/api.ts
+++ b/apps/ui/src/mcp-registry/api.ts
@@ -1,0 +1,6 @@
+import { OpenAPI, McpRegistryService } from 'shared';
+
+// Use relative URL in production, absolute URL in development
+OpenAPI.BASE = import.meta.env.PROD ? '' : 'http://localhost:3000';
+
+export { McpRegistryService };

--- a/apps/ui/src/mcp-registry/types.ts
+++ b/apps/ui/src/mcp-registry/types.ts
@@ -1,0 +1,38 @@
+export interface McpServer {
+  id: string;
+  providedId: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface McpScope {
+  id: string;
+  scopeId: string;
+  serverId: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface McpConnection {
+  id: string;
+  serverId: string;
+  clientId: string;
+  authorizeUrl: string;
+  tokenUrl: string;
+  friendlyName: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface McpScopeMapping {
+  id: string;
+  scopeId: string;
+  serverId: string;
+  connectionId: string;
+  downstreamScope: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/apps/ui/src/mcp-registry/useMcpRegistry.ts
+++ b/apps/ui/src/mcp-registry/useMcpRegistry.ts
@@ -1,0 +1,232 @@
+import { useEffect, useState } from 'react';
+import { McpRegistryService } from './api';
+import { McpServer, McpScope, McpConnection, McpScopeMapping } from './types';
+
+export const useMcpRegistry = () => {
+  // UI feedback
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Data store
+  const [servers, setServers] = useState<McpServer[]>([]);
+  const [selectedServer, setSelectedServer] = useState<McpServer | null>(null);
+  const [scopes, setScopes] = useState<McpScope[]>([]);
+  const [connections, setConnections] = useState<McpConnection[]>([]);
+  const [mappings, setMappings] = useState<McpScopeMapping[]>([]);
+
+  // Boot
+  useEffect(() => {
+    loadServers();
+  }, []);
+
+  // Load servers
+  const loadServers = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await McpRegistryService.mcpRegistryControllerListServers();
+      setServers(response.items || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load servers');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Load server details (scopes, connections, mappings)
+  const loadServerDetails = async (serverId: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [serverData, scopesData, connectionsData] = await Promise.all([
+        McpRegistryService.mcpRegistryControllerGetServer(serverId),
+        McpRegistryService.mcpRegistryControllerListScopes(serverId),
+        McpRegistryService.mcpRegistryControllerListConnections(serverId),
+      ]);
+
+      setSelectedServer(serverData);
+      setScopes(scopesData || []);
+      setConnections(connectionsData || []);
+
+      // Load mappings for each scope
+      if (scopesData && scopesData.length > 0) {
+        const allMappings: McpScopeMapping[] = [];
+        for (const scope of scopesData) {
+          try {
+            const scopeMappings = await McpRegistryService.mcpRegistryControllerListMappings(
+              serverId,
+              scope.scopeId
+            );
+            if (scopeMappings) {
+              allMappings.push(...scopeMappings);
+            }
+          } catch (err) {
+            console.error(`Failed to load mappings for scope ${scope.scopeId}`, err);
+          }
+        }
+        setMappings(allMappings);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load server details');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Create server
+  const createServer = async (data: { providedId: string; name: string; description: string }) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await McpRegistryService.mcpRegistryControllerCreateServer(data);
+      await loadServers();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create server');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Create scope
+  const createScope = async (serverId: string, scopeId: string, description: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await McpRegistryService.mcpRegistryControllerCreateScopes(serverId);
+      if (selectedServer?.id === serverId) {
+        await loadServerDetails(serverId);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create scope');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Create connection
+  const createConnection = async (
+    serverId: string,
+    data: {
+      clientId: string;
+      clientSecret: string;
+      authorizeUrl: string;
+      tokenUrl: string;
+      friendlyName: string;
+    }
+  ) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await McpRegistryService.mcpRegistryControllerCreateConnection(serverId, data);
+      if (selectedServer?.id === serverId) {
+        await loadServerDetails(serverId);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create connection');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Create mapping
+  const createMapping = async (
+    serverId: string,
+    data: {
+      scopeId: string;
+      connectionId: string;
+      downstreamScope: string;
+    }
+  ) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await McpRegistryService.mcpRegistryControllerCreateMapping(serverId, data);
+      if (selectedServer?.id === serverId) {
+        await loadServerDetails(serverId);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create mapping');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Delete scope
+  const deleteScope = async (serverId: string, scopeId: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await McpRegistryService.mcpRegistryControllerDeleteScope(serverId, scopeId);
+      if (selectedServer?.id === serverId) {
+        await loadServerDetails(serverId);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete scope');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Delete connection
+  const deleteConnection = async (connectionId: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await McpRegistryService.mcpRegistryControllerDeleteConnection(connectionId);
+      if (selectedServer) {
+        await loadServerDetails(selectedServer.id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete connection');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Delete mapping
+  const deleteMapping = async (mappingId: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await McpRegistryService.mcpRegistryControllerDeleteMapping(mappingId);
+      if (selectedServer) {
+        await loadServerDetails(selectedServer.id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete mapping');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    // UI feedback
+    isLoading,
+    error,
+
+    // Data
+    servers,
+    selectedServer,
+    scopes,
+    connections,
+    mappings,
+
+    // Actions
+    loadServers,
+    loadServerDetails,
+    createServer,
+    createScope,
+    createConnection,
+    createMapping,
+    deleteScope,
+    deleteConnection,
+    deleteMapping,
+  };
+};


### PR DESCRIPTION
## Summary
- Implemented complete MCP Registry UI with dashboard and server detail views
- Created useMcpRegistry hook for state management and API calls
- Added forms for creating servers, scopes, OAuth connections, and scope mappings
- Implemented delete functionality for scopes, connections, and mappings
- Applied consistent styling matching existing Taskeroo patterns
- Added navigation routes at /mcp-registry and /mcp-registry/:serverId

## Components Created
- **McpRegistryDashboard**: Lists all registered MCP servers with create functionality
- **McpServerDetail**: Shows detailed view of a server with scopes, connections, and mappings
- **useMcpRegistry**: Custom hook wrapping McpRegistryService API calls
- **McpRegistry.css**: Styling consistent with Taskeroo design patterns

## Test Plan
- [ ] Verify dashboard loads at /mcp-registry
- [ ] Test creating a new MCP server
- [ ] Navigate to server detail page
- [ ] Create scopes for the server
- [ ] Create OAuth connections for the server
- [ ] Create scope mappings between MCP scopes and downstream scopes
- [ ] Test delete functionality for scopes, connections, and mappings
- [ ] Verify error handling and loading states
- [ ] Check responsive design and UI consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)