### PR TITLE
Add navigation to server detail page after creation

### DIFF
--- a/apps/ui/src/mcp-registry/McpRegistryDashboard.tsx
+++ b/apps/ui/src/mcp-registry/McpRegistryDashboard.tsx
@@ -20,9 +20,13 @@ export function McpRegistryDashboard() {
   const handleCreateServer = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await createServer(formData);
+      const createdServer = await createServer(formData);
       setShowCreateForm(false);
       setFormData({ providedId: '', name: '', description: '' });
+      // Navigate to the newly created server's detail page
+      if (createdServer) {
+        navigate(`/mcp-registry/${createdServer.id}`);
+      }
     } catch (err) {
       // Error is handled by the hook
       console.error('Failed to create server', err);

--- a/apps/ui/src/mcp-registry/useMcpRegistry.ts
+++ b/apps/ui/src/mcp-registry/useMcpRegistry.ts
@@ -117,8 +117,9 @@ export const useMcpRegistry = () => {
     setIsLoading(true);
     setError(null);
     try {
-      await McpRegistryService.mcpRegistryControllerCreateServer(data);
+      const createdServer = await McpRegistryService.mcpRegistryControllerCreateServer(data);
       await loadServers();
+      return createdServer;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create server');
       throw err;


### PR DESCRIPTION
## Summary
- Automatically redirect users to newly created server detail page
- Modified createServer hook to return the created server data
- Updated handleCreateServer to navigate to  after creation
- Provides seamless UX from creation to configuration

## Test plan
- [x] Build passes successfully
- [ ] Create a new MCP server
- [ ] Verify automatic navigation to the server detail page
- [ ] Verify scopes, connections, and mappings sections are visible
- [ ] Test that the flow feels natural and intuitive

🤖 Generated with [Claude Code](https://claude.com/claude-code)