### PR TITLE
Decouple TaskerooService from WebSocket transport layer

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.1.8",
     "@nestjs/swagger": "^11.2.1",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TaskerooModule } from './taskeroo/taskeroo.module';
 import { WikirooModule } from './wikiroo/wikiroo.module';
 import { AuthorizationServerModule } from './authorization-server/authorization-server.module';
@@ -15,6 +16,7 @@ import { McpRegistryModule } from './mcp-registry/mcp-registry.module';
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: true,
     }),
+    EventEmitterModule.forRoot(),
     TaskerooModule,
     WikirooModule,
     AuthorizationServerModule,

--- a/apps/backend/src/taskeroo/events/taskeroo.events.ts
+++ b/apps/backend/src/taskeroo/events/taskeroo.events.ts
@@ -1,0 +1,31 @@
+import { TaskEntity } from '../task.entity';
+import { CommentEntity } from '../comment.entity';
+
+/**
+ * Domain events for the Taskeroo domain.
+ * These events decouple the service layer from transport concerns (WebSocket, HTTP, etc.)
+ */
+
+export class TaskCreatedEvent {
+  constructor(public readonly task: TaskEntity) {}
+}
+
+export class TaskUpdatedEvent {
+  constructor(public readonly task: TaskEntity) {}
+}
+
+export class TaskAssignedEvent {
+  constructor(public readonly task: TaskEntity) {}
+}
+
+export class TaskDeletedEvent {
+  constructor(public readonly taskId: string) {}
+}
+
+export class CommentAddedEvent {
+  constructor(public readonly comment: CommentEntity) {}
+}
+
+export class TaskStatusChangedEvent {
+  constructor(public readonly task: TaskEntity) {}
+}

--- a/apps/backend/src/taskeroo/taskeroo.gateway.ts
+++ b/apps/backend/src/taskeroo/taskeroo.gateway.ts
@@ -6,9 +6,21 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { Logger } from '@nestjs/common';
-import { TaskEntity } from './task.entity';
-import { CommentEntity } from './comment.entity';
+import { OnEvent } from '@nestjs/event-emitter';
+import {
+  TaskCreatedEvent,
+  TaskUpdatedEvent,
+  TaskAssignedEvent,
+  TaskDeletedEvent,
+  CommentAddedEvent,
+  TaskStatusChangedEvent,
+} from './events/taskeroo.events';
 
+/**
+ * WebSocket gateway for Taskeroo domain.
+ * Listens to domain events and broadcasts them via WebSocket.
+ * This decouples the service layer from transport concerns.
+ */
 @WebSocketGateway({
   cors: {
     origin: '*',
@@ -31,27 +43,33 @@ export class TaskerooGateway
     this.logger.log(`Client disconnected: ${client.id}`);
   }
 
-  emitTaskCreated(task: TaskEntity) {
-    this.server.emit('task.created', task);
+  @OnEvent('task.created')
+  handleTaskCreated(event: TaskCreatedEvent) {
+    this.server.emit('task.created', event.task);
   }
 
-  emitTaskUpdated(task: TaskEntity) {
-    this.server.emit('task.updated', task);
+  @OnEvent('task.updated')
+  handleTaskUpdated(event: TaskUpdatedEvent) {
+    this.server.emit('task.updated', event.task);
   }
 
-  emitTaskDeleted(taskId: string) {
-    this.server.emit('task.deleted', { taskId });
+  @OnEvent('task.deleted')
+  handleTaskDeleted(event: TaskDeletedEvent) {
+    this.server.emit('task.deleted', { taskId: event.taskId });
   }
 
-  emitTaskAssigned(task: TaskEntity) {
-    this.server.emit('task.assigned', task);
+  @OnEvent('task.assigned')
+  handleTaskAssigned(event: TaskAssignedEvent) {
+    this.server.emit('task.assigned', event.task);
   }
 
-  emitCommentAdded(comment: CommentEntity) {
-    this.server.emit('task.commented', comment);
+  @OnEvent('comment.added')
+  handleCommentAdded(event: CommentAddedEvent) {
+    this.server.emit('task.commented', event.comment);
   }
 
-  emitStatusChanged(task: TaskEntity) {
-    this.server.emit('task.status_changed', task);
+  @OnEvent('task.statusChanged')
+  handleStatusChanged(event: TaskStatusChangedEvent) {
+    this.server.emit('task.status_changed', event.task);
   }
 }

--- a/apps/backend/src/taskeroo/taskeroo.service.ts
+++ b/apps/backend/src/taskeroo/taskeroo.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Repository } from 'typeorm';
 import { TaskEntity } from './task.entity';
 import { TaskStatus } from './enums';
@@ -20,7 +21,14 @@ import {
   InvalidStatusTransitionError,
   CommentRequiredError,
 } from './errors/taskeroo.errors';
-import { TaskerooGateway } from './taskeroo.gateway';
+import {
+  TaskCreatedEvent,
+  TaskUpdatedEvent,
+  TaskAssignedEvent,
+  TaskDeletedEvent,
+  CommentAddedEvent,
+  TaskStatusChangedEvent,
+} from './events/taskeroo.events';
 
 @Injectable()
 export class TaskerooService {
@@ -31,7 +39,7 @@ export class TaskerooService {
     private readonly taskRepository: Repository<TaskEntity>,
     @InjectRepository(CommentEntity)
     private readonly commentRepository: Repository<CommentEntity>,
-    private readonly gateway: TaskerooGateway,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async createTask(input: CreateTaskInput): Promise<TaskResult> {
@@ -68,7 +76,7 @@ export class TaskerooService {
       name: taskWithRelations.name,
     });
 
-    this.gateway.emitTaskCreated(taskWithRelations);
+    this.eventEmitter.emit('task.created', new TaskCreatedEvent(taskWithRelations));
     return this.mapTaskToResult(taskWithRelations);
   }
 
@@ -95,7 +103,7 @@ export class TaskerooService {
       taskId: updatedTask.id,
     });
 
-    this.gateway.emitTaskUpdated(updatedTask);
+    this.eventEmitter.emit('task.updated', new TaskUpdatedEvent(updatedTask));
     return this.mapTaskToResult(updatedTask);
   }
 
@@ -129,7 +137,7 @@ export class TaskerooService {
       sessionId: assignedTask.sessionId,
     });
 
-    this.gateway.emitTaskAssigned(assignedTask);
+    this.eventEmitter.emit('task.assigned', new TaskAssignedEvent(assignedTask));
     return this.mapTaskToResult(assignedTask);
   }
 
@@ -152,7 +160,7 @@ export class TaskerooService {
       taskId,
     });
 
-    this.gateway.emitTaskDeleted(taskId);
+    this.eventEmitter.emit('task.deleted', new TaskDeletedEvent(taskId));
   }
 
   async listTasks(input: ListTasksInput): Promise<ListTasksResult> {
@@ -236,7 +244,7 @@ export class TaskerooService {
       taskId,
     });
 
-    this.gateway.emitCommentAdded(savedComment);
+    this.eventEmitter.emit('comment.added', new CommentAddedEvent(savedComment));
     return this.mapCommentToResult(savedComment);
   }
 
@@ -303,7 +311,7 @@ export class TaskerooService {
       status: taskWithRelations.status,
     });
 
-    this.gateway.emitStatusChanged(taskWithRelations);
+    this.eventEmitter.emit('task.statusChanged', new TaskStatusChangedEvent(taskWithRelations));
     return this.mapTaskToResult(taskWithRelations);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "dependencies": {
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
+        "@nestjs/event-emitter": "^3.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.1.8",
         "@nestjs/swagger": "^11.2.1",
@@ -2808,6 +2809,19 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-3.0.1.tgz",
+      "integrity": "sha512-0Ln/x+7xkU6AJFOcQI9tIhUMXVF7D5itiaQGOyJbXtlAfAIt8gzDdJm+Im7cFzKoWkiW5nCXCPh6GSvdQd/3Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/mapped-types": {
@@ -7242,6 +7256,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -12470,10 +12490,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-markdown": {
-      "resolved": "packages/react-markdown",
-      "link": true
-    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -15777,7 +15793,8 @@
       }
     },
     "packages/react-markdown": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "extraneous": true
     },
     "packages/shared": {
       "version": "0.0.1",


### PR DESCRIPTION
## Summary
- Installed @nestjs/event-emitter package
- Created domain events for Taskeroo (TaskCreatedEvent, TaskUpdatedEvent, TaskAssignedEvent, TaskDeletedEvent, CommentAddedEvent, TaskStatusChangedEvent)
- Refactored TaskerooService to emit domain events instead of calling gateway directly
- Updated TaskerooGateway to listen to domain events using @OnEvent decorators
- Added EventEmitterModule to AppModule

## Context
Services review task identified that TaskerooService had transport coupling - it directly depended on WebSocket gateway (lines 34,71,98,132,155,239,306), violating best practice #7 (logs/metrics at domain level, no transport concerns).

This refactoring implements an event-driven architecture where the service layer emits domain events and transport layers (like WebSocket gateway) subscribe to these events independently. The service no longer knows about WebSocket or any specific transport mechanism.

## Benefits
- Service layer is now transport-agnostic
- Can easily add new transport layers (HTTP SSE, message queues, etc.) without modifying service
- Better separation of concerns
- Follows domain-driven design principles

## Test plan
- [x] npm run build:prod passes successfully
- [x] EventEmitterModule properly initialized
- [x] All domain events created and imported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)