### PR TITLE
fix: exclude /.well-known routes from SPA fallback middleware

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -64,8 +64,8 @@ async function bootstrap() {
     // SPA fallback: serve index.html for all non-API, non-asset routes
     // This allows client-side routing to work
     app.use((req, res, next) => {
-      // Don't intercept API routes or static assets
-      if (req.path.startsWith('/api/') || req.path.startsWith('/assets/')) {
+      // Don't intercept API routes, static assets, or well-known routes
+      if (req.path.startsWith('/api/') || req.path.startsWith('/assets/') || req.path.startsWith('/.well-known/')) {
         return next();
       }
       // Serve index.html for all other routes


### PR DESCRIPTION
## Summary
Fixed routing issue where /.well-known routes were being intercepted by the SPA fallback middleware instead of being handled by the discovery controller.

## Changes
- Added /.well-known/ path exclusion to the SPA fallback middleware check in main.ts
- Ensures proper separation of concerns: API routes, well-known routes, static assets, and SPA fallback

## Testing
- npm run build:prod passed successfully
- No breaking changes to existing functionality