### PR TITLE
Prevent Chrome password manager from triggering on OAuth connection form

### DIFF
--- a/apps/ui/src/mcp-registry/McpServerDetail.tsx
+++ b/apps/ui/src/mcp-registry/McpServerDetail.tsx
@@ -350,7 +350,7 @@ export function McpServerDetail() {
         <div className="modal-overlay" onClick={() => setActiveForm(null)}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <h2>Create OAuth Connection</h2>
-            <form onSubmit={handleCreateConnection}>
+            <form onSubmit={handleCreateConnection} autoComplete="off">
               <div className="form-group">
                 <label htmlFor="friendlyName">Friendly Name</label>
                 <input
@@ -361,6 +361,7 @@ export function McpServerDetail() {
                     setConnectionForm({ ...connectionForm, friendlyName: e.target.value })
                   }
                   placeholder="e.g., GitHub OAuth"
+                  autoComplete="off"
                   required
                 />
               </div>
@@ -373,6 +374,7 @@ export function McpServerDetail() {
                   onChange={(e) =>
                     setConnectionForm({ ...connectionForm, clientId: e.target.value })
                   }
+                  autoComplete="off"
                   required
                 />
               </div>
@@ -385,6 +387,7 @@ export function McpServerDetail() {
                   onChange={(e) =>
                     setConnectionForm({ ...connectionForm, clientSecret: e.target.value })
                   }
+                  autoComplete="new-password"
                   required
                 />
               </div>


### PR DESCRIPTION
## Summary
- Fixed Chrome password manager being triggered when creating OAuth connections
- Added autocomplete attributes to prevent password save prompts

## Changes Made
1. **OAuth Connection Form**: Added `autoComplete="off"` to the form element
2. **Form Inputs**: 
   - `friendlyName`: Added `autoComplete="off"`
   - `clientId`: Added `autoComplete="off"`
   - `clientSecret`: Added `autoComplete="new-password"`

## Technical Details
Chrome's password manager heuristics detect forms with password-type inputs and prompt users to save credentials. Since this is an OAuth client credentials form (not user credentials), we don't want Chrome to offer password saving. The `autoComplete` attributes tell the browser not to suggest password management for these fields.

## Test Plan
- [ ] Open MCP Registry and navigate to server detail
- [ ] Click "+ Add Connection" button
- [ ] Fill in the connection form including Client Secret
- [ ] Submit the form
- [ ] Verify Chrome does NOT prompt to save password
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)