### PR TITLE
added discovery endpoint

### DIFF
--- a/apps/backend/src/authorization-server/authorization-server-metadata.controller.ts
+++ b/apps/backend/src/authorization-server/authorization-server-metadata.controller.ts
@@ -1,0 +1,92 @@
+import { Controller, Get, Param, Req } from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import type { Request } from 'express';
+import { isUUID } from 'class-validator';
+import { McpRegistryService } from '../mcp-registry/mcp-registry.service';
+import { AuthorizationServerMetadataDto } from './dto/authorization-server-metadata.dto';
+import { GrantType } from './enums';
+
+@ApiTags('Authorization Server')
+@Controller('.well-known/oauth-authorization-server')
+export class AuthorizationServerMetadataController {
+  constructor(private readonly mcpRegistryService: McpRegistryService) {}
+
+  @Get(':mcpServerId')
+  @ApiOperation({
+    summary:
+      'Expose OAuth 2.0 Authorization Server metadata for a registered MCP server',
+    description:
+      'Provides discovery metadata (RFC 8414) for OAuth 2.0 clients integrating with an MCP server. Accepts either the server UUID or the providedId.',
+  })
+  @ApiParam({
+    name: 'mcpServerId',
+    description: 'MCP server UUID or providedId',
+  })
+  @ApiOkResponse({
+    description: 'Authorization server metadata retrieved successfully',
+    type: AuthorizationServerMetadataDto,
+  })
+  async getAuthorizationServerMetadata(
+    @Param('mcpServerId') mcpServerId: string,
+    @Req() request: Request,
+  ): Promise<AuthorizationServerMetadataDto> {
+    const server = isUUID(mcpServerId)
+      ? await this.mcpRegistryService.getServerById(mcpServerId)
+      : await this.mcpRegistryService.getServerByProvidedId(mcpServerId);
+
+    const baseUrl = this.resolveBaseUrl(request);
+
+    const serverIdentifier = server.providedId ?? server.id;
+
+    return {
+      issuer: `${baseUrl}/v1/${serverIdentifier}`,
+      authorization_endpoint: `${baseUrl}/v1/authorize/${serverIdentifier}`,
+      registration_endpoint: `${baseUrl}/v1/register/${serverIdentifier}`,
+      scopes_supported: (server.scopes ?? [])
+        .map((scope) => scope.scopeId)
+        .sort(),
+      response_types_supported: ['code'],
+      grant_types_supported: [
+        GrantType.AUTHORIZATION_CODE,
+        GrantType.REFRESH_TOKEN,
+      ],
+      token_endpoint_auth_methods_supported: ['client_secret_post'],
+      code_challenge_methods_supported: ['S256'],
+    };
+  }
+
+  private resolveBaseUrl(request: Request): string {
+    const forwardedProto = this.firstHeaderValue(
+      request.headers['x-forwarded-proto'],
+    );
+    const protocol = forwardedProto ?? request.protocol;
+
+    const forwardedHost = this.firstHeaderValue(
+      request.headers['x-forwarded-host'],
+    );
+    const host = forwardedHost ?? request.get('host') ?? 'localhost';
+
+    const normalizedHost = host.replace(/\/+$/, '');
+
+    return `${protocol}://${normalizedHost}/api`;
+  }
+
+  private firstHeaderValue(
+    headerValue: string | string[] | undefined,
+  ): string | undefined {
+    if (!headerValue) {
+      return undefined;
+    }
+
+    if (Array.isArray(headerValue)) {
+      return headerValue[0];
+    }
+
+    return headerValue.split(',')[0]?.trim();
+  }
+}

--- a/apps/backend/src/authorization-server/authorization-server.module.ts
+++ b/apps/backend/src/authorization-server/authorization-server.module.ts
@@ -3,11 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ClientRegistrationService } from './client-registration.service';
 import { ClientRegistrationController } from './client-registration.controller';
 import { RegisteredClientEntity } from './registered-client.entity';
+import { AuthorizationServerMetadataController } from './authorization-server-metadata.controller';
+import { McpRegistryModule } from '../mcp-registry/mcp-registry.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RegisteredClientEntity])],
+  imports: [TypeOrmModule.forFeature([RegisteredClientEntity]), McpRegistryModule],
   providers: [ClientRegistrationService],
-  controllers: [ClientRegistrationController],
+  controllers: [ClientRegistrationController, AuthorizationServerMetadataController],
   exports: [ClientRegistrationService],
 })
 export class AuthorizationServerModule {}

--- a/apps/backend/src/authorization-server/dto/authorization-server-metadata.dto.ts
+++ b/apps/backend/src/authorization-server/dto/authorization-server-metadata.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GrantType } from '../enums';
+
+export class AuthorizationServerMetadataDto {
+  @ApiProperty({
+    description: 'Issuer identifier for the MCP authorization server',
+    example: 'https://api.example.com/v1/mcp-server',
+  })
+  issuer!: string;
+
+  @ApiProperty({
+    description: 'Authorization endpoint for initiating OAuth 2.0 authorization code flows',
+    example: 'https://api.example.com/v1/authorize/mcp-server',
+  })
+  authorization_endpoint!: string;
+
+  @ApiProperty({
+    description: 'Dynamic client registration endpoint for MCP integrations',
+    example: 'https://api.example.com/v1/register/mcp-server',
+  })
+  registration_endpoint!: string;
+
+  @ApiProperty({
+    description: 'Scopes supported by this MCP authorization server',
+    example: ['mcp:tool.read', 'mcp:tool.write'],
+    type: [String],
+  })
+  scopes_supported!: string[];
+
+  @ApiProperty({
+    description: 'OAuth 2.0 response types supported by this authorization server',
+    example: ['code'],
+    type: [String],
+  })
+  response_types_supported!: string[];
+
+  @ApiProperty({
+    description: 'OAuth 2.0 grant types supported by this authorization server',
+    example: [GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN],
+    enum: GrantType,
+    isArray: true,
+  })
+  grant_types_supported!: GrantType[];
+
+  @ApiProperty({
+    description: 'Client authentication methods supported by the token endpoint',
+    example: ['client_secret_post'],
+    type: [String],
+  })
+  token_endpoint_auth_methods_supported!: string[];
+
+  @ApiProperty({
+    description: 'PKCE code challenge methods supported by this authorization server',
+    example: ['S256'],
+    type: [String],
+  })
+  code_challenge_methods_supported!: string[];
+}

--- a/apps/backend/test/authorization-server-metadata.e2e-spec.ts
+++ b/apps/backend/test/authorization-server-metadata.e2e-spec.ts
@@ -1,0 +1,96 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { CreateServerDto } from '../src/mcp-registry/dto/create-server.dto';
+import { CreateScopeDto } from '../src/mcp-registry/dto/create-scope.dto';
+import { ProblemDetailsFilter } from '../src/http/problem-details.filter';
+
+describe('AuthorizationServerMetadataController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new ProblemDetailsFilter());
+
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should expose authorization server metadata for a registered MCP server by providedId', async () => {
+    const serverDto: CreateServerDto = {
+      providedId: `discovery-server-${Math.random()}`,
+      name: 'Discovery Test MCP Server',
+      description: 'Server used for authorization metadata discovery tests',
+    };
+
+    const createServerResponse = await request(app.getHttpServer())
+      .post('/mcp/servers')
+      .send(serverDto)
+      .expect(201);
+
+    const serverId: string = createServerResponse.body.id;
+
+    const scopeDto: CreateScopeDto = {
+      scopeId: 'tool:read',
+      description: 'Read tool data',
+    };
+
+    await request(app.getHttpServer())
+      .post(`/mcp/servers/${serverId}/scopes`)
+      .send(scopeDto)
+      .expect(201);
+
+    const response = await request(app.getHttpServer())
+      .get(
+        `/.well-known/oauth-authorization-server/${serverDto.providedId}`,
+      )
+      .expect(200);
+
+    expect(response.body.issuer).toContain(`/api/v1/${serverDto.providedId}`);
+    expect(response.body.authorization_endpoint).toContain(
+      `/api/v1/authorize/${serverDto.providedId}`,
+    );
+    expect(response.body.registration_endpoint).toContain(
+      `/api/v1/register/${serverDto.providedId}`,
+    );
+    expect(response.body.scopes_supported).toEqual(['tool:read']);
+    expect(response.body.response_types_supported).toEqual(['code']);
+    expect(response.body.grant_types_supported).toEqual([
+      'authorization_code',
+      'refresh_token',
+    ]);
+    expect(response.body.token_endpoint_auth_methods_supported).toEqual([
+      'client_secret_post',
+    ]);
+    expect(response.body.code_challenge_methods_supported).toEqual(['S256']);
+  });
+
+  it('should return 404 when requesting metadata for a non-existent MCP server', async () => {
+    const missingId = 'non-existent-server';
+
+    const response = await request(app.getHttpServer())
+      .get(`/.well-known/oauth-authorization-server/${missingId}`)
+      .expect(404);
+
+    expect(response.body).toMatchObject({
+      status: 404,
+      title: 'MCP server not found',
+    });
+  });
+});

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -567,6 +567,39 @@
         ]
       }
     },
+    "/api/v1/.well-known/oauth-authorization-server/{mcpServerId}": {
+      "get": {
+        "description": "Provides discovery metadata (RFC 8414) for OAuth 2.0 clients integrating with an MCP server. Accepts either the server UUID or the providedId.",
+        "operationId": "AuthorizationServerMetadataController_getAuthorizationServerMetadata",
+        "parameters": [
+          {
+            "name": "mcpServerId",
+            "required": true,
+            "in": "path",
+            "description": "MCP server UUID or providedId",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authorization server metadata retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationServerMetadataDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Expose OAuth 2.0 Authorization Server metadata for a registered MCP server",
+        "tags": [
+          "Authorization Server"
+        ]
+      }
+    },
     "/api/v1/mcp/servers": {
       "post": {
         "operationId": "McpRegistryController_createServer",
@@ -1712,6 +1745,92 @@
           "grant_types",
           "token_endpoint_auth_method",
           "client_id_issued_at"
+        ]
+      },
+      "AuthorizationServerMetadataDto": {
+        "type": "object",
+        "properties": {
+          "issuer": {
+            "type": "string",
+            "description": "Issuer identifier for the MCP authorization server",
+            "example": "https://api.example.com/v1/mcp-server"
+          },
+          "authorization_endpoint": {
+            "type": "string",
+            "description": "Authorization endpoint for initiating OAuth 2.0 authorization code flows",
+            "example": "https://api.example.com/v1/authorize/mcp-server"
+          },
+          "registration_endpoint": {
+            "type": "string",
+            "description": "Dynamic client registration endpoint for MCP integrations",
+            "example": "https://api.example.com/v1/register/mcp-server"
+          },
+          "scopes_supported": {
+            "description": "Scopes supported by this MCP authorization server",
+            "example": [
+              "mcp:tool.read",
+              "mcp:tool.write"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "response_types_supported": {
+            "description": "OAuth 2.0 response types supported by this authorization server",
+            "example": [
+              "code"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "grant_types_supported": {
+            "type": "array",
+            "description": "OAuth 2.0 grant types supported by this authorization server",
+            "example": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "items": {
+              "type": "string",
+              "enum": [
+                "authorization_code",
+                "refresh_token"
+              ]
+            }
+          },
+          "token_endpoint_auth_methods_supported": {
+            "description": "Client authentication methods supported by the token endpoint",
+            "example": [
+              "client_secret_post"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "code_challenge_methods_supported": {
+            "description": "PKCE code challenge methods supported by this authorization server",
+            "example": [
+              "S256"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "issuer",
+          "authorization_endpoint",
+          "registration_endpoint",
+          "scopes_supported",
+          "response_types_supported",
+          "grant_types_supported",
+          "token_endpoint_auth_methods_supported",
+          "code_challenge_methods_supported"
         ]
       },
       "CreateServerDto": {

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -204,6 +204,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/.well-known/oauth-authorization-server/{mcpServerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Expose OAuth 2.0 Authorization Server metadata for a registered MCP server
+         * @description Provides discovery metadata (RFC 8414) for OAuth 2.0 clients integrating with an MCP server. Accepts either the server UUID or the providedId.
+         */
+        get: operations["AuthorizationServerMetadataController_getAuthorizationServerMetadata"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/mcp/servers": {
         parameters: {
             query?: never;
@@ -735,6 +755,60 @@ export interface components {
              * @example 2025-11-05T08:00:00.000Z
              */
             client_id_issued_at: string;
+        };
+        AuthorizationServerMetadataDto: {
+            /**
+             * @description Issuer identifier for the MCP authorization server
+             * @example https://api.example.com/v1/mcp-server
+             */
+            issuer: string;
+            /**
+             * @description Authorization endpoint for initiating OAuth 2.0 authorization code flows
+             * @example https://api.example.com/v1/authorize/mcp-server
+             */
+            authorization_endpoint: string;
+            /**
+             * @description Dynamic client registration endpoint for MCP integrations
+             * @example https://api.example.com/v1/register/mcp-server
+             */
+            registration_endpoint: string;
+            /**
+             * @description Scopes supported by this MCP authorization server
+             * @example [
+             *       "mcp:tool.read",
+             *       "mcp:tool.write"
+             *     ]
+             */
+            scopes_supported: string[];
+            /**
+             * @description OAuth 2.0 response types supported by this authorization server
+             * @example [
+             *       "code"
+             *     ]
+             */
+            response_types_supported: string[];
+            /**
+             * @description OAuth 2.0 grant types supported by this authorization server
+             * @example [
+             *       "authorization_code",
+             *       "refresh_token"
+             *     ]
+             */
+            grant_types_supported: ("authorization_code" | "refresh_token")[];
+            /**
+             * @description Client authentication methods supported by the token endpoint
+             * @example [
+             *       "client_secret_post"
+             *     ]
+             */
+            token_endpoint_auth_methods_supported: string[];
+            /**
+             * @description PKCE code challenge methods supported by this authorization server
+             * @example [
+             *       "S256"
+             *     ]
+             */
+            code_challenge_methods_supported: string[];
         };
         CreateServerDto: {
             /**
@@ -1444,6 +1518,29 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ClientRegistrationResponseDto"][];
+                };
+            };
+        };
+    };
+    AuthorizationServerMetadataController_getAuthorizationServerMetadata: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description MCP server UUID or providedId */
+                mcpServerId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Authorization server metadata retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthorizationServerMetadataDto"];
                 };
             };
         };

--- a/packages/shared/src/client/index.ts
+++ b/packages/shared/src/client/index.ts
@@ -8,6 +8,7 @@ export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
 export type { AssignTaskDto } from './models/AssignTaskDto';
+export type { AuthorizationServerMetadataDto } from './models/AuthorizationServerMetadataDto';
 export { ClientRegistrationResponseDto } from './models/ClientRegistrationResponseDto';
 export type { CommentResponseDto } from './models/CommentResponseDto';
 export type { ConnectionResponseDto } from './models/ConnectionResponseDto';

--- a/packages/shared/src/client/models/AuthorizationServerMetadataDto.ts
+++ b/packages/shared/src/client/models/AuthorizationServerMetadataDto.ts
@@ -1,0 +1,39 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AuthorizationServerMetadataDto = {
+    /**
+     * Issuer identifier for the MCP authorization server
+     */
+    issuer: string;
+    /**
+     * Authorization endpoint for initiating OAuth 2.0 authorization code flows
+     */
+    authorization_endpoint: string;
+    /**
+     * Dynamic client registration endpoint for MCP integrations
+     */
+    registration_endpoint: string;
+    /**
+     * Scopes supported by this MCP authorization server
+     */
+    scopes_supported: Array<string>;
+    /**
+     * OAuth 2.0 response types supported by this authorization server
+     */
+    response_types_supported: Array<string>;
+    /**
+     * OAuth 2.0 grant types supported by this authorization server
+     */
+    grant_types_supported: Array<'authorization_code' | 'refresh_token'>;
+    /**
+     * Client authentication methods supported by the token endpoint
+     */
+    token_endpoint_auth_methods_supported: Array<string>;
+    /**
+     * PKCE code challenge methods supported by this authorization server
+     */
+    code_challenge_methods_supported: Array<string>;
+};
+

--- a/packages/shared/src/client/services/AuthorizationServerService.ts
+++ b/packages/shared/src/client/services/AuthorizationServerService.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AuthorizationServerMetadataDto } from '../models/AuthorizationServerMetadataDto';
 import type { ClientRegistrationResponseDto } from '../models/ClientRegistrationResponseDto';
 import type { RegisterClientDto } from '../models/RegisterClientDto';
 import type { CancelablePromise } from '../core/CancelablePromise';
@@ -60,6 +61,24 @@ export class AuthorizationServerService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/authz/clients',
+        });
+    }
+    /**
+     * Expose OAuth 2.0 Authorization Server metadata for a registered MCP server
+     * Provides discovery metadata (RFC 8414) for OAuth 2.0 clients integrating with an MCP server. Accepts either the server UUID or the providedId.
+     * @param mcpServerId MCP server UUID or providedId
+     * @returns AuthorizationServerMetadataDto Authorization server metadata retrieved successfully
+     * @throws ApiError
+     */
+    public static authorizationServerMetadataControllerGetAuthorizationServerMetadata(
+        mcpServerId: string,
+    ): CancelablePromise<AuthorizationServerMetadataDto> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/.well-known/oauth-authorization-server/{mcpServerId}',
+            path: {
+                'mcpServerId': mcpServerId,
+            },
         });
     }
 }


### PR DESCRIPTION
Exposes `/api/v1/.well-known/oauth-authorization-server/:mcp_server_id` with scopes pulled from the mcp server registry.
Might need to tweak the path. Will do that later once I have an MCP server to play with. Also need to refine the register endpoint