### PR TITLE
feat(wikiroo): add MCP server implementation

### DIFF
--- a/apps/backend/src/wikiroo/wikiroo.controller.ts
+++ b/apps/backend/src/wikiroo/wikiroo.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, All, Req, Res } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiCreatedResponse,
@@ -6,6 +6,7 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
+import type { Request, Response } from "express";
 import { WikirooService } from './wikiroo.service';
 import { CreatePageDto } from './dto/create-page.dto';
 import { PageResponseDto } from './dto/page-response.dto';
@@ -13,11 +14,15 @@ import { PageListResponseDto } from './dto/page-list-response.dto';
 import { PageSummaryDto } from './dto/page-summary.dto';
 import { PageParamsDto } from './dto/page-params.dto';
 import { PageResult, PageSummaryResult } from './dto/service/wikiroo.service.types';
+import { WikirooMcpGateway } from './wikiroo.mcp.gateway';
 
 @ApiTags('Wikiroo')
 @Controller('wikiroo/pages')
 export class WikirooController {
-  constructor(private readonly wikirooService: WikirooService) {}
+  constructor(
+    private readonly wikirooService: WikirooService,
+    private readonly gateway: WikirooMcpGateway,
+  ) {}
 
   @Post()
   @ApiOperation({ summary: 'Create a new wiki page' })
@@ -79,5 +84,10 @@ export class WikirooController {
       createdAt: result.createdAt.toISOString(),
       updatedAt: result.updatedAt.toISOString(),
     };
+  }
+
+  @All('mcp')
+  async handleMcp(@Req() req: Request, @Res() res: Response) {
+    await this.gateway.handleRequest(req, res);
   }
 }

--- a/apps/backend/src/wikiroo/wikiroo.mcp.gateway.ts
+++ b/apps/backend/src/wikiroo/wikiroo.mcp.gateway.ts
@@ -1,0 +1,99 @@
+import { Injectable } from "@nestjs/common";
+import type { Request, Response } from "express";
+import { WikirooService } from "./wikiroo.service";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { z } from "zod";
+
+@Injectable()
+export class WikirooMcpGateway {
+
+  constructor(private readonly wikirooService: WikirooService) { }
+
+  private buildServer(): McpServer {
+    const server = new McpServer({
+      name: 'wikiroo',
+      version: '0.0.0',
+    });
+
+    server.registerTool(
+      'list_pages',
+      {
+        title: 'List wiki pages',
+        description: 'Get a list of all wiki pages with metadata (title, id, author)',
+      },
+      async ({ }) => {
+        const pages = await this.wikirooService.listPages();
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(pages),
+          }],
+        }
+      }
+    )
+
+    server.registerTool(
+      'get_page',
+      {
+        title: 'Get wiki page',
+        description: 'Retrieve the full content of a wiki page by ID',
+        inputSchema: {
+          pageId: z.string(),
+        },
+      },
+      async ({ pageId }) => {
+        const page = await this.wikirooService.getPageById(pageId);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(page),
+          }],
+        }
+      }
+    )
+
+    server.registerTool(
+      'create_page',
+      {
+        title: 'Create wiki page',
+        description: 'Create a new wiki page with title, content, and author',
+        inputSchema: {
+          title: z.string(),
+          content: z.string(),
+          author: z.string(),
+        },
+      },
+      async ({ title, content, author }) => {
+        const page = await this.wikirooService.createPage({
+          title,
+          content,
+          author,
+        });
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(page),
+          }],
+        }
+      }
+    )
+
+    return server;
+  }
+
+  async handleRequest(req: Request, res: Response) {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+
+    res.on('close', () => {
+      transport.close();
+    });
+
+    const server = this.buildServer()
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  }
+}

--- a/apps/backend/src/wikiroo/wikiroo.module.ts
+++ b/apps/backend/src/wikiroo/wikiroo.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { WikirooService } from './wikiroo.service';
 import { WikirooController } from './wikiroo.controller';
 import { WikiPageEntity } from './page.entity';
+import { WikirooMcpGateway } from './wikiroo.mcp.gateway';
 
 @Module({
   imports: [TypeOrmModule.forFeature([WikiPageEntity])],
   controllers: [WikirooController],
-  providers: [WikirooService],
+  providers: [WikirooService, WikirooMcpGateway],
   exports: [WikirooService],
 })
 export class WikirooModule {}

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -565,6 +565,104 @@
         ]
       }
     },
+    "/api/v1/wikiroo/pages/mcp": {
+      "get": {
+        "operationId": "WikirooController_handleMcp_get",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Wikiroo"
+        ]
+      },
+      "post": {
+        "operationId": "WikirooController_handleMcp_post",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Wikiroo"
+        ]
+      },
+      "put": {
+        "operationId": "WikirooController_handleMcp_put",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Wikiroo"
+        ]
+      },
+      "delete": {
+        "operationId": "WikirooController_handleMcp_delete",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Wikiroo"
+        ]
+      },
+      "patch": {
+        "operationId": "WikirooController_handleMcp_patch",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Wikiroo"
+        ]
+      },
+      "options": {
+        "operationId": "WikirooController_handleMcp_options",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Wikiroo"
+        ]
+      },
+      "head": {
+        "operationId": "WikirooController_handleMcp_head",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Wikiroo"
+        ]
+      },
+      "search": {
+        "operationId": "WikirooController_handleMcp_search",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Wikiroo"
+        ]
+      }
+    },
     "/api/v1/mcp/servers": {
       "post": {
         "operationId": "McpRegistryController_createServer",

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -160,6 +160,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/wikiroo/pages/mcp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["WikirooController_handleMcp_get"];
+        put: operations["WikirooController_handleMcp_put"];
+        post: operations["WikirooController_handleMcp_post"];
+        delete: operations["WikirooController_handleMcp_delete"];
+        options: operations["WikirooController_handleMcp_options"];
+        head: operations["WikirooController_handleMcp_head"];
+        patch: operations["WikirooController_handleMcp_patch"];
+        trace?: never;
+    };
     "/api/v1/mcp/servers": {
         parameters: {
             query?: never;
@@ -1764,6 +1780,125 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["PageResponseDto"];
                 };
+            };
+        };
+    };
+    WikirooController_handleMcp_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WikirooController_handleMcp_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WikirooController_handleMcp_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WikirooController_handleMcp_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WikirooController_handleMcp_options: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WikirooController_handleMcp_head: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WikirooController_handleMcp_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/shared/src/client/services/WikirooService.ts
+++ b/packages/shared/src/client/services/WikirooService.ts
@@ -56,4 +56,74 @@ export class WikirooService {
             },
         });
     }
+    /**
+     * @returns any
+     * @throws ApiError
+     */
+    public static wikirooControllerHandleMcpGet(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/wikiroo/pages/mcp',
+        });
+    }
+    /**
+     * @returns any
+     * @throws ApiError
+     */
+    public static wikirooControllerHandleMcpPost(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/wikiroo/pages/mcp',
+        });
+    }
+    /**
+     * @returns any
+     * @throws ApiError
+     */
+    public static wikirooControllerHandleMcpPut(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/v1/wikiroo/pages/mcp',
+        });
+    }
+    /**
+     * @returns any
+     * @throws ApiError
+     */
+    public static wikirooControllerHandleMcpDelete(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/wikiroo/pages/mcp',
+        });
+    }
+    /**
+     * @returns any
+     * @throws ApiError
+     */
+    public static wikirooControllerHandleMcpPatch(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/v1/wikiroo/pages/mcp',
+        });
+    }
+    /**
+     * @returns any
+     * @throws ApiError
+     */
+    public static wikirooControllerHandleMcpOptions(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'OPTIONS',
+            url: '/api/v1/wikiroo/pages/mcp',
+        });
+    }
+    /**
+     * @returns any
+     * @throws ApiError
+     */
+    public static wikirooControllerHandleMcpHead(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'HEAD',
+            url: '/api/v1/wikiroo/pages/mcp',
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- Implemented MCP server for wikiroo following the taskeroo pattern
- Added three tools: list_pages (metadata only), get_page (full page content), and create_page
- Wired MCP gateway through module and controller at `/api/v1/wikiroo/pages/mcp`

## Test plan
- [x] Build passes successfully with `npm run build:prod`
- [ ] Verify MCP endpoint is accessible
- [ ] Test list_pages tool returns correct metadata
- [ ] Test get_page tool retrieves full page content
- [ ] Test create_page tool creates new pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)