### PR TITLE
Hide Scope Mappings section when no connections exist

### DIFF
--- a/apps/ui/src/mcp-registry/McpServerDetail.tsx
+++ b/apps/ui/src/mcp-registry/McpServerDetail.tsx
@@ -323,44 +323,46 @@ export function McpServerDetail() {
           </div>
         </div>
 
-        {/* Mappings Section */}
-        <div className="detail-section">
-          <div className="section-header">
-            <h2>Scope Mappings</h2>
-            <button
-              onClick={() => setActiveForm('mapping')}
-              className="btn-secondary"
-              disabled={scopes.length === 0 || connections.length === 0}
-            >
-              + Add Mapping
-            </button>
-          </div>
-          <div className="items-list">
-            {mappings.length === 0 ? (
-              <p className="empty-text">No mappings configured</p>
-            ) : (
-              mappings.map((mapping) => {
-                const scope = scopes.find((s) => s.scopeId === mapping.scopeId);
-                const connection = connections.find((c) => c.id === mapping.connectionId);
-                return (
-                  <div key={mapping.id} className="item-card">
-                    <div className="item-content">
-                      <h3>{scope?.scopeId || mapping.scopeId}</h3>
-                      <p>→ {mapping.downstreamScope}</p>
-                      <p className="small-text">via {connection?.friendlyName || 'Unknown'}</p>
+        {/* Mappings Section - Only show if there are connections */}
+        {connections.length > 0 && (
+          <div className="detail-section">
+            <div className="section-header">
+              <h2>Scope Mappings</h2>
+              <button
+                onClick={() => setActiveForm('mapping')}
+                className="btn-secondary"
+                disabled={scopes.length === 0}
+              >
+                + Add Mapping
+              </button>
+            </div>
+            <div className="items-list">
+              {mappings.length === 0 ? (
+                <p className="empty-text">No mappings configured</p>
+              ) : (
+                mappings.map((mapping) => {
+                  const scope = scopes.find((s) => s.scopeId === mapping.scopeId);
+                  const connection = connections.find((c) => c.id === mapping.connectionId);
+                  return (
+                    <div key={mapping.id} className="item-card">
+                      <div className="item-content">
+                        <h3>{scope?.scopeId || mapping.scopeId}</h3>
+                        <p>→ {mapping.downstreamScope}</p>
+                        <p className="small-text">via {connection?.friendlyName || 'Unknown'}</p>
+                      </div>
+                      <button
+                        onClick={() => handleDeleteMapping(mapping.id)}
+                        className="btn-delete"
+                      >
+                        Delete
+                      </button>
                     </div>
-                    <button
-                      onClick={() => handleDeleteMapping(mapping.id)}
-                      className="btn-delete"
-                    >
-                      Delete
-                    </button>
-                  </div>
-                );
-              })
-            )}
+                  );
+                })
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       {/* Create Scope Modal */}


### PR DESCRIPTION
## Summary

This PR improves the UX by hiding the Scope Mappings section when there are no OAuth connections configured.

### Problem
Previously, the Scope Mappings section was always visible with a disabled Add Mapping button when there were no connections. This was confusing since mappings require connections to function.

### Solution
- Wrapped the entire mapping section in a conditional render: `{connections.length > 0 && (...)}`
- Section now only appears when there are connections available to map to
- Removed redundant connections check from button disabled state
- Button still disabled when there are no scopes defined

### Testing
- npm run build:prod ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)