### PR TITLE
Refactor scope mapping UI to support multiple mappings

### DIFF
--- a/apps/ui/src/mcp-registry/McpRegistry.css
+++ b/apps/ui/src/mcp-registry/McpRegistry.css
@@ -301,6 +301,75 @@
   margin-top: 20px;
 }
 
+/* Mapping Row Styles */
+.mapping-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.mapping-connection-select {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.mapping-scope-input {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.mapping-connection-select:focus,
+.mapping-scope-input:focus {
+  outline: none;
+  border-color: #3498db;
+}
+
+.btn-remove {
+  background: #e74c3c;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  width: 32px;
+  height: 32px;
+  font-size: 20px;
+  cursor: pointer;
+  transition: background 0.2s;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.btn-remove:hover {
+  background: #c0392b;
+}
+
+.btn-add-mapping {
+  background: #3498db;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.2s;
+  margin-top: 10px;
+}
+
+.btn-add-mapping:hover {
+  background: #2980b9;
+}
+
 /* Empty State */
 .empty-state {
   text-align: center;


### PR DESCRIPTION
## Summary
- Refactored the scope mapping form to allow creating multiple connection/downstream scope pairs for a single MCP scope
- MCP Scope selection remains at the top of the form
- Users can now add/remove dynamic rows for connection and downstream scope pairs
- New rows automatically pre-select the connection from the previous row for convenience
- Added comprehensive CSS styling for the new mapping row layout

## Changes Made
1. **State Management**: Changed `mappingForm` state from single mapping to array of mappings
2. **Form Handler**: Updated `handleCreateMapping` to create all mappings sequentially
3. **Helper Functions**: Added `handleAddMappingRow`, `handleRemoveMappingRow`, and `handleUpdateMappingRow`
4. **UI Components**: Refactored modal form to render dynamic mapping rows with add/remove buttons
5. **Styling**: Added CSS classes for `.mapping-row`, `.mapping-connection-select`, `.mapping-scope-input`, `.btn-remove`, and `.btn-add-mapping`

## Test Plan
- [ ] Open the MCP Server detail page
- [ ] Click "+ Add Mapping" button
- [ ] Select an MCP Scope from dropdown
- [ ] Fill in connection and downstream scope for first row
- [ ] Click "+ Add Entry" to add more rows
- [ ] Verify new rows pre-select the previous connection
- [ ] Test removing rows (verify at least one row remains)
- [ ] Submit form and verify all mappings are created successfully
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)