### PR TITLE
Implement downstream OAuth flow for MCP connections

### DIFF
--- a/apps/backend/src/auth-journeys/auth-journeys.service.ts
+++ b/apps/backend/src/auth-journeys/auth-journeys.service.ts
@@ -149,4 +149,42 @@ export class AuthJourneysService {
   async saveMcpAuthFlow(mcpAuthFlow: McpAuthorizationFlowEntity): Promise<McpAuthorizationFlowEntity> {
     return this.mcpAuthorizationFlowRepository.save(mcpAuthFlow);
   }
+
+  /*
+  Public API: Get connection authorization flows for an auth journey
+  Used by downstream auth flow to process all connections
+  */
+  async getConnectionFlowsForJourney(
+    journeyId: string,
+    relations?: string[]
+  ): Promise<ConnectionAuthorizationFlowEntity[]> {
+    return this.connectionAuthorizationFlowRepository.find({
+      where: { authorizationJourneyId: journeyId },
+      relations,
+    });
+  }
+
+  /*
+  Public API: Find connection authorization flow by state
+  Used by callback handler to identify which flow is being completed
+  */
+  async findConnectionFlowByState(
+    state: string,
+    relations?: string[]
+  ): Promise<ConnectionAuthorizationFlowEntity | null> {
+    return this.connectionAuthorizationFlowRepository.findOne({
+      where: { state },
+      relations,
+    });
+  }
+
+  /*
+  Public API: Save/update connection authorization flow
+  Used by downstream auth flow to update connection state
+  */
+  async saveConnectionFlow(
+    connectionFlow: ConnectionAuthorizationFlowEntity
+  ): Promise<ConnectionAuthorizationFlowEntity> {
+    return this.connectionAuthorizationFlowRepository.save(connectionFlow);
+  }
 }

--- a/apps/backend/src/auth-journeys/entities/connection-authorization-flow.entity.ts
+++ b/apps/backend/src/auth-journeys/entities/connection-authorization-flow.entity.ts
@@ -37,6 +37,25 @@ export class ConnectionAuthorizationFlowEntity {
   @JoinColumn({ name: 'mcp_connection_id' })
   mcpConnection!: McpConnectionEntity;
 
+  // OAuth flow tracking fields
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  state?: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  authorizationCode?: string;
+
+  @Column({ type: 'text', nullable: true })
+  accessToken?: string;
+
+  @Column({ type: 'text', nullable: true })
+  refreshToken?: string;
+
+  @Column({ type: 'datetime', nullable: true })
+  tokenExpiresAt?: Date;
+
+  @Column({ type: 'varchar', length: 50, default: 'pending' })
+  status!: string; // pending, authorized, failed
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 

--- a/apps/backend/src/authorization-server/dto/callback-request.dto.ts
+++ b/apps/backend/src/authorization-server/dto/callback-request.dto.ts
@@ -1,0 +1,36 @@
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CallbackRequestDto {
+  @ApiProperty({
+    description: 'Authorization code from downstream OAuth provider',
+    example: 'abc123xyz',
+  })
+  @IsString()
+  @IsNotEmpty()
+  code!: string;
+
+  @ApiProperty({
+    description: 'State parameter that identifies the connection flow',
+    example: 'xyz789abc',
+  })
+  @IsString()
+  @IsNotEmpty()
+  state!: string;
+
+  @ApiPropertyOptional({
+    description: 'Error code if authorization failed',
+    example: 'access_denied',
+  })
+  @IsString()
+  @IsOptional()
+  error?: string;
+
+  @ApiPropertyOptional({
+    description: 'Error description if authorization failed',
+    example: 'User denied the authorization request',
+  })
+  @IsString()
+  @IsOptional()
+  error_description?: string;
+}

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -1751,6 +1751,69 @@
         ]
       }
     },
+    "/api/v1/auth/callback": {
+      "get": {
+        "description": "Handles callbacks from downstream OAuth providers. Validates the state, exchanges authorization code for tokens, and continues the auth flow.",
+        "operationId": "AuthorizationController_callback",
+        "parameters": [
+          {
+            "name": "code",
+            "required": true,
+            "in": "query",
+            "description": "Authorization code from downstream OAuth provider",
+            "schema": {
+              "example": "abc123xyz",
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "required": true,
+            "in": "query",
+            "description": "State parameter that identifies the connection flow",
+            "schema": {
+              "example": "xyz789abc",
+              "type": "string"
+            }
+          },
+          {
+            "name": "error",
+            "required": false,
+            "in": "query",
+            "description": "Error code if authorization failed",
+            "schema": {
+              "example": "access_denied",
+              "type": "string"
+            }
+          },
+          {
+            "name": "error_description",
+            "required": false,
+            "in": "query",
+            "description": "Error description if authorization failed",
+            "schema": {
+              "example": "User denied the authorization request",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirects to next step in the authorization flow"
+          },
+          "400": {
+            "description": "Invalid callback parameters or state"
+          },
+          "404": {
+            "description": "Connection flow not found for provided state"
+          }
+        },
+        "summary": "OAuth 2.0 Callback Endpoint for Downstream Systems",
+        "tags": [
+          "Authorization Server"
+        ]
+      }
+    },
     "/.well-known/jwks.json": {
       "get": {
         "description": "Returns the public keys used to verify JWT signatures. This endpoint provides all valid (non-expired) keys to support key rotation.",

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -480,6 +480,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/auth/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * OAuth 2.0 Callback Endpoint for Downstream Systems
+         * @description Handles callbacks from downstream OAuth providers. Validates the state, exchanges authorization code for tokens, and continues the auth flow.
+         */
+        get: operations["AuthorizationController_callback"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/.well-known/jwks.json": {
         parameters: {
             query?: never;
@@ -2938,6 +2958,47 @@ export interface operations {
             };
             /** @description Invalid introspection request parameters */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthorizationController_callback: {
+        parameters: {
+            query: {
+                /** @description Authorization code from downstream OAuth provider */
+                code: string;
+                /** @description State parameter that identifies the connection flow */
+                state: string;
+                /** @description Error code if authorization failed */
+                error?: string;
+                /** @description Error description if authorization failed */
+                error_description?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirects to next step in the authorization flow */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid callback parameters or state */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Connection flow not found for provided state */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/shared/src/client/services/AuthorizationServerService.ts
+++ b/packages/shared/src/client/services/AuthorizationServerService.ts
@@ -237,4 +237,36 @@ export class AuthorizationServerService {
             },
         });
     }
+    /**
+     * OAuth 2.0 Callback Endpoint for Downstream Systems
+     * Handles callbacks from downstream OAuth providers. Validates the state, exchanges authorization code for tokens, and continues the auth flow.
+     * @param code Authorization code from downstream OAuth provider
+     * @param state State parameter that identifies the connection flow
+     * @param error Error code if authorization failed
+     * @param errorDescription Error description if authorization failed
+     * @returns void
+     * @throws ApiError
+     */
+    public static authorizationControllerCallback(
+        code: string,
+        state: string,
+        error?: string,
+        errorDescription?: string,
+    ): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/auth/callback',
+            query: {
+                'code': code,
+                'state': state,
+                'error': error,
+                'error_description': errorDescription,
+            },
+            errors: {
+                302: `Redirects to next step in the authorization flow`,
+                400: `Invalid callback parameters or state`,
+                404: `Connection flow not found for provided state`,
+            },
+        });
+    }
 }


### PR DESCRIPTION
## Summary

- Add complete downstream authentication flow to handle OAuth for MCP server connections
- Detect if MCP server has connections and initiate OAuth flows for each
- Handle callbacks from downstream OAuth providers
- Exchange authorization codes for access tokens
- Complete MCP auth flow when all downstream connections are authorized

## Implementation Details

- **ConnectionAuthorizationFlowEntity**: Added fields to track OAuth state (state, authorizationCode, accessToken, refreshToken, tokenExpiresAt, status)
- **AuthJourneysService**: Added helper methods to manage connection flows (getConnectionFlowsForJourney, findConnectionFlowByState, saveConnectionFlow)
- **Authorization flow**: Modified processConsentDecision to detect connections and initiate downstream OAuth flows
- **Callback endpoint**: Created /api/v1/auth/callback to handle OAuth callbacks from downstream systems
- **Token exchange**: Implemented exchangeCodeForToken to exchange authorization codes for access tokens using downstream provider's token endpoint

## Test plan

- [ ] Test with MCP server that has no connections (should skip downstream auth)
- [ ] Test with MCP server that has one connection (should initiate OAuth flow and complete when authorized)
- [ ] Test with MCP server that has multiple connections (should handle all flows sequentially)
- [ ] Test error handling when downstream provider returns error
- [ ] Test token exchange with valid authorization code
- [ ] Verify all tokens are stored correctly in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)