### PR TITLE
feat: add MCP JWT DTOs

### DIFF
--- a/apps/backend/src/authorization-server/dto/introspect-token-request.dto.ts
+++ b/apps/backend/src/authorization-server/dto/introspect-token-request.dto.ts
@@ -1,0 +1,48 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TokenTypeHint } from '../enums';
+
+/**
+ * DTO for the OAuth 2.0 token introspection request body (RFC 7662).
+ */
+export class IntrospectTokenRequestDto {
+  @ApiProperty({
+    description: 'Access or refresh token that should be validated',
+    example: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  token!: string;
+
+  @ApiPropertyOptional({
+    description: 'Hint to help the server determine the token lookup strategy',
+    enum: TokenTypeHint,
+    example: TokenTypeHint.ACCESS_TOKEN,
+  })
+  @IsOptional()
+  @IsEnum(TokenTypeHint)
+  token_type_hint?: TokenTypeHint;
+
+  @ApiProperty({
+    description: 'Client identifier making the request (required for public MCP clients)',
+    example: '0bab273987a2e163c3abb40c631ec0a4',
+  })
+  @IsString()
+  @IsNotEmpty()
+  client_id!: string;
+
+  @ApiPropertyOptional({
+    description: 'Client secret for confidential clients (MCP clients typically omit this)',
+    example: 's3cr3t',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  client_secret?: string;
+}

--- a/apps/backend/src/authorization-server/dto/introspect-token-response.dto.ts
+++ b/apps/backend/src/authorization-server/dto/introspect-token-response.dto.ts
@@ -1,0 +1,97 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TokenType } from '../enums';
+import type { McpJwtPayload } from '../types';
+
+/**
+ * DTO for OAuth 2.0 token introspection responses (RFC 7662).
+ * Mirrors the claims we issue in the JWT payload.
+ */
+export class IntrospectTokenResponseDto {
+  @ApiProperty({
+    description: 'Indicates whether the token is currently valid',
+    example: true,
+  })
+  active!: boolean;
+
+  @ApiProperty({
+    description: 'Token type, always Bearer for MCP clients',
+    enum: TokenType,
+    example: TokenType.BEARER,
+  })
+  token_type!: TokenType;
+
+  @ApiProperty({
+    description: 'Client identifier associated with the token',
+    example: '0bab273987a2e163c3abb40c631ec0a4',
+  })
+  client_id!: string;
+
+  @ApiProperty({
+    description: 'Subject of the token (resource owner or actor)',
+    example: 'journey:1234',
+  })
+  sub!: McpJwtPayload['sub'];
+
+  @ApiProperty({
+    description: 'Audience that should accept this token',
+    oneOf: [
+      { type: 'string', example: 'taskeroo-api' },
+      { type: 'array', items: { type: 'string' }, example: ['taskeroo-api'] },
+    ],
+  })
+  aud!: McpJwtPayload['aud'];
+
+  @ApiProperty({
+    description: 'Issuer that minted the token',
+    example: 'https://auth.taskeroo.local/auth',
+  })
+  iss!: McpJwtPayload['iss'];
+
+  @ApiProperty({
+    description: 'Unique token identifier for replay detection',
+    example: 'b15e8a76-5b6d-4bde-9a3b-26fdbaab5b4c',
+  })
+  jti!: McpJwtPayload['jti'];
+
+  @ApiProperty({
+    description: 'Expiration timestamp (seconds since Unix epoch)',
+    example: 1731145219,
+  })
+  exp!: McpJwtPayload['exp'];
+
+  @ApiProperty({
+    description: 'Issued-at timestamp (seconds since Unix epoch)',
+    example: 1731141619,
+  })
+  iat!: McpJwtPayload['iat'];
+
+  @ApiPropertyOptional({
+    description: 'Not-before timestamp (seconds since Unix epoch)',
+    example: 1731141019,
+  })
+  nbf?: number;
+
+  @ApiPropertyOptional({
+    description: 'Granted scopes (space-delimited) for display purposes',
+    example: 'tasks:read tasks:write',
+  })
+  scope?: string;
+
+  @ApiProperty({
+    description: 'MCP server identifier the token is scoped to',
+    example: 'taskeroo',
+  })
+  server_identifier!: McpJwtPayload['server_identifier'];
+
+  @ApiProperty({
+    description: 'Resource URL that was used during authorization',
+    example: 'http://localhost:4001/',
+  })
+  resource!: McpJwtPayload['resource'];
+
+  @ApiProperty({
+    description: 'Version of the MCP server contract',
+    example: '1.0.0',
+  })
+  version!: McpJwtPayload['version'];
+}

--- a/apps/backend/src/authorization-server/dto/token-request.dto.ts
+++ b/apps/backend/src/authorization-server/dto/token-request.dto.ts
@@ -1,0 +1,81 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Length,
+  Matches,
+  ValidateIf,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { GrantType } from '../enums';
+
+/**
+ * OAuth 2.0 token request DTO.
+ * Covers both authorization_code (with PKCE) and refresh_token grants.
+ */
+export class TokenRequestDto {
+  @ApiProperty({
+    description: 'Grant type that determines which parameters must be supplied',
+    enum: GrantType,
+    example: GrantType.AUTHORIZATION_CODE,
+  })
+  @IsEnum(GrantType)
+  grant_type!: GrantType;
+
+  @ApiProperty({
+    description: 'Client identifier issued during dynamic registration',
+    example: '0bab273987a2e163c3abb40c631ec0a4',
+  })
+  @IsString()
+  @IsNotEmpty()
+  client_id!: string;
+
+  @ApiPropertyOptional({
+    description: 'Authorization code that was issued by the /authorize endpoint',
+    example: 'SplxlOBeZQQYbYS6WxSbIA',
+  })
+  @ValidateIf((dto) => dto.grant_type === GrantType.AUTHORIZATION_CODE)
+  @IsString()
+  @IsNotEmpty()
+  code?: string;
+
+  @ApiPropertyOptional({
+    description: 'Redirect URI used during authorization (required when code is present)',
+    example: 'http://localhost:6274/oauth/callback/debug',
+  })
+  @ValidateIf((dto) => dto.grant_type === GrantType.AUTHORIZATION_CODE)
+  @IsString()
+  @IsNotEmpty()
+  @IsUrl({ require_protocol: true, require_tld: false })
+  redirect_uri?: string;
+
+  @ApiPropertyOptional({
+    description: 'PKCE code verifier used to validate the authorization code exchange',
+    example: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+  })
+  @ValidateIf((dto) => dto.grant_type === GrantType.AUTHORIZATION_CODE)
+  @IsString()
+  @IsNotEmpty()
+  @Length(43, 128)
+  @Matches(/^[A-Za-z0-9-._~]+$/)
+  code_verifier?: string;
+
+  @ApiPropertyOptional({
+    description: 'Refresh token issued earlier by the authorization server',
+    example: 'def5020091c58c49fbb...',
+  })
+  @ValidateIf((dto) => dto.grant_type === GrantType.REFRESH_TOKEN)
+  @IsString()
+  @IsNotEmpty()
+  refresh_token?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional list of scopes to narrow when refreshing a token (space-delimited)',
+    example: 'tasks:read tasks:write',
+  })
+  @IsOptional()
+  @IsString()
+  scope?: string;
+}

--- a/apps/backend/src/authorization-server/dto/token-response.dto.ts
+++ b/apps/backend/src/authorization-server/dto/token-response.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TokenType } from '../enums';
+
+/**
+ * Standard OAuth 2.0 token response DTO.
+ * Mirrors RFC 6749 Section 5.1 for bearer tokens.
+ */
+export class TokenResponseDto {
+  @ApiProperty({
+    description: 'Opaque access token used to access protected resources',
+    example: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  access_token!: string;
+
+  @ApiProperty({
+    description: 'Type of token issued (MCP clients always receive Bearer tokens)',
+    enum: TokenType,
+    example: TokenType.BEARER,
+    default: TokenType.BEARER,
+  })
+  token_type: TokenType = TokenType.BEARER;
+
+  @ApiProperty({
+    description: 'Lifetime of the access token in seconds',
+    example: 3600,
+  })
+  expires_in!: number;
+
+  @ApiProperty({
+    description: 'Refresh token that can be exchanged for a new access token',
+    example: 'def5020091c58c49fbb...',
+  })
+  refresh_token!: string;
+
+  @ApiPropertyOptional({
+    description: 'Space-delimited scopes that were granted for this token',
+    example: 'tasks:read tasks:write',
+  })
+  scope?: string;
+}

--- a/apps/backend/src/authorization-server/enums/index.ts
+++ b/apps/backend/src/authorization-server/enums/index.ts
@@ -1,3 +1,5 @@
 export * from './grant-type.enum';
 export * from './response-type.enum';
 export * from './token-endpoint-auth-method.enum';
+export * from './token-type.enum';
+export * from './token-type-hint.enum';

--- a/apps/backend/src/authorization-server/enums/token-type-hint.enum.ts
+++ b/apps/backend/src/authorization-server/enums/token-type-hint.enum.ts
@@ -1,0 +1,8 @@
+/**
+ * Token type hints defined by RFC 7662 for the introspection endpoint.
+ * Helps the authorization server optimize token lookups.
+ */
+export enum TokenTypeHint {
+  ACCESS_TOKEN = 'access_token',
+  REFRESH_TOKEN = 'refresh_token',
+}

--- a/apps/backend/src/authorization-server/enums/token-type.enum.ts
+++ b/apps/backend/src/authorization-server/enums/token-type.enum.ts
@@ -1,0 +1,7 @@
+/**
+ * OAuth 2.0 token types supported by the authorization server.
+ * MCP clients only receive Bearer tokens today, but enum keeps the contract explicit.
+ */
+export enum TokenType {
+  BEARER = 'Bearer',
+}

--- a/apps/backend/src/authorization-server/types/index.ts
+++ b/apps/backend/src/authorization-server/types/index.ts
@@ -1,0 +1,1 @@
+export * from './mcp-jwt-payload.type';

--- a/apps/backend/src/authorization-server/types/mcp-jwt-payload.type.ts
+++ b/apps/backend/src/authorization-server/types/mcp-jwt-payload.type.ts
@@ -1,0 +1,60 @@
+/**
+ * Shape of the JWT payload we issue for MCP access tokens.
+ * Service layer consumes this pure type instead of HTTP DTO classes (see docs/reviews/dto-service-layer-types.md).
+ */
+export interface McpJwtPayload {
+  /**
+   * Issuer - authorization server identifier (URL)
+   */
+  iss: string;
+
+  /**
+   * Subject - represents the resource owner or actor on whose behalf the client is operating
+   */
+  sub: string;
+
+  /**
+   * Audience - the resource server(s) that should accept this token
+   */
+  aud: string | string[];
+
+  /**
+   * Expiration time (seconds since Unix epoch)
+   */
+  exp: number;
+
+  /**
+   * Issued-at time (seconds since Unix epoch)
+   */
+  iat: number;
+
+  /**
+   * Unique identifier for the token to support replay protection
+   */
+  jti: string;
+
+  /**
+   * Client identifier that was issued during registration
+   */
+  client_id: string;
+
+  /**
+   * Scopes granted to the client, stored as individual scope strings
+   */
+  scope: string[];
+
+  /**
+   * MCP server identifier (providedId) that the token is scoped to
+   */
+  server_identifier: string;
+
+  /**
+   * Resource URL associated with the authorization request
+   */
+  resource: string;
+
+  /**
+   * Version of the MCP server contract that this token was minted for
+   */
+  version: string;
+}


### PR DESCRIPTION
## Summary
- add OAuth token/introspection DTOs for the MCP authorization server
- introduce token enums plus a pure JWT payload type per the docs
- prep the contracts expected by the upcoming /token and /introspect endpoints

## Testing
- npm run build:prod