### PR TITLE
Centralize backend URL configuration across frontend

### DIFF
--- a/apps/ui/src/config/api.ts
+++ b/apps/ui/src/config/api.ts
@@ -1,0 +1,58 @@
+/**
+ * Centralized API configuration for the frontend application.
+ *
+ * This module provides a single source of truth for backend URL configuration,
+ * handling both production and development environments.
+ *
+ * - In production: Uses relative paths ("/")
+ * - In development: Uses http://localhost:{BACKEND_PORT}
+ */
+
+/**
+ * Get the backend port from environment variables
+ */
+const getBackendPort = (): number => {
+  return import.meta.env.VITE_BACKEND_PORT || 3000;
+};
+
+/**
+ * Get the base URL for API requests
+ *
+ * @returns "/" in production, "http://localhost:{port}" in development
+ */
+export const getApiBaseUrl = (): string => {
+  if (import.meta.env.PROD) {
+    return '';
+  }
+  return `http://localhost:${getBackendPort()}`;
+};
+
+/**
+ * Get the full backend URL including protocol and host
+ *
+ * @returns Full URL in development, "/" in production
+ */
+export const getBackendUrl = (): string => {
+  if (import.meta.env.PROD) {
+    return '/';
+  }
+  return `http://localhost:${getBackendPort()}`;
+};
+
+/**
+ * Get the WebSocket URL for real-time connections
+ *
+ * @param path - The WebSocket path (e.g., "/taskeroo")
+ * @returns WebSocket-compatible URL
+ */
+export const getWebSocketUrl = (path: string): string => {
+  if (import.meta.env.PROD) {
+    return path;
+  }
+  return `http://localhost:${getBackendPort()}${path}`;
+};
+
+/**
+ * Pre-configured base URL for OpenAPI clients
+ */
+export const API_BASE_URL = getApiBaseUrl();

--- a/apps/ui/src/consent/ConsentScreen.tsx
+++ b/apps/ui/src/consent/ConsentScreen.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { HomeLink } from '../components/HomeLink';
 import { usePageTitle } from '../hooks/usePageTitle';
+import { getApiBaseUrl } from '../config/api';
 import './ConsentScreen.css';
 
 interface AuthFlowDetails {
@@ -51,9 +52,7 @@ export function ConsentScreen() {
     setError(null);
 
     try {
-      const baseUrl = import.meta.env.PROD
-        ? ''
-        : `http://localhost:${import.meta.env.VITE_BACKEND_PORT || 3000}`;
+      const baseUrl = getApiBaseUrl();
       const response = await fetch(`${baseUrl}/api/v1/auth/flow/${flowId}`);
 
       if (!response.ok) {
@@ -74,9 +73,7 @@ export function ConsentScreen() {
 
     // Use a form submission to POST the consent decision
     // This allows the browser to naturally follow the 302 redirect
-    const baseUrl = import.meta.env.PROD
-      ? ''
-      : `http://localhost:${import.meta.env.VITE_BACKEND_PORT || 3000}`;
+    const baseUrl = getApiBaseUrl();
 
     const form = document.createElement('form');
     form.method = 'POST';

--- a/apps/ui/src/mcp-registry/api.ts
+++ b/apps/ui/src/mcp-registry/api.ts
@@ -1,6 +1,7 @@
 import { OpenAPI, McpRegistryService } from 'shared';
+import { API_BASE_URL } from '../config/api';
 
-// Use relative URL in production, absolute URL in development
-OpenAPI.BASE = import.meta.env.PROD ? '' : 'http://localhost:3000';
+// Use centralized API configuration
+OpenAPI.BASE = API_BASE_URL;
 
 export { McpRegistryService };

--- a/apps/ui/src/mcp-registry/useAuthorizationServer.ts
+++ b/apps/ui/src/mcp-registry/useAuthorizationServer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { McpRegistryService } from './api';
+import { getApiBaseUrl } from '../config/api';
 
 
 export const useAuthorizationServer = (mcpServerId?: string, mcpServerVersion?: string) => {
@@ -15,15 +16,8 @@ export const useAuthorizationServer = (mcpServerId?: string, mcpServerVersion?: 
 
   async function loadMetadata(mcpServerId: string, mcpServerVersion: string) {
 
-    // Make base url
-    let baseUrl: string;
-    if (import.meta.env.PROD) {
-      baseUrl = '';
-    } else {
-      const PORT = import.meta.env.VITE_BACKEND_PORT || 3000;
-      baseUrl = `http://localhost:${PORT}`;
-    }
-
+    // Make base url using centralized config
+    const baseUrl = getApiBaseUrl();
 
     // Make authorization server url
     const asUrl = new URL(`${baseUrl}/mcp/${mcpServerId}/${mcpServerVersion}`);

--- a/apps/ui/src/taskeroo/TaskBoard.tsx
+++ b/apps/ui/src/taskeroo/TaskBoard.tsx
@@ -9,8 +9,6 @@ import { useTaskeroo } from './useTaskeroo';
 import { Task, TaskStatus } from './types';
 import { usePageTitle } from '../hooks/usePageTitle';
 
-const API_BASE = 'http://localhost:3000';
-
 export function TaskBoard() {
   const { tasks, isConnected } = useTaskeroo();
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);

--- a/apps/ui/src/taskeroo/api.ts
+++ b/apps/ui/src/taskeroo/api.ts
@@ -1,6 +1,7 @@
 import { OpenAPI, TaskService } from 'shared';
+import { API_BASE_URL } from '../config/api';
 
-// Use relative URL in production, absolute URL in development
-OpenAPI.BASE = import.meta.env.PROD ? '' : 'http://localhost:3000';
+// Use centralized API configuration
+OpenAPI.BASE = API_BASE_URL;
 
 export { TaskService as TaskerooService };

--- a/apps/ui/src/taskeroo/useTaskeroo.ts
+++ b/apps/ui/src/taskeroo/useTaskeroo.ts
@@ -2,9 +2,10 @@ import { io, Socket } from 'socket.io-client';
 import { TaskerooService } from './api'
 import { Task, Comment } from './types';
 import { useEffect, useState } from 'react';
+import { getWebSocketUrl } from '../config/api';
 
-// Use relative URL in production, absolute URL in development
-const SOCKET_URL = import.meta.env.PROD ? '/taskeroo' : 'http://localhost:3000/taskeroo';
+// Use centralized API configuration
+const SOCKET_URL = getWebSocketUrl('/taskeroo');
 
 export const useTaskeroo = () => {
 

--- a/apps/ui/src/wikiroo/api.ts
+++ b/apps/ui/src/wikiroo/api.ts
@@ -1,6 +1,7 @@
 import { OpenAPI, WikirooService } from 'shared';
+import { API_BASE_URL } from '../config/api';
 
-// Use relative URL in production, absolute URL in development
-OpenAPI.BASE = import.meta.env.PROD ? '' : 'http://localhost:3000';
+// Use centralized API configuration
+OpenAPI.BASE = API_BASE_URL;
 
 export { WikirooService };


### PR DESCRIPTION
## Summary

Addresses task #26db7d33-a19f-4b14-a908-e72c29caaadd by creating a centralized API configuration module that provides a single source of truth for backend URL configuration.

### Changes Made:

**New Configuration Module** (`src/config/api.ts`):
- `getApiBaseUrl()` - Returns "" in prod, "http://localhost:{port}" in dev
- `getBackendUrl()` - Returns "/" in prod, full URL in dev
- `getWebSocketUrl(path)` - Returns WebSocket-compatible URLs
- `API_BASE_URL` - Pre-configured constant for OpenAPI clients

**Updated Modules**:
- ✅ `taskeroo/api.ts` - OpenAPI client
- ✅ `mcp-registry/api.ts` - OpenAPI client
- ✅ `wikiroo/api.ts` - OpenAPI client
- ✅ `taskeroo/useTaskeroo.ts` - WebSocket connection
- ✅ `taskeroo/TaskBoard.tsx` - Removed hardcoded URL
- ✅ `consent/ConsentScreen.tsx` - Both fetch locations
- ✅ `mcp-registry/useAuthorizationServer.ts` - Metadata loading

### Benefits:
- Single source of truth for backend URL configuration
- Consistent prod/dev environment handling
- Respects `VITE_BACKEND_PORT` environment variable
- Easier to maintain and update
- Eliminates code duplication

## Test Plan
- [x] Production build passes (`npm run build:prod`)
- [ ] Verify all API calls work in development
- [ ] Verify WebSocket connections work
- [ ] Verify consent flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)