### PR TITLE
Centralize frontend URL configuration in backend

### DIFF
--- a/apps/backend/src/authorization-server/authorization.controller.ts
+++ b/apps/backend/src/authorization-server/authorization.controller.ts
@@ -23,6 +23,7 @@ import { AuthorizationService } from './authorization.service';
 import { AuthorizationRequestDto } from './dto/authorization-request.dto';
 import { ConsentDecisionDto } from './dto/consent-decision.dto';
 import { McpAuthorizationFlowEntity } from 'src/auth-journeys/entities';
+import { getFrontendPath } from '../config/frontend.config';
 
 @ApiTags('Authorization Server')
 @Controller('auth')
@@ -62,11 +63,8 @@ export class AuthorizationController {
       );
 
       // Redirect to the consent screen with the flow ID
-      // In dev, UI runs on a different port; in prod, it's served from the same origin
-      const uiPort = process.env.VITE_PORT;
-      const consentUrl = uiPort
-        ? `http://localhost:${uiPort}/consent?flow=${flowId}`
-        : `/consent?flow=${flowId}`;
+      // Use centralized frontend URL configuration
+      const consentUrl = getFrontendPath(`/consent?flow=${flowId}`);
       res.redirect(HttpStatus.FOUND, consentUrl);
     } catch (error) {
       // If there's an error, redirect back with error parameters

--- a/apps/backend/src/config/frontend.config.ts
+++ b/apps/backend/src/config/frontend.config.ts
@@ -1,0 +1,59 @@
+/**
+ * Centralized frontend URL configuration for the backend application.
+ *
+ * This module provides a single source of truth for frontend URL configuration,
+ * handling both production and development environments.
+ *
+ * - In production: Frontend is served from the same origin (relative paths)
+ * - In development: Frontend runs on a different port (absolute URLs)
+ */
+
+/**
+ * Get the frontend base URL for redirects and links
+ *
+ * @returns Relative path "/" in production, "http://localhost:{port}" in development
+ */
+export function getFrontendUrl(): string {
+  const uiPort = process.env.VITE_PORT;
+
+  // In development, frontend runs on a different port
+  if (uiPort) {
+    return `http://localhost:${uiPort}`;
+  }
+
+  // In production, frontend is served from the same origin
+  return '';
+}
+
+/**
+ * Get a full frontend URL for a specific path
+ *
+ * @param path - The path to append (e.g., "/consent", "/dashboard")
+ * @returns Full URL in development, relative path in production
+ */
+export function getFrontendPath(path: string): string {
+  const baseUrl = getFrontendUrl();
+
+  // Ensure path starts with /
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  return `${baseUrl}${normalizedPath}`;
+}
+
+/**
+ * Check if the application is running in development mode
+ *
+ * @returns true if running in development, false otherwise
+ */
+export function isDevelopment(): boolean {
+  return process.env.NODE_ENV !== 'production';
+}
+
+/**
+ * Check if the application is running in production mode
+ *
+ * @returns true if running in production, false otherwise
+ */
+export function isProduction(): boolean {
+  return process.env.NODE_ENV === 'production';
+}


### PR DESCRIPTION
## Summary

Addresses task #9464d06c-59b3-4c9a-b8d3-744b014b1305 by creating a centralized frontend URL configuration module in the backend.

### Changes Made:

**New Configuration Module** (`src/config/frontend.config.ts`):
- `getFrontendUrl()` - Returns base frontend URL ("" in prod, "http://localhost:{port}" in dev)
- `getFrontendPath(path)` - Returns full frontend URL for a specific path
- `isDevelopment()` / `isProduction()` - Environment check helpers

**Updated Authorization Controller**:
- Import `getFrontendPath` from centralized config
- Replace inline URL logic (lines 66-69) with `getFrontendPath('/consent?flow=${flowId}')`
- Simplifies consent screen redirect logic

### Benefits:
- Single source of truth for frontend URL configuration in backend
- Consistent prod/dev environment handling
- Respects `VITE_PORT` environment variable
- Can be easily consumed across the entire backend stack
- Mirrors the pattern used in frontend for consistency

### Related:
This complements PR #86 which centralized backend URL configuration in the frontend, providing a symmetric solution for both sides of the application.

## Test Plan
- [x] Production build passes (`npm run build:prod`)
- [ ] Verify authorization flow redirects correctly in development
- [ ] Verify authorization flow redirects correctly in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)