### PR TITLE
Fix excessive spacing in task modal

### DIFF
--- a/apps/ui/src/taskeroo/TaskBoard.css
+++ b/apps/ui/src/taskeroo/TaskBoard.css
@@ -391,7 +391,7 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 24px;
+  padding: 16px 20px;
 }
 
 .modal-header h2 {
@@ -454,7 +454,7 @@ form {
 }
 
 .detail-section {
-  padding: 20px 24px;
+  padding: 12px 20px;
   border-bottom: 1px solid #ecf0f1;
 }
 
@@ -463,7 +463,7 @@ form {
 }
 
 .detail-section h3 {
-  margin: 0 0 15px 0;
+  margin: 0 0 10px 0;
   color: #2c3e50;
   font-size: 16px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Reduced modal header padding from 24px to 16px 20px for a tighter layout
- Reduced detail section padding from 20px 24px to 12px 20px
- Reduced h3 bottom margin from 15px to 10px

These changes make the task modal more compact and remove the excessive white space around the form and title.

## Test plan
- [x] Build passes (`npm run build:prod`)
- [ ] Visual verification: Open task modal and confirm spacing is more compact
- [ ] Ensure all form elements are still properly accessible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)