### PR TITLE
Replace alert() and confirm() with UI-friendly components

### DIFF
--- a/apps/ui/src/components/ConfirmDialog.css
+++ b/apps/ui/src/components/ConfirmDialog.css
@@ -1,0 +1,85 @@
+.confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.confirm-dialog {
+  background: white;
+  border-radius: 12px;
+  padding: 30px;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  animation: scaleIn 0.2s ease-out;
+}
+
+@keyframes scaleIn {
+  from {
+    transform: scale(0.9);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.confirm-message {
+  font-size: 16px;
+  color: #2c3e50;
+  margin-bottom: 24px;
+  line-height: 1.5;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.btn-secondary,
+.btn-danger {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-secondary {
+  background: #ecf0f1;
+  color: #2c3e50;
+}
+
+.btn-secondary:hover {
+  background: #d5dbdb;
+}
+
+.btn-danger {
+  background: #e74c3c;
+  color: white;
+}
+
+.btn-danger:hover {
+  background: #c0392b;
+}

--- a/apps/ui/src/components/ConfirmDialog.tsx
+++ b/apps/ui/src/components/ConfirmDialog.tsx
@@ -1,0 +1,33 @@
+import './ConfirmDialog.css';
+
+interface ConfirmDialogProps {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+export function ConfirmDialog({
+  message,
+  onConfirm,
+  onCancel,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+}: ConfirmDialogProps) {
+  return (
+    <div className="confirm-overlay" onClick={onCancel}>
+      <div className="confirm-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="confirm-message">{message}</div>
+        <div className="confirm-actions">
+          <button onClick={onCancel} className="btn-secondary">
+            {cancelText}
+          </button>
+          <button onClick={onConfirm} className="btn-danger">
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/Toast.css
+++ b/apps/ui/src/components/Toast.css
@@ -1,0 +1,66 @@
+.toast {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  padding: 16px 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  z-index: 9999;
+  animation: slideIn 0.3s ease-out;
+  min-width: 300px;
+  max-width: 500px;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.toast-info {
+  background: #3498db;
+  color: white;
+}
+
+.toast-success {
+  background: #2ecc71;
+  color: white;
+}
+
+.toast-error {
+  background: #e74c3c;
+  color: white;
+}
+
+.toast span {
+  flex: 1;
+  font-size: 14px;
+}
+
+.toast-close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 24px;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+}
+
+.toast-close:hover {
+  opacity: 1;
+}

--- a/apps/ui/src/components/Toast.tsx
+++ b/apps/ui/src/components/Toast.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import './Toast.css';
+
+interface ToastProps {
+  message: string;
+  type?: 'success' | 'error' | 'info';
+  onClose: () => void;
+  duration?: number;
+}
+
+export function Toast({ message, type = 'info', onClose, duration = 3000 }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, duration);
+    return () => clearTimeout(timer);
+  }, [onClose, duration]);
+
+  return (
+    <div className={`toast toast-${type}`}>
+      <span>{message}</span>
+      <button onClick={onClose} className="toast-close" aria-label="Close">
+        ×
+      </button>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/useToast.ts
+++ b/apps/ui/src/hooks/useToast.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+
+export interface ToastMessage {
+  id: number;
+  message: string;
+  type: 'success' | 'error' | 'info';
+}
+
+export function useToast() {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  const showToast = useCallback(
+    (message: string, type: 'success' | 'error' | 'info' = 'info') => {
+      const id = Date.now();
+      setToasts((prev) => [...prev, { id, message, type }]);
+    },
+    []
+  );
+
+  const removeToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  return { toasts, showToast, removeToast };
+}

--- a/apps/ui/src/mcp-registry/McpServerDetail.tsx
+++ b/apps/ui/src/mcp-registry/McpServerDetail.tsx
@@ -2,9 +2,15 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useMcpRegistry } from './useMcpRegistry';
 import { usePageTitle } from '../hooks/usePageTitle';
+import { ConfirmDialog } from '../components/ConfirmDialog';
 import './McpRegistry.css';
 
 type FormType = 'scope' | 'connection' | 'mapping' | null;
+
+interface ConfirmState {
+  message: string;
+  onConfirm: () => void;
+}
 
 export function McpServerDetail() {
   const { serverId } = useParams<{ serverId: string }>();
@@ -26,6 +32,7 @@ export function McpServerDetail() {
   } = useMcpRegistry();
 
   const [activeForm, setActiveForm] = useState<FormType>(null);
+  const [confirmState, setConfirmState] = useState<ConfirmState | null>(null);
   const [scopeForm, setScopeForm] = useState({ scopeId: '', description: '' });
   const [connectionForm, setConnectionForm] = useState({
     clientId: '',
@@ -126,30 +133,49 @@ export function McpServerDetail() {
   };
 
   const handleDeleteScope = async (scopeId: string) => {
-    if (!serverId || !confirm('Are you sure you want to delete this scope?')) return;
-    try {
-      await deleteScope(serverId, scopeId);
-    } catch (err) {
-      console.error('Failed to delete scope', err);
-    }
+    if (!serverId) return;
+    setConfirmState({
+      message: 'Are you sure you want to delete this scope?',
+      onConfirm: async () => {
+        try {
+          await deleteScope(serverId, scopeId);
+          setConfirmState(null);
+        } catch (err) {
+          console.error('Failed to delete scope', err);
+          setConfirmState(null);
+        }
+      },
+    });
   };
 
   const handleDeleteConnection = async (connectionId: string) => {
-    if (!confirm('Are you sure you want to delete this connection?')) return;
-    try {
-      await deleteConnection(connectionId);
-    } catch (err) {
-      console.error('Failed to delete connection', err);
-    }
+    setConfirmState({
+      message: 'Are you sure you want to delete this connection?',
+      onConfirm: async () => {
+        try {
+          await deleteConnection(connectionId);
+          setConfirmState(null);
+        } catch (err) {
+          console.error('Failed to delete connection', err);
+          setConfirmState(null);
+        }
+      },
+    });
   };
 
   const handleDeleteMapping = async (mappingId: string) => {
-    if (!confirm('Are you sure you want to delete this mapping?')) return;
-    try {
-      await deleteMapping(mappingId);
-    } catch (err) {
-      console.error('Failed to delete mapping', err);
-    }
+    setConfirmState({
+      message: 'Are you sure you want to delete this mapping?',
+      onConfirm: async () => {
+        try {
+          await deleteMapping(mappingId);
+          setConfirmState(null);
+        } catch (err) {
+          console.error('Failed to delete mapping', err);
+          setConfirmState(null);
+        }
+      },
+    });
   };
 
   if (isLoading && !selectedServer) {
@@ -485,6 +511,14 @@ export function McpServerDetail() {
             </form>
           </div>
         </div>
+      )}
+
+      {confirmState && (
+        <ConfirmDialog
+          message={confirmState.message}
+          onConfirm={confirmState.onConfirm}
+          onCancel={() => setConfirmState(null)}
+        />
       )}
     </div>
   );

--- a/apps/ui/src/taskeroo/CreateTaskForm.tsx
+++ b/apps/ui/src/taskeroo/CreateTaskForm.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
 import { TaskerooService } from './api';
+import { useToast } from '../hooks/useToast';
+import { Toast } from '../components/Toast';
 
 interface CreateTaskFormProps {
   onClose: () => void;
 }
 
 export function CreateTaskForm({ onClose }: CreateTaskFormProps) {
+  const { toasts, showToast, removeToast } = useToast();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [assignee, setAssignee] = useState('');
@@ -36,7 +39,7 @@ export function CreateTaskForm({ onClose }: CreateTaskFormProps) {
       onClose();
     } catch (err: any) {
       const errorMessage = err?.body?.detail || err?.message || 'Failed to create task';
-      alert(`Error: ${errorMessage}`);
+      showToast(`Error: ${errorMessage}`, 'error');
       console.error(err);
     } finally {
       setLoading(false);
@@ -107,6 +110,15 @@ export function CreateTaskForm({ onClose }: CreateTaskFormProps) {
             </button>
           </div>
         </form>
+
+        {toasts.map((toast) => (
+          <Toast
+            key={toast.id}
+            message={toast.message}
+            type={toast.type}
+            onClose={() => removeToast(toast.id)}
+          />
+        ))}
       </div>
     </div>
   );

--- a/apps/ui/src/wikiroo/WikirooHomePage.tsx
+++ b/apps/ui/src/wikiroo/WikirooHomePage.tsx
@@ -3,6 +3,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import './Wikiroo.css';
 import { useWikiroo } from './useWikiroo';
 import { usePageTitle } from '../hooks/usePageTitle';
+import { useToast } from '../hooks/useToast';
+import { Toast } from '../components/Toast';
 
 function formatDate(value: string) {
   try {
@@ -23,6 +25,7 @@ export function WikirooHomePage() {
   } = useWikiroo();
 
   const navigate = useNavigate();
+  const { toasts, showToast, removeToast } = useToast();
   const [showForm, setShowForm] = useState(false);
   const [title, setTitle] = useState('');
   const [author, setAuthor] = useState('');
@@ -49,7 +52,7 @@ export function WikirooHomePage() {
       navigate(`/wikiroo/${created.id}`);
     } catch (err: any) {
       const message = err?.body?.detail || err?.message || 'Failed to create page';
-      alert(message);
+      showToast(message, 'error');
     }
   };
 
@@ -153,6 +156,15 @@ export function WikirooHomePage() {
 
       {isLoadingList && <div className="wikiroo-status">Loading pages…</div>}
       {error && <div className="wikiroo-error">{error}</div>}
+
+      {toasts.map((toast) => (
+        <Toast
+          key={toast.id}
+          message={toast.message}
+          type={toast.type}
+          onClose={() => removeToast(toast.id)}
+        />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Eliminated all window.alert() and window.confirm() usage in the UI
- Created reusable Toast and ConfirmDialog components for better UX
- All confirmation and alert flows now use modern, non-blocking UI elements

## Changes Made
1. **New Components**:
   - `Toast.tsx`: Auto-dismissing notification component with success/error/info types
   - `ConfirmDialog.tsx`: Modal confirmation dialog with confirm/cancel actions
   - Both components include comprehensive CSS with animations

2. **New Hook**:
   - `useToast.ts`: Custom hook for managing toast notification state

3. **Replacements**:
   - `WikirooHomePage.tsx`: Replaced alert() with Toast for error messages
   - `CreateTaskForm.tsx`: Replaced alert() with Toast for error messages  
   - `McpServerDetail.tsx`: Replaced 3 confirm() calls with ConfirmDialog

## Test Plan
- [ ] Test Wikiroo page creation error handling - should show toast instead of alert
- [ ] Test Taskeroo task creation error handling - should show toast instead of alert
- [ ] Test MCP scope deletion - should show confirmation dialog instead of browser confirm
- [ ] Test MCP connection deletion - should show confirmation dialog instead of browser confirm
- [ ] Test MCP mapping deletion - should show confirmation dialog instead of browser confirm
- [ ] Verify toasts auto-dismiss after 3 seconds
- [ ] Verify confirmation dialogs can be closed by clicking overlay or cancel
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)