### PR TITLE
feat(auth): add debug endpoint for active signing key

### DIFF
--- a/apps/backend/src/authorization-server/jwks.controller.ts
+++ b/apps/backend/src/authorization-server/jwks.controller.ts
@@ -35,4 +35,37 @@ export class JwksController {
       })),
     };
   }
+
+  @Get('jwk-active.json')
+  @ApiOperation({
+    summary: 'Get Active Signing Key (Single JWK)',
+    description:
+      'Returns the currently active signing key as a single JWK. Useful for debugging and testing JWT verification with tools like jwt.io. This endpoint returns only the current signing key, not the full key set.',
+  })
+  @ApiOkResponse({
+    description: 'Active JWK retrieved successfully',
+  })
+  async getActiveJwk() {
+    const jwks = await this.jwksService.getPublicKeys();
+    const activeSigningKey = await this.jwksService.getActiveSigningKey();
+
+    // Find the active key in the JWKS
+    const activeJwk = jwks.keys.find((key) => key.kid === activeSigningKey.kid);
+
+    if (!activeJwk) {
+      throw new Error('Active signing key not found in JWKS');
+    }
+
+    return {
+      kty: activeJwk.kty,
+      use: activeJwk.use,
+      kid: activeJwk.kid,
+      alg: activeJwk.alg,
+      n: activeJwk.n,
+      e: activeJwk.e,
+      x: activeJwk.x,
+      y: activeJwk.y,
+      crv: activeJwk.crv,
+    };
+  }
 }

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -1712,6 +1712,22 @@
         ]
       }
     },
+    "/.well-known/jwk-active.json": {
+      "get": {
+        "description": "Returns the currently active signing key as a single JWK. Useful for debugging and testing JWT verification with tools like jwt.io. This endpoint returns only the current signing key, not the full key set.",
+        "operationId": "JwksController_getActiveJwk",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Active JWK retrieved successfully"
+          }
+        },
+        "summary": "Get Active Signing Key (Single JWK)",
+        "tags": [
+          "JWKS"
+        ]
+      }
+    },
     "/.well-known/oauth-authorization-server/mcp/{mcpServerId}/{version}": {
       "get": {
         "description": "Provides discovery metadata (RFC 8414) for OAuth 2.0 clients integrating with a specific MCP server version. Accepts either the server UUID or the providedId.",

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -480,6 +480,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/.well-known/jwk-active.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Active Signing Key (Single JWK)
+         * @description Returns the currently active signing key as a single JWK. Useful for debugging and testing JWT verification with tools like jwt.io. This endpoint returns only the current signing key, not the full key set.
+         */
+        get: operations["JwksController_getActiveJwk"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/.well-known/oauth-authorization-server/mcp/{mcpServerId}/{version}": {
         parameters: {
             query?: never;
@@ -2813,6 +2833,24 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["JwksResponseDto"];
                 };
+            };
+        };
+    };
+    JwksController_getActiveJwk: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Active JWK retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/shared/src/client/services/JwksService.ts
+++ b/packages/shared/src/client/services/JwksService.ts
@@ -19,4 +19,16 @@ export class JwksService {
             url: '/.well-known/jwks.json',
         });
     }
+    /**
+     * Get Active Signing Key (Single JWK)
+     * Returns the currently active signing key as a single JWK. Useful for debugging and testing JWT verification with tools like jwt.io. This endpoint returns only the current signing key, not the full key set.
+     * @returns any Active JWK retrieved successfully
+     * @throws ApiError
+     */
+    public static jwksControllerGetActiveJwk(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/.well-known/jwk-active.json',
+        });
+    }
 }


### PR DESCRIPTION
## Summary
Fixed JWT verification issue with jwt.io by adding a dedicated endpoint for the active signing key.

## Problem
Users reported JWT signature verification failing with "Invalid Compact JWS" error when using jwt.io. Root cause:
- jwt.io expects a single JWK (JSON Web Key) for verification
- Our `/.well-known/jwks.json` returns a JWKS (JSON Web Key Set) containing multiple keys
- When pasting JWKS into jwt.io, it tries to parse the entire key set as a single key, causing the error

## Solution
Added `GET /.well-known/jwk-active.json` endpoint that returns only the currently active signing key as a single JWK.

Benefits:
✅ Can be copied directly into jwt.io for JWT verification  
✅ Maintains OAuth 2.0 compliance (JWKS endpoint unchanged for key rotation)  
✅ Makes debugging and testing much easier  
✅ Properly documented with OpenAPI specs  

## How to use
1. Get JWT from `/token` endpoint
2. Copy JWT to jwt.io
3. Get active JWK from `/.well-known/jwk-active.json`
4. Paste JWK into jwt.io's "Verify Signature" section
5. Signature validates successfully ✓

## Test plan
- [x] Build validation passed
- [ ] Test JWT verification flow with jwt.io
- [ ] Verify endpoint returns correct JWK format
- [ ] Confirm kid matches between JWT header and JWK

🤖 Generated with [Claude Code](https://claude.com/claude-code)