### PR TITLE
Align JWKS and discovery controllers with guidelines

### DIFF
--- a/apps/backend/src/authorization-server/dto/jwks-response.dto.ts
+++ b/apps/backend/src/authorization-server/dto/jwks-response.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class JwkResponseDto {
+  @ApiProperty({
+    description: 'Key type, for example RSA or EC.',
+    example: 'RSA',
+  })
+  kty!: string;
+
+  @ApiProperty({
+    description: 'Key usage indicating how the key can be used.',
+    example: 'sig',
+  })
+  use!: string;
+
+  @ApiProperty({
+    description: 'Unique identifier for the key used for rotation.',
+    example: '1234567890abcdef',
+  })
+  kid!: string;
+
+  @ApiProperty({
+    description: 'Algorithm intended for use with this key.',
+    example: 'RS256',
+  })
+  alg!: string;
+
+  @ApiPropertyOptional({
+    description: 'RSA modulus encoded using base64url.',
+  })
+  n?: string;
+
+  @ApiPropertyOptional({
+    description: 'RSA public exponent encoded using base64url.',
+    example: 'AQAB',
+  })
+  e?: string;
+
+  @ApiPropertyOptional({
+    description: 'Public coordinate X for EC keys encoded using base64url.',
+  })
+  x?: string;
+
+  @ApiPropertyOptional({
+    description: 'Public coordinate Y for EC keys encoded using base64url.',
+  })
+  y?: string;
+
+  @ApiPropertyOptional({
+    description: 'Curve name for EC keys.',
+    example: 'P-256',
+  })
+  crv?: string;
+}
+
+export class JwksResponseDto {
+  @ApiProperty({
+    description: 'Collection of JSON Web Keys currently valid for signature verification.',
+    type: [JwkResponseDto],
+  })
+  keys!: JwkResponseDto[];
+}

--- a/apps/backend/src/authorization-server/jwks.controller.ts
+++ b/apps/backend/src/authorization-server/jwks.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { JwksService, JWKS } from './jwks.service';
+import { JwksService } from './jwks.service';
+import { JwksResponseDto } from './dto/jwks-response.dto';
 
 @ApiTags('JWKS')
 @Controller('.well-known')
@@ -15,27 +16,23 @@ export class JwksController {
   })
   @ApiOkResponse({
     description: 'JWKS retrieved successfully',
-    schema: {
-      type: 'object',
-      properties: {
-        keys: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              kty: { type: 'string', example: 'RSA' },
-              use: { type: 'string', example: 'sig' },
-              kid: { type: 'string', example: '1234567890abcdef' },
-              alg: { type: 'string', example: 'RS256' },
-              n: { type: 'string' },
-              e: { type: 'string' },
-            },
-          },
-        },
-      },
-    },
+    type: JwksResponseDto,
   })
-  async getJwks(): Promise<JWKS> {
-    return this.jwksService.getPublicKeys();
+  async getJwks(): Promise<JwksResponseDto> {
+    const jwks = await this.jwksService.getPublicKeys();
+
+    return {
+      keys: jwks.keys.map((key) => ({
+        kty: key.kty,
+        use: key.use,
+        kid: key.kid,
+        alg: key.alg,
+        n: key.n,
+        e: key.e,
+        x: key.x,
+        y: key.y,
+        crv: key.crv,
+      })),
+    };
   }
 }

--- a/apps/backend/src/discovery/discovery.module.ts
+++ b/apps/backend/src/discovery/discovery.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { DiscoveryController } from './discovery.controller';
+import { DiscoveryService } from './discovery.service';
 import { McpRegistryModule } from '../mcp-registry/mcp-registry.module';
 
 @Module({
   imports: [McpRegistryModule],
   controllers: [DiscoveryController],
+  providers: [DiscoveryService],
 })
 export class DiscoveryModule {}

--- a/apps/backend/src/discovery/discovery.service.ts
+++ b/apps/backend/src/discovery/discovery.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { GrantType } from '../authorization-server/enums';
+import { McpRegistryService } from '../mcp-registry/mcp-registry.service';
+import {
+  AuthorizationServerMetadataResult,
+  GetAuthorizationServerMetadataInput,
+} from './dto/service/discovery.service.types';
+
+@Injectable()
+export class DiscoveryService {
+  constructor(private readonly mcpRegistryService: McpRegistryService) {}
+
+  async getAuthorizationServerMetadata(
+    input: GetAuthorizationServerMetadataInput,
+  ): Promise<AuthorizationServerMetadataResult> {
+    const server =
+      input.lookupBy === 'id'
+        ? await this.mcpRegistryService.getServerById(input.serverIdentifier)
+        : await this.mcpRegistryService.getServerByProvidedId(
+            input.serverIdentifier,
+          );
+
+    const serverIdentifier = server.providedId ?? server.id;
+    const scopes = (server.scopes ?? [])
+      .map((scope) => scope.scopeId)
+      .sort((a, b) => a.localeCompare(b));
+
+    return {
+      issuer: input.issuer,
+      authorization_endpoint: `${input.issuer}/api/v1/auth/authorize/mcp/${serverIdentifier}/${input.version}`,
+      token_endpoint: `${input.issuer}/api/v1/auth/token/mcp/${serverIdentifier}/${input.version}`,
+      registration_endpoint: `${input.issuer}/api/v1/auth/clients/register/mcp/${serverIdentifier}/${input.version}`,
+      scopes_supported: scopes,
+      response_types_supported: ['code'],
+      grant_types_supported: [
+        GrantType.AUTHORIZATION_CODE,
+        GrantType.REFRESH_TOKEN,
+      ],
+      token_endpoint_auth_methods_supported: [
+        'client_secret_basic',
+        'private_key_jwt',
+      ],
+      code_challenge_methods_supported: ['S256'],
+    };
+  }
+}

--- a/apps/backend/src/discovery/dto/get-authorization-server-metadata-params.dto.ts
+++ b/apps/backend/src/discovery/dto/get-authorization-server-metadata-params.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class GetAuthorizationServerMetadataParamsDto {
+  @ApiProperty({
+    name: 'mcpServerId',
+    description: 'MCP server UUID or provided identifier registered in the catalog.',
+    example: 'inventory-service',
+  })
+  @IsString()
+  @IsNotEmpty()
+  mcpServerId!: string;
+
+  @ApiProperty({
+    name: 'version',
+    description: 'Semantic version for the MCP server configuration.',
+    example: 'v1',
+  })
+  @IsString()
+  @IsNotEmpty()
+  version!: string;
+}

--- a/apps/backend/src/discovery/dto/service/discovery.service.types.ts
+++ b/apps/backend/src/discovery/dto/service/discovery.service.types.ts
@@ -1,0 +1,22 @@
+import { GrantType } from '../../../authorization-server/enums';
+
+export type ServerLookupStrategy = 'id' | 'providedId';
+
+export type GetAuthorizationServerMetadataInput = {
+  serverIdentifier: string;
+  version: string;
+  issuer: string;
+  lookupBy: ServerLookupStrategy;
+};
+
+export type AuthorizationServerMetadataResult = {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+  scopes_supported: string[];
+  response_types_supported: string[];
+  grant_types_supported: GrantType[];
+  token_endpoint_auth_methods_supported: string[];
+  code_challenge_methods_supported: string[];
+};


### PR DESCRIPTION
## Summary
- add request/response DTOs so JWKS and discovery controllers meet transport-boundary rules
- move discovery metadata assembly into a dedicated service with service-layer types
- document/validate path params and keep controller logic focused on HTTP concerns

## Testing
- npm -w backend run typecheck