### PR TITLE
refactor(services): fix repository anti-pattern by enforcing single ownership

### DIFF
--- a/apps/backend/src/auth-journeys/auth-journeys.service.ts
+++ b/apps/backend/src/auth-journeys/auth-journeys.service.ts
@@ -95,4 +95,58 @@ export class AuthJourneysService {
     )
     return authJourneys;
   }
+
+  /*
+  Public API: Find MCP authorization flow by client ID and server ID
+  Used by AuthorizationService to locate existing flows
+  */
+  async findMcpAuthFlowByClientAndServer(
+    clientId: string,
+    serverId: string,
+    relations?: string[]
+  ): Promise<McpAuthorizationFlowEntity | null> {
+    return this.mcpAuthorizationFlowRepository.findOne({
+      where: {
+        clientId,
+        serverId,
+      },
+      relations,
+    });
+  }
+
+  /*
+  Public API: Find MCP authorization flow by flow ID
+  Used by AuthorizationService for consent flow
+  */
+  async findMcpAuthFlowById(
+    flowId: string,
+    relations?: string[]
+  ): Promise<McpAuthorizationFlowEntity | null> {
+    return this.mcpAuthorizationFlowRepository.findOne({
+      where: { id: flowId },
+      relations,
+    });
+  }
+
+  /*
+  Public API: Find MCP authorization flow by authorization code
+  Used by TokenService for token exchange
+  */
+  async findMcpAuthFlowByAuthorizationCode(
+    authorizationCode: string,
+    relations?: string[]
+  ): Promise<McpAuthorizationFlowEntity | null> {
+    return this.mcpAuthorizationFlowRepository.findOne({
+      where: { authorizationCode },
+      relations,
+    });
+  }
+
+  /*
+  Public API: Save/update MCP authorization flow
+  Used by AuthorizationService and TokenService to update flow state
+  */
+  async saveMcpAuthFlow(mcpAuthFlow: McpAuthorizationFlowEntity): Promise<McpAuthorizationFlowEntity> {
+    return this.mcpAuthorizationFlowRepository.save(mcpAuthFlow);
+  }
 }

--- a/apps/backend/src/authorization-server/authorization-server.module.ts
+++ b/apps/backend/src/authorization-server/authorization-server.module.ts
@@ -9,14 +9,13 @@ import { RegisteredClientEntity } from './registered-client.entity';
 import { JwksKeyEntity } from './jwks-key.entity';
 import { JwksService } from './jwks.service';
 import { JwksController } from './jwks.controller';
-import { McpAuthorizationFlowEntity } from 'src/auth-journeys/entities';
 import { AuthJourneysModule } from 'src/auth-journeys/auth-journeys.module';
 import { McpRegistryModule } from 'src/mcp-registry/mcp-registry.module';
 
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([RegisteredClientEntity, McpAuthorizationFlowEntity, JwksKeyEntity]),
+    TypeOrmModule.forFeature([RegisteredClientEntity, JwksKeyEntity]),
     AuthJourneysModule,
     McpRegistryModule,
   ],


### PR DESCRIPTION
## Summary
Fixed repository anti-pattern where AuthJourneysService, AuthorizationService, and TokenService all directly injected `Repository<McpAuthorizationFlowEntity>`.

**Root cause**: Multiple services accessing the same repository creates tight coupling and makes it difficult to maintain data consistency.

**Solution**: Implemented single ownership pattern - only AuthJourneysService owns the McpAuthorizationFlowEntity repository. Other services interact through AuthJourneysService public API.

## Changes
- **AuthJourneysService**: Added 4 public API methods for repository access:
  - `findMcpAuthFlowByClientAndServer()` 
  - `findMcpAuthFlowById()`
  - `findMcpAuthFlowByAuthorizationCode()`
  - `saveMcpAuthFlow()`
- **AuthorizationService**: Removed direct repository injection, now uses AuthJourneysService
- **TokenService**: Removed direct repository injection, now uses AuthJourneysService
- **AuthorizationServerModule**: Removed McpAuthorizationFlowEntity from TypeOrmModule.forFeature (now owned by AuthJourneysModule)

## Benefits
✅ Single service owns McpAuthorizationFlowEntity repository (proper domain ownership)
✅ Better encapsulation - repository access controlled through service layer
✅ Easier to ensure data consistency and add business logic
✅ Follows DDD principles and service review guidelines

## Test plan
- [x] Build validation passed
- [ ] Verify authorization flow still works end-to-end
- [ ] Verify token exchange still works
- [ ] Check that no other services depend on McpAuthorizationFlowEntity repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)