### PR TITLE
Add OAuth 2.0 token introspection endpoint

### DIFF
--- a/apps/backend/src/authorization-server/authorization.controller.ts
+++ b/apps/backend/src/authorization-server/authorization.controller.ts
@@ -25,6 +25,8 @@ import { AuthorizationRequestDto } from './dto/authorization-request.dto';
 import { ConsentDecisionDto } from './dto/consent-decision.dto';
 import { TokenRequestDto } from './dto/token-request.dto';
 import { TokenResponseDto } from './dto/token-response.dto';
+import { IntrospectTokenRequestDto } from './dto/introspect-token-request.dto';
+import { IntrospectTokenResponseDto } from './dto/introspect-token-response.dto';
 import { McpAuthorizationFlowEntity } from 'src/auth-journeys/entities';
 import { getFrontendPath } from '../config/frontend.config';
 
@@ -165,5 +167,26 @@ export class AuthorizationController {
     @Param('version') version: string,
   ): Promise<TokenResponseDto> {
     return this.tokenService.exchangeAuthorizationCode(tokenRequest);
+  }
+
+  @Post('introspect/mcp/:serverIdentifier/:version')
+  @ApiOperation({
+    summary: 'OAuth 2.0 Token Introspection Endpoint',
+    description:
+      'Introspects an access token to validate it and retrieve its metadata. Verifies JWT signature, expiration, and claims according to RFC 7662.',
+  })
+  @ApiOkResponse({
+    description: 'Token introspection response (active true/false with metadata)',
+    type: IntrospectTokenResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid introspection request parameters',
+  })
+  async introspect(
+    @Body() introspectRequest: IntrospectTokenRequestDto,
+    @Param('serverIdentifier') serverIdentifier: string,
+    @Param('version') version: string,
+  ): Promise<IntrospectTokenResponseDto> {
+    return this.tokenService.introspectToken(introspectRequest);
   }
 }

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -1689,6 +1689,59 @@
         ]
       }
     },
+    "/api/v1/auth/introspect/mcp/{serverIdentifier}/{version}": {
+      "post": {
+        "description": "Introspects an access token to validate it and retrieve its metadata. Verifies JWT signature, expiration, and claims according to RFC 7662.",
+        "operationId": "AuthorizationController_introspect",
+        "parameters": [
+          {
+            "name": "serverIdentifier",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntrospectTokenRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token introspection response (active true/false with metadata)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntrospectTokenResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid introspection request parameters"
+          }
+        },
+        "summary": "OAuth 2.0 Token Introspection Endpoint",
+        "tags": [
+          "Authorization Server"
+        ]
+      }
+    },
     "/.well-known/jwks.json": {
       "get": {
         "description": "Returns the public keys used to verify JWT signatures. This endpoint provides all valid (non-expired) keys to support key rotation.",
@@ -1707,22 +1760,6 @@
           }
         },
         "summary": "Get JSON Web Key Set (JWKS)",
-        "tags": [
-          "JWKS"
-        ]
-      }
-    },
-    "/.well-known/jwk-active.json": {
-      "get": {
-        "description": "Returns the currently active signing key as a single JWK. Useful for debugging and testing JWT verification with tools like jwt.io. This endpoint returns only the current signing key, not the full key set.",
-        "operationId": "JwksController_getActiveJwk",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Active JWK retrieved successfully"
-          }
-        },
-        "summary": "Get Active Signing Key (Single JWK)",
         "tags": [
           "JWKS"
         ]
@@ -2895,6 +2932,145 @@
           "token_type",
           "expires_in",
           "refresh_token"
+        ]
+      },
+      "IntrospectTokenRequestDto": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Access or refresh token that should be validated",
+            "example": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+          },
+          "token_type_hint": {
+            "type": "string",
+            "description": "Hint to help the server determine the token lookup strategy",
+            "enum": [
+              "access_token",
+              "refresh_token"
+            ],
+            "example": "access_token"
+          },
+          "client_id": {
+            "type": "string",
+            "description": "Client identifier making the request (required for public MCP clients)",
+            "example": "0bab273987a2e163c3abb40c631ec0a4"
+          },
+          "client_secret": {
+            "type": "string",
+            "description": "Client secret for confidential clients (MCP clients typically omit this)",
+            "example": "s3cr3t",
+            "nullable": true
+          }
+        },
+        "required": [
+          "token",
+          "client_id"
+        ]
+      },
+      "IntrospectTokenResponseDto": {
+        "type": "object",
+        "properties": {
+          "active": {
+            "type": "boolean",
+            "description": "Indicates whether the token is currently valid",
+            "example": true
+          },
+          "token_type": {
+            "type": "string",
+            "description": "Token type, always Bearer for MCP clients",
+            "enum": [
+              "Bearer"
+            ],
+            "example": "Bearer"
+          },
+          "client_id": {
+            "type": "string",
+            "description": "Client identifier associated with the token",
+            "example": "0bab273987a2e163c3abb40c631ec0a4"
+          },
+          "sub": {
+            "type": "object",
+            "description": "Subject of the token (resource owner or actor)",
+            "example": "journey:1234"
+          },
+          "aud": {
+            "description": "Audience that should accept this token",
+            "oneOf": [
+              {
+                "type": "string",
+                "example": "taskeroo-api"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "example": [
+                  "taskeroo-api"
+                ]
+              }
+            ]
+          },
+          "iss": {
+            "type": "object",
+            "description": "Issuer that minted the token",
+            "example": "https://auth.taskeroo.local/auth"
+          },
+          "jti": {
+            "type": "object",
+            "description": "Unique token identifier for replay detection",
+            "example": "b15e8a76-5b6d-4bde-9a3b-26fdbaab5b4c"
+          },
+          "exp": {
+            "type": "object",
+            "description": "Expiration timestamp (seconds since Unix epoch)",
+            "example": 1731145219
+          },
+          "iat": {
+            "type": "object",
+            "description": "Issued-at timestamp (seconds since Unix epoch)",
+            "example": 1731141619
+          },
+          "nbf": {
+            "type": "number",
+            "description": "Not-before timestamp (seconds since Unix epoch)",
+            "example": 1731141019
+          },
+          "scope": {
+            "type": "string",
+            "description": "Granted scopes (space-delimited) for display purposes",
+            "example": "tasks:read tasks:write"
+          },
+          "server_identifier": {
+            "type": "object",
+            "description": "MCP server identifier the token is scoped to",
+            "example": "taskeroo"
+          },
+          "resource": {
+            "type": "object",
+            "description": "Resource URL that was used during authorization",
+            "example": "http://localhost:4001/"
+          },
+          "version": {
+            "type": "object",
+            "description": "Version of the MCP server contract",
+            "example": "1.0.0"
+          }
+        },
+        "required": [
+          "active",
+          "token_type",
+          "client_id",
+          "sub",
+          "aud",
+          "iss",
+          "jti",
+          "exp",
+          "iat",
+          "server_identifier",
+          "resource",
+          "version"
         ]
       },
       "JwkResponseDto": {

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -460,6 +460,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/auth/introspect/mcp/{serverIdentifier}/{version}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * OAuth 2.0 Token Introspection Endpoint
+         * @description Introspects an access token to validate it and retrieve its metadata. Verifies JWT signature, expiration, and claims according to RFC 7662.
+         */
+        post: operations["AuthorizationController_introspect"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/.well-known/jwks.json": {
         parameters: {
             query?: never;
@@ -472,26 +492,6 @@ export interface paths {
          * @description Returns the public keys used to verify JWT signatures. This endpoint provides all valid (non-expired) keys to support key rotation.
          */
         get: operations["JwksController_getJwks"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/.well-known/jwk-active.json": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Active Signing Key (Single JWK)
-         * @description Returns the currently active signing key as a single JWK. Useful for debugging and testing JWT verification with tools like jwt.io. This endpoint returns only the current signing key, not the full key set.
-         */
-        get: operations["JwksController_getActiveJwk"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1286,6 +1286,99 @@ export interface components {
              * @example tasks:read tasks:write
              */
             scope?: string;
+        };
+        IntrospectTokenRequestDto: {
+            /**
+             * @description Access or refresh token that should be validated
+             * @example eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
+             */
+            token: string;
+            /**
+             * @description Hint to help the server determine the token lookup strategy
+             * @example access_token
+             * @enum {string}
+             */
+            token_type_hint?: "access_token" | "refresh_token";
+            /**
+             * @description Client identifier making the request (required for public MCP clients)
+             * @example 0bab273987a2e163c3abb40c631ec0a4
+             */
+            client_id: string;
+            /**
+             * @description Client secret for confidential clients (MCP clients typically omit this)
+             * @example s3cr3t
+             */
+            client_secret?: string | null;
+        };
+        IntrospectTokenResponseDto: {
+            /**
+             * @description Indicates whether the token is currently valid
+             * @example true
+             */
+            active: boolean;
+            /**
+             * @description Token type, always Bearer for MCP clients
+             * @example Bearer
+             * @enum {string}
+             */
+            token_type: "Bearer";
+            /**
+             * @description Client identifier associated with the token
+             * @example 0bab273987a2e163c3abb40c631ec0a4
+             */
+            client_id: string;
+            /**
+             * @description Subject of the token (resource owner or actor)
+             * @example journey:1234
+             */
+            sub: Record<string, never>;
+            /** @description Audience that should accept this token */
+            aud: string | string[];
+            /**
+             * @description Issuer that minted the token
+             * @example https://auth.taskeroo.local/auth
+             */
+            iss: Record<string, never>;
+            /**
+             * @description Unique token identifier for replay detection
+             * @example b15e8a76-5b6d-4bde-9a3b-26fdbaab5b4c
+             */
+            jti: Record<string, never>;
+            /**
+             * @description Expiration timestamp (seconds since Unix epoch)
+             * @example 1731145219
+             */
+            exp: Record<string, never>;
+            /**
+             * @description Issued-at timestamp (seconds since Unix epoch)
+             * @example 1731141619
+             */
+            iat: Record<string, never>;
+            /**
+             * @description Not-before timestamp (seconds since Unix epoch)
+             * @example 1731141019
+             */
+            nbf?: number;
+            /**
+             * @description Granted scopes (space-delimited) for display purposes
+             * @example tasks:read tasks:write
+             */
+            scope?: string;
+            /**
+             * @description MCP server identifier the token is scoped to
+             * @example taskeroo
+             */
+            server_identifier: Record<string, never>;
+            /**
+             * @description Resource URL that was used during authorization
+             * @example http://localhost:4001/
+             */
+            resource: Record<string, never>;
+            /**
+             * @description Version of the MCP server contract
+             * @example 1.0.0
+             */
+            version: Record<string, never>;
         };
         JwkResponseDto: {
             /**
@@ -2816,6 +2909,40 @@ export interface operations {
             };
         };
     };
+    AuthorizationController_introspect: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                serverIdentifier: string;
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IntrospectTokenRequestDto"];
+            };
+        };
+        responses: {
+            /** @description Token introspection response (active true/false with metadata) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntrospectTokenResponseDto"];
+                };
+            };
+            /** @description Invalid introspection request parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     JwksController_getJwks: {
         parameters: {
             query?: never;
@@ -2833,24 +2960,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["JwksResponseDto"];
                 };
-            };
-        };
-    };
-    JwksController_getActiveJwk: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Active JWK retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };

--- a/packages/shared/src/client/index.ts
+++ b/packages/shared/src/client/index.ts
@@ -25,6 +25,8 @@ export type { DeleteConnectionResponseDto } from './models/DeleteConnectionRespo
 export type { DeleteMappingResponseDto } from './models/DeleteMappingResponseDto';
 export type { DeleteScopeResponseDto } from './models/DeleteScopeResponseDto';
 export type { DeleteServerResponseDto } from './models/DeleteServerResponseDto';
+export { IntrospectTokenRequestDto } from './models/IntrospectTokenRequestDto';
+export { IntrospectTokenResponseDto } from './models/IntrospectTokenResponseDto';
 export type { JwkResponseDto } from './models/JwkResponseDto';
 export type { JwksResponseDto } from './models/JwksResponseDto';
 export type { MappingResponseDto } from './models/MappingResponseDto';

--- a/packages/shared/src/client/models/IntrospectTokenRequestDto.ts
+++ b/packages/shared/src/client/models/IntrospectTokenRequestDto.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type IntrospectTokenRequestDto = {
+    /**
+     * Access or refresh token that should be validated
+     */
+    token: string;
+    /**
+     * Hint to help the server determine the token lookup strategy
+     */
+    token_type_hint?: IntrospectTokenRequestDto.token_type_hint;
+    /**
+     * Client identifier making the request (required for public MCP clients)
+     */
+    client_id: string;
+    /**
+     * Client secret for confidential clients (MCP clients typically omit this)
+     */
+    client_secret?: string | null;
+};
+export namespace IntrospectTokenRequestDto {
+    /**
+     * Hint to help the server determine the token lookup strategy
+     */
+    export enum token_type_hint {
+        ACCESS_TOKEN = 'access_token',
+        REFRESH_TOKEN = 'refresh_token',
+    }
+}
+

--- a/packages/shared/src/client/models/IntrospectTokenResponseDto.ts
+++ b/packages/shared/src/client/models/IntrospectTokenResponseDto.ts
@@ -1,0 +1,71 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type IntrospectTokenResponseDto = {
+    /**
+     * Indicates whether the token is currently valid
+     */
+    active: boolean;
+    /**
+     * Token type, always Bearer for MCP clients
+     */
+    token_type: IntrospectTokenResponseDto.token_type;
+    /**
+     * Client identifier associated with the token
+     */
+    client_id: string;
+    /**
+     * Subject of the token (resource owner or actor)
+     */
+    sub: Record<string, any>;
+    /**
+     * Audience that should accept this token
+     */
+    aud: (string | Array<string>);
+    /**
+     * Issuer that minted the token
+     */
+    iss: Record<string, any>;
+    /**
+     * Unique token identifier for replay detection
+     */
+    jti: Record<string, any>;
+    /**
+     * Expiration timestamp (seconds since Unix epoch)
+     */
+    exp: Record<string, any>;
+    /**
+     * Issued-at timestamp (seconds since Unix epoch)
+     */
+    iat: Record<string, any>;
+    /**
+     * Not-before timestamp (seconds since Unix epoch)
+     */
+    nbf?: number;
+    /**
+     * Granted scopes (space-delimited) for display purposes
+     */
+    scope?: string;
+    /**
+     * MCP server identifier the token is scoped to
+     */
+    server_identifier: Record<string, any>;
+    /**
+     * Resource URL that was used during authorization
+     */
+    resource: Record<string, any>;
+    /**
+     * Version of the MCP server contract
+     */
+    version: Record<string, any>;
+};
+export namespace IntrospectTokenResponseDto {
+    /**
+     * Token type, always Bearer for MCP clients
+     */
+    export enum token_type {
+        BEARER = 'Bearer',
+    }
+}
+

--- a/packages/shared/src/client/services/AuthorizationServerService.ts
+++ b/packages/shared/src/client/services/AuthorizationServerService.ts
@@ -4,6 +4,8 @@
 /* eslint-disable */
 import type { ClientRegistrationResponseDto } from '../models/ClientRegistrationResponseDto';
 import type { ConsentDecisionDto } from '../models/ConsentDecisionDto';
+import type { IntrospectTokenRequestDto } from '../models/IntrospectTokenRequestDto';
+import type { IntrospectTokenResponseDto } from '../models/IntrospectTokenResponseDto';
 import type { McpAuthorizationFlowEntity } from '../models/McpAuthorizationFlowEntity';
 import type { RegisterClientDto } from '../models/RegisterClientDto';
 import type { TokenRequestDto } from '../models/TokenRequestDto';
@@ -201,6 +203,34 @@ export class AuthorizationServerService {
             errors: {
                 400: `Invalid token request parameters`,
                 401: `Invalid authorization code, code_verifier, or expired code`,
+            },
+        });
+    }
+    /**
+     * OAuth 2.0 Token Introspection Endpoint
+     * Introspects an access token to validate it and retrieve its metadata. Verifies JWT signature, expiration, and claims according to RFC 7662.
+     * @param serverIdentifier
+     * @param version
+     * @param requestBody
+     * @returns IntrospectTokenResponseDto Token introspection response (active true/false with metadata)
+     * @throws ApiError
+     */
+    public static authorizationControllerIntrospect(
+        serverIdentifier: string,
+        version: string,
+        requestBody: IntrospectTokenRequestDto,
+    ): CancelablePromise<IntrospectTokenResponseDto> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/auth/introspect/mcp/{serverIdentifier}/{version}',
+            path: {
+                'serverIdentifier': serverIdentifier,
+                'version': version,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Invalid introspection request parameters`,
             },
         });
     }

--- a/packages/shared/src/client/services/JwksService.ts
+++ b/packages/shared/src/client/services/JwksService.ts
@@ -19,16 +19,4 @@ export class JwksService {
             url: '/.well-known/jwks.json',
         });
     }
-    /**
-     * Get Active Signing Key (Single JWK)
-     * Returns the currently active signing key as a single JWK. Useful for debugging and testing JWT verification with tools like jwt.io. This endpoint returns only the current signing key, not the full key set.
-     * @returns any Active JWK retrieved successfully
-     * @throws ApiError
-     */
-    public static jwksControllerGetActiveJwk(): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/.well-known/jwk-active.json',
-        });
-    }
 }


### PR DESCRIPTION
## Summary
- Implemented RFC 7662 compliant token introspection endpoint
- Validates JWT signature using JWKS public keys
- Verifies token expiration, client_id, and other claims
- Returns detailed metadata when valid or active:false when invalid

## Changes
- Added `introspectToken()` method to TokenService
- Added POST `/auth/introspect/mcp/:serverIdentifier/:version` endpoint
- Generated OpenAPI spec and client SDK updates

## Test Plan
- [ ] Build passes (✅ already verified)
- [ ] Endpoint accepts valid token and returns active:true with metadata
- [ ] Endpoint rejects expired token and returns active:false
- [ ] Endpoint rejects token with invalid signature and returns active:false
- [ ] Endpoint rejects token with mismatched client_id and returns active:false