### PR TITLE
Fix wikiroo page width issue

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -160,8 +160,7 @@
 }
 
 .wikiroo-page-view {
-  max-width: 900px;
-  margin: 0 auto;
+  /* Removed max-width constraint to allow full-width display */
 }
 
 .wikiroo-meta {


### PR DESCRIPTION
## Summary
- Removed max-width: 900px constraint from .wikiroo-page-view class in Wikiroo.css
- Page now takes full browser width instead of showing white bars on sides
- Fixed issue where page content was centered with white space

## Test plan
- [x] Build validation passed (npm run build:prod)
- [ ] Visual verification: Load a wikiroo page and verify it takes full browser width
- [ ] Verify responsive behavior on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)