### PR TITLE
fix(auth): add optional resource field to token request DTO

### DIFF
--- a/apps/backend/src/authorization-server/authorization.controller.ts
+++ b/apps/backend/src/authorization-server/authorization.controller.ts
@@ -8,8 +8,6 @@ import {
   Res,
   HttpStatus,
   BadRequestException,
-  UsePipes,
-  ValidationPipe,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -146,10 +144,6 @@ export class AuthorizationController {
   }
 
   @Post('token/mcp/:serverIdentifier/:version')
-  @UsePipes(new ValidationPipe({
-    whitelist: true, // Strip properties that don't have decorators
-    forbidNonWhitelisted: false, // Allow extra fields but ignore them
-  }))
   @ApiOperation({
     summary: 'OAuth 2.0 Token Endpoint',
     description:

--- a/apps/backend/src/authorization-server/dto/token-request.dto.ts
+++ b/apps/backend/src/authorization-server/dto/token-request.dto.ts
@@ -78,4 +78,12 @@ export class TokenRequestDto {
   @IsOptional()
   @IsString()
   scope?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional resource indicator (RFC 8707) - identifies the target resource server',
+    example: 'http://localhost:4001/',
+  })
+  @IsOptional()
+  @IsString()
+  resource?: string;
 }


### PR DESCRIPTION
## Summary
Fixed validation error when MCP inspector sends 'resource' field to /token endpoint. Previous fix using @UsePipes didn't work because the global ValidationPipe has `forbidNonWhitelisted: true`.

## Root Cause
The global ValidationPipe in main.ts is configured with:
```typescript
new ValidationPipe({
  whitelist: true,
  forbidNonWhitelisted: true,  // This rejects any unknown fields
  transform: true,
})
```

The endpoint-level @UsePipes decorator couldn't override this global setting.

## Solution
Added `resource` as an optional field to TokenRequestDto per RFC 8707 (Resource Indicators for OAuth 2.0). This is the proper approach:
- `resource` is a standard OAuth 2.0 extension parameter
- Field is validated as a string when present
- Not required, so clients that don't send it are unaffected
- Global validation rules still apply for all other fields

## Changes
- Added optional `resource?: string` field to TokenRequestDto with @IsOptional and @IsString decorators
- Removed previous @UsePipes approach from controller
- Removed unused UsePipes and ValidationPipe imports

## Test plan
- [x] Build validation passed
- [ ] Test with MCP inspector sending resource field
- [ ] Test without resource field to ensure backwards compatibility
- [ ] Verify other validation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)