### PR TITLE
Fix: Use NODE_ENV instead of VITE_PORT for dev/prod detection

### DIFF
--- a/apps/backend/src/config/frontend.config.ts
+++ b/apps/backend/src/config/frontend.config.ts
@@ -14,10 +14,9 @@
  * @returns Relative path "/" in production, "http://localhost:{port}" in development
  */
 export function getFrontendUrl(): string {
-  const uiPort = process.env.VITE_PORT;
-
   // In development, frontend runs on a different port
-  if (uiPort) {
+  if (process.env.NODE_ENV !== 'production') {
+    const uiPort = process.env.VITE_PORT || '5173';
     return `http://localhost:${uiPort}`;
   }
 


### PR DESCRIPTION
## Summary

- Fix backend frontend redirect to use NODE_ENV instead of VITE_PORT
- Backend now correctly redirects to vite in development mode

## Problem

Backend was checking if `VITE_PORT` environment variable was set to determine if running in development mode. Since this variable is not normally set, the backend would always redirect to `/` instead of the vite dev server.

## Solution

Changed `getFrontendUrl()` in `apps/backend/src/config/frontend.config.ts` to:
- Check `NODE_ENV !== 'production'` to detect development mode
- Use `VITE_PORT` if set, otherwise default to `5173`
- In production, serve frontend from same origin (empty string)

## Changes

- **Before**: Only redirected to vite if VITE_PORT was explicitly set
- **After**: Redirects to vite in all non-production environments

## Test plan

- [ ] Start backend in development (NODE_ENV not set or !== 'production') - should redirect to http://localhost:5173
- [ ] Start backend in production (NODE_ENV=production) - should serve from same origin
- [ ] Test with VITE_PORT set to custom port - should use that port

🤖 Generated with [Claude Code](https://claude.com/claude-code)