### PR TITLE
Configure ports for parallel development stacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-# Application Port
+# Backend Port (NestJS application)
 PORT=3000
+
+# Frontend Port (Vite development server)
+VITE_PORT=5173
 
 # Database Configuration
 DATABASE_PATH=data/database.sqlite

--- a/README.md
+++ b/README.md
@@ -24,6 +24,35 @@ npm install
 npm run dev
 ```
 
+#### Running Multiple Stacks in Parallel
+
+To run multiple development stacks simultaneously (useful for testing or comparing branches), configure different ports using environment variables:
+
+**Stack 1 (default ports):**
+```bash
+npm run dev
+# Backend: http://localhost:3000
+# Frontend: http://localhost:5173
+```
+
+**Stack 2 (custom ports):**
+```bash
+PORT=3001 VITE_PORT=5174 npm run dev
+# Backend: http://localhost:3001
+# Frontend: http://localhost:5174
+```
+
+You can also create `.env` files for each stack:
+```bash
+# .env.stack1
+PORT=3000
+VITE_PORT=5173
+
+# .env.stack2
+PORT=3001
+VITE_PORT=5174
+```
+
 ### Production Mode (Docker)
 ```bash
 # Run on default port (3000)

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "build:prod": "npm run build && cp -r ./dist ../backend/dist/public",
-    "preview": "vite preview --port 5173"
+    "preview": "vite preview --port ${VITE_PORT:-5173}"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -6,7 +6,7 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173
+    port: Number(process.env.VITE_PORT) || 5173
   },
   build: {
     outDir: './dist',


### PR DESCRIPTION
## Summary

- Made Vite frontend port configurable via VITE_PORT environment variable (defaults to 5173)
- Backend port was already configurable via PORT environment variable (defaults to 3000)
- Updated .env.example with clear documentation for both port variables
- Updated preview script in package.json to use VITE_PORT
- Added comprehensive documentation to README.md explaining how to run multiple development stacks in parallel

## Changes

### Files Modified
- **apps/ui/vite.config.ts**: Updated server port configuration to use VITE_PORT env variable
- **apps/ui/package.json**: Updated preview script to use VITE_PORT with fallback
- **.env.example**: Added VITE_PORT variable with documentation
- **README.md**: Added section on running multiple stacks in parallel with examples

## Test Plan

- [x] Production build passes (npm run build:prod)
- [x] TypeScript compilation succeeds
- [ ] Test with default ports (PORT=3000, VITE_PORT=5173)
- [ ] Test with custom ports (PORT=3001, VITE_PORT=5174)
- [ ] Verify both stacks can run simultaneously without conflicts

## Use Case

This change enables developers to run multiple development stacks in parallel by setting different port values:

```bash
# Terminal 1 - Stack 1 (default ports)
npm run dev

# Terminal 2 - Stack 2 (custom ports)
PORT=3001 VITE_PORT=5174 npm run dev
```

This is particularly useful for:
- Testing different branches simultaneously
- Comparing implementations side-by-side
- Running multiple feature developments in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)