### PR TITLE
Update .claude commands to reference MCP server tools

### DIFF
--- a/.claude/commands/assign-task.md
+++ b/.claude/commands/assign-task.md
@@ -4,3 +4,5 @@ Assign a task to an agent, optionally tracking the work with a session id.
 Provide the task id, the agent name, and optionally the session id the agent is working under.
 
 Run `.claude/scripts/taskeroo/assign_task.sh "<task id>" "<assignee name>" [session id]`
+
+Alternatively, you can use the MCP server tool `mcp__taskeroo__assign_task` which provides the same functionality.

--- a/.claude/commands/change-task-status.md
+++ b/.claude/commands/change-task-status.md
@@ -2,3 +2,5 @@
 Enum of NOT_STARTED, IN_PROGRESS, FOR_REVIEW, DONE
 
 Run `.claude/scripts/taskeroo/change_task_status.sh "<task id>" "<status>"`
+
+Alternatively, you can use the MCP server tool `mcp__taskeroo__change_task_status` which provides the same functionality.

--- a/.claude/commands/comment-task.md
+++ b/.claude/commands/comment-task.md
@@ -3,3 +3,5 @@ Adds a comment to a task.
 Make it somewhat detailed to keep track of what you're doing and what you've done.
 
 Run `.claude/scripts/taskeroo/comment_task.sh "<task id>" "<your name>" "<comment text>"`
+
+Alternatively, you can use the MCP server tool `mcp__taskeroo__add_comment` which provides the same functionality.

--- a/.claude/commands/create-task.md
+++ b/.claude/commands/create-task.md
@@ -5,3 +5,5 @@ Give it a descriptive title.
 Give it a detailed description with acceptance criteria.
 
 Run `.claude/scripts/taskeroo/create_task.sh "<task title>" "<task description>"`
+
+Alternatively, you can use the MCP server tool `mcp__taskeroo__create_task` which provides the same functionality.

--- a/.claude/commands/list-tasks.md
+++ b/.claude/commands/list-tasks.md
@@ -2,3 +2,5 @@
 Returns a list of all the tasks available in our board.
 
 Run `.claude/scripts/taskeroo/list_tasks.sh`
+
+Alternatively, you can use the MCP server tool `mcp__taskeroo__list_tasks` which provides the same functionality.

--- a/.claude/commands/start-task.md
+++ b/.claude/commands/start-task.md
@@ -11,20 +11,20 @@ Your AGENT_NAME will be `claude-{ROLE}`. For example, `claude-dev`.
 
 ### Prep
 1. Get a session ID: `.claude/scripts/workflow/start_session.sh`
-2. Fetch the task `.claude/scripts/taskeroo/get_task.sh {TASK_ID}`
+2. Fetch the task `.claude/scripts/taskeroo/get_task.sh {TASK_ID}` (or use MCP tool `mcp__taskeroo__get_task`)
 3. Prepare the local environment `.claude/scripts/workflow/start_task.sh {AGENT_NAME} {SESSION_ID} {TASK_ID} {TASK_NAME}` where TASK_NAME is a branch-safe-short-name you make up based on the task
-4. Update task - assigned to you and in progress & comment with branch `.claude/scripts/workflow/update_task_in_progress.sh {TASK_ID} {AGENT_NAME} {SESSION_ID}`
+4. Update task - assigned to you and in progress & comment with branch `.claude/scripts/workflow/update_task_in_progress.sh {TASK_ID} {AGENT_NAME} {SESSION_ID}` (or use MCP tool `mcp__taskeroo__mark_task_in_progress` with the branch name)
 ### Work
 5. Get instructions for your role from `.claude/roles/{ROLE}.md` (for example, `.claude/roles/dev.md`)
 5. Implement & make frequent comments to the task
 ### Finish
 6. Open PR to `agents/main` by running `.claude/scripts/workflow/open_pr_to_agents_main.sh "PR Title" "PR Body"`
-7. Update task - in review & comment with PR link by running the `.claude/scripts/workflow/update_task_in_review.sh {TASK_ID} {AGENT_NAME} {PR_LINK}`
+7. Update task - in review & comment with PR link by running the `.claude/scripts/workflow/update_task_in_review.sh {TASK_ID} {AGENT_NAME} {PR_LINK}` (or use MCP tool `mcp__taskeroo__mark_task_for_review`)
 8. Watch CI
 9. If CI passed:
   - Merge pull request
-  - Update task - done & comment saying CI passed by running `.claude/scripts/workflow/update_task_done.sh {TASK_ID} {AGENT_NAME} {COMMENTS}`
+  - Update task - done & comment saying CI passed by running `.claude/scripts/workflow/update_task_done.sh {TASK_ID} {AGENT_NAME} {COMMENTS}` (or use MCP tool `mcp__taskeroo__mark_task_done`)
 9. If CI Failed:
-  - Update task - in progress & comment explaining failure by running `.claude/scripts/workflow/update_task_failed.sh {TASK_ID} {AGENT_NAME} {COMMENTS}`
+  - Update task - in progress & comment explaining failure by running `.claude/scripts/workflow/update_task_failed.sh {TASK_ID} {AGENT_NAME} {COMMENTS}` (or use MCP tools to change status and add comment)
   - Start work again
 10. When done, checkout `agents/main` and pull


### PR DESCRIPTION
## Summary
- Updated .claude/commands files to indicate MCP server tools can be used as alternatives to shell scripts
- Modified: list-tasks, assign-task, comment-task, change-task-status, create-task, and start-task
- Added references to journey tools (mark_task_in_progress, mark_task_for_review, mark_task_done)

## Test plan
- [x] Build passes successfully
- [x] All command files updated with MCP tool references
- [x] Documentation is clear and concise