### PR TITLE
Fix: Refactor downstream auth to handle one flow at a time

### DIFF
--- a/apps/backend/src/auth-journeys/auth-journeys.service.ts
+++ b/apps/backend/src/auth-journeys/auth-journeys.service.ts
@@ -187,4 +187,18 @@ export class AuthJourneysService {
   ): Promise<ConnectionAuthorizationFlowEntity> {
     return this.connectionAuthorizationFlowRepository.save(connectionFlow);
   }
+
+  /*
+  Public API: Find MCP authorization flow by auth journey ID
+  Used to get the MCP flow when completing the auth journey
+  */
+  async findMcpAuthFlowByJourneyId(
+    journeyId: string,
+    relations?: string[]
+  ): Promise<McpAuthorizationFlowEntity | null> {
+    return this.mcpAuthorizationFlowRepository.findOne({
+      where: { authorizationJourneyId: journeyId },
+      relations,
+    });
+  }
 }


### PR DESCRIPTION
## Summary

- Refactor downstream OAuth flow to handle one connection at a time instead of all at once
- Fix the async nature of OAuth redirects where each redirect ends the request
- Fix authorization URL construction for GCP OAuth

## Changes

- **Replaced** `initiateDownstreamAuthFlows` with `processNextDownstreamFlow` - finds next pending connection and initiates OAuth for ONE connection
- **Created** `initiateConnectionOAuth` - handles single connection OAuth initiation
- **Created** `completeMcpAuthFlow` - issues MCP authorization code when all connections are done
- **Updated** consent handler to use new processNextDownstreamFlow method
- **Updated** callback handler to process next flow after completing current one
- **Fixed** authorization URL construction - added `access_type=offline` and `prompt=consent` for Google OAuth
- **Added** `findMcpAuthFlowByJourneyId` helper in AuthJourneysService

## Flow

1. User consents → process next flow → redirect to first OAuth provider
2. User authorizes → callback → process next flow → redirect to second OAuth provider
3. ...continue until all connections are authorized...
4. All done → complete MCP auth → redirect to MCP client with code

## Test plan

- [ ] Test with no connections (should complete immediately)
- [ ] Test with one connection (should redirect to OAuth, then complete)
- [ ] Test with multiple connections (should redirect through each OAuth sequentially)
- [ ] Verify GCP OAuth works with new URL parameters

Fixes issue reported by @Fran about handling async OAuth flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)