### PR TITLE
feat(wikiroo): add update, append, and delete endpoints

### DIFF
--- a/apps/backend/src/wikiroo/dto/append-page.dto.ts
+++ b/apps/backend/src/wikiroo/dto/append-page.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AppendPageDto {
+  @ApiProperty({
+    description: 'Markdown content to append to the existing page content',
+    example: '\n## Additional details',
+  })
+  @IsString()
+  @IsNotEmpty()
+  content!: string;
+}

--- a/apps/backend/src/wikiroo/dto/service/wikiroo.service.types.ts
+++ b/apps/backend/src/wikiroo/dto/service/wikiroo.service.types.ts
@@ -4,6 +4,16 @@ export interface CreatePageInput {
   author: string;
 }
 
+export interface UpdatePageInput {
+  title?: string;
+  content?: string;
+  author?: string;
+}
+
+export interface AppendPageInput {
+  content: string;
+}
+
 export interface PageResult {
   id: string;
   title: string;

--- a/apps/backend/src/wikiroo/dto/update-page.dto.ts
+++ b/apps/backend/src/wikiroo/dto/update-page.dto.ts
@@ -1,0 +1,30 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdatePageDto {
+  @ApiPropertyOptional({
+    description: 'Updated title of the wiki page',
+    example: 'Updated onboarding guide',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  title?: string;
+
+  @ApiPropertyOptional({
+    description: 'Updated markdown content of the page',
+    example: '## Updated content',
+  })
+  @IsOptional()
+  @IsString()
+  content?: string;
+
+  @ApiPropertyOptional({
+    description: 'Updated author of the page',
+    example: 'Agent Roo',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  author?: string;
+}

--- a/apps/backend/src/wikiroo/wikiroo.mcp.gateway.ts
+++ b/apps/backend/src/wikiroo/wikiroo.mcp.gateway.ts
@@ -79,6 +79,79 @@ export class WikirooMcpGateway {
       }
     )
 
+    server.registerTool(
+      'update_page',
+      {
+        title: 'Update wiki page',
+        description: 'Update the title, content, or author of an existing wiki page',
+        inputSchema: {
+          pageId: z.string(),
+          title: z.string().optional(),
+          content: z.string().optional(),
+          author: z.string().optional(),
+        },
+      },
+      async ({ pageId, title, content, author }) => {
+        if (title === undefined && content === undefined && author === undefined) {
+          throw new Error('At least one field must be provided to update the page.');
+        }
+
+        const page = await this.wikirooService.updatePage(pageId, {
+          title,
+          content,
+          author,
+        });
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(page),
+          }],
+        };
+      }
+    )
+
+    server.registerTool(
+      'append_page',
+      {
+        title: 'Append wiki page content',
+        description: 'Append markdown content to the end of an existing wiki page',
+        inputSchema: {
+          pageId: z.string(),
+          content: z.string(),
+        },
+      },
+      async ({ pageId, content }) => {
+        const page = await this.wikirooService.appendToPage(pageId, { content });
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(page),
+          }],
+        };
+      }
+    )
+
+    server.registerTool(
+      'delete_page',
+      {
+        title: 'Delete wiki page',
+        description: 'Delete a wiki page by its identifier',
+        inputSchema: {
+          pageId: z.string(),
+        },
+      },
+      async ({ pageId }) => {
+        await this.wikirooService.deletePage(pageId);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ status: 'deleted', pageId }),
+          }],
+        };
+      }
+    )
+
     return server;
   }
 

--- a/apps/backend/test/wikiroo.e2e-spec.ts
+++ b/apps/backend/test/wikiroo.e2e-spec.ts
@@ -83,11 +83,56 @@ describe('Wikiroo E2E Tests', () => {
     expect(response.body.author).toBe('Agent Tester');
   });
 
+  it('should reject updates without any fields', async () => {
+    await request(httpServer)
+      .patch(`/api/v1/wikiroo/pages/${createdPageId}`)
+      .send({})
+      .expect(400);
+  });
+
+  it('should update the wiki page title', async () => {
+    const response = await request(httpServer)
+      .patch(`/api/v1/wikiroo/pages/${createdPageId}`)
+      .send({
+        title: 'Updated Test Page',
+      })
+      .expect(200);
+
+    expect(response.body.title).toBe('Updated Test Page');
+    expect(response.body.content).toBe(
+      'This is a wikiroo page created during tests.',
+    );
+  });
+
+  it('should append content to the wiki page', async () => {
+    const appendText = '\nAdditional wikiroo details.';
+    const response = await request(httpServer)
+      .post(`/api/v1/wikiroo/pages/${createdPageId}/append`)
+      .send({
+        content: appendText,
+      })
+      .expect(200);
+
+    expect(response.body.content).toContain(appendText.trim());
+  });
+
+  it('should delete the wiki page', async () => {
+    await request(httpServer)
+      .delete(`/api/v1/wikiroo/pages/${createdPageId}`)
+      .expect(204);
+  });
+
   it('should return 404 for unknown page', async () => {
     const response = await request(httpServer)
       .get('/api/v1/wikiroo/pages/00000000-0000-0000-0000-000000000000')
       .expect(404);
 
     expect(response.body.code).toBe('PAGE_NOT_FOUND');
+  });
+
+  it('should return 404 when fetching a deleted page', async () => {
+    await request(httpServer)
+      .get(`/api/v1/wikiroo/pages/${createdPageId}`)
+      .expect(404);
   });
 });

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -563,6 +563,117 @@
         "tags": [
           "Wikiroo"
         ]
+      },
+      "patch": {
+        "operationId": "WikirooController_updatePage",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Wiki page identifier",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePageDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Wiki page updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No update fields provided"
+          }
+        },
+        "summary": "Update an existing wiki page",
+        "tags": [
+          "Wikiroo"
+        ]
+      },
+      "delete": {
+        "operationId": "WikirooController_deletePage",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Wiki page identifier",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Wiki page deleted successfully"
+          }
+        },
+        "summary": "Delete a wiki page",
+        "tags": [
+          "Wikiroo"
+        ]
+      }
+    },
+    "/api/v1/wikiroo/pages/{id}/append": {
+      "post": {
+        "operationId": "WikirooController_appendToPage",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Wiki page identifier",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppendPageDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Wiki page content appended successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Append content to an existing wiki page",
+        "tags": [
+          "Wikiroo"
+        ]
       }
     },
     "/api/v1/wikiroo/pages/mcp": {
@@ -2187,6 +2298,39 @@
           "content",
           "author"
         ]
+      },
+      "AppendPageDto": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Markdown content to append to the existing page content",
+            "example": "\\n## Additional details"
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
+      "UpdatePageDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Updated title of the wiki page",
+            "example": "Updated onboarding guide"
+          },
+          "content": {
+            "type": "string",
+            "description": "Updated markdown content of the page",
+            "example": "## Updated content"
+          },
+          "author": {
+            "type": "string",
+            "description": "Updated author of the page",
+            "example": "Agent Roo"
+          }
+        }
       },
       "PageResponseDto": {
         "type": "object",

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -154,6 +154,25 @@ export interface paths {
         get: operations["WikirooController_getPage"];
         put?: never;
         post?: never;
+        /** Update an existing wiki page */
+        patch: operations["WikirooController_updatePage"];
+        /** Delete a wiki page */
+        delete: operations["WikirooController_deletePage"];
+        options?: never;
+        head?: never;
+        trace?: never;
+    };
+    "/api/v1/wikiroo/pages/{id}/append": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Append content to an existing wiki page */
+        post: operations["WikirooController_appendToPage"];
+        get?: never;
+        put?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -749,6 +768,30 @@ export interface components {
              * @example Agent Roo
              */
             author: string;
+        };
+        AppendPageDto: {
+            /**
+             * @description Markdown content to append to the existing page content
+             * @example ## Additional details
+             */
+            content: string;
+        };
+        UpdatePageDto: {
+            /**
+             * @description Updated title of the wiki page
+             * @example Updated onboarding guide
+             */
+            title?: string;
+            /**
+             * @description Updated markdown content of the page
+             * @example ## Updated content
+             */
+            content?: string;
+            /**
+             * @description Updated author of the page
+             * @example Agent Roo
+             */
+            author?: string;
         };
         PageResponseDto: {
             /**
@@ -1998,6 +2041,88 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Wiki page retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PageResponseDto"];
+                };
+            };
+        };
+    };
+    WikirooController_updatePage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Wiki page identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePageDto"];
+            };
+        };
+        responses: {
+            /** @description Wiki page updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PageResponseDto"];
+                };
+            };
+            /** @description No update fields provided */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WikirooController_deletePage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Wiki page identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Wiki page deleted successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WikirooController_appendToPage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Wiki page identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AppendPageDto"];
+            };
+        };
+        responses: {
+            /** @description Wiki page content appended successfully */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/shared/src/client/index.ts
+++ b/packages/shared/src/client/index.ts
@@ -21,6 +21,7 @@ export type { CreatePageDto } from './models/CreatePageDto';
 export type { CreateScopeDto } from './models/CreateScopeDto';
 export type { CreateServerDto } from './models/CreateServerDto';
 export type { CreateTaskDto } from './models/CreateTaskDto';
+export type { AppendPageDto } from './models/AppendPageDto';
 export type { DeleteConnectionResponseDto } from './models/DeleteConnectionResponseDto';
 export type { DeleteMappingResponseDto } from './models/DeleteMappingResponseDto';
 export type { DeleteScopeResponseDto } from './models/DeleteScopeResponseDto';
@@ -43,6 +44,7 @@ export { TaskResponseDto } from './models/TaskResponseDto';
 export { TokenRequestDto } from './models/TokenRequestDto';
 export { TokenResponseDto } from './models/TokenResponseDto';
 export type { UpdateConnectionDto } from './models/UpdateConnectionDto';
+export type { UpdatePageDto } from './models/UpdatePageDto';
 export type { UpdateTaskDto } from './models/UpdateTaskDto';
 
 export { AppService } from './services/AppService';

--- a/packages/shared/src/client/models/AppendPageDto.ts
+++ b/packages/shared/src/client/models/AppendPageDto.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AppendPageDto = {
+    /**
+     * Markdown content to append to the existing page content
+     */
+    content: string;
+};
+

--- a/packages/shared/src/client/models/UpdatePageDto.ts
+++ b/packages/shared/src/client/models/UpdatePageDto.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UpdatePageDto = {
+    /**
+     * Updated title of the wiki page
+     */
+    title?: string;
+    /**
+     * Updated markdown content of the page
+     */
+    content?: string;
+    /**
+     * Updated author of the page
+     */
+    author?: string;
+};
+

--- a/packages/shared/src/client/services/WikirooService.ts
+++ b/packages/shared/src/client/services/WikirooService.ts
@@ -2,9 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AppendPageDto } from '../models/AppendPageDto';
 import type { CreatePageDto } from '../models/CreatePageDto';
 import type { PageListResponseDto } from '../models/PageListResponseDto';
 import type { PageResponseDto } from '../models/PageResponseDto';
+import type { UpdatePageDto } from '../models/UpdatePageDto';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -50,6 +52,68 @@ export class WikirooService {
     ): CancelablePromise<PageResponseDto> {
         return __request(OpenAPI, {
             method: 'GET',
+            url: '/api/v1/wikiroo/pages/{id}',
+            path: {
+                'id': id,
+            },
+        });
+    }
+    /**
+     * Update an existing wiki page
+     * @param id Wiki page identifier
+     * @param requestBody
+     * @returns PageResponseDto Wiki page updated successfully
+     * @throws ApiError
+     */
+    public static wikirooControllerUpdatePage(
+        id: string,
+        requestBody: UpdatePageDto,
+    ): CancelablePromise<PageResponseDto> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/v1/wikiroo/pages/{id}',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `No update fields provided`,
+            },
+        });
+    }
+    /**
+     * Append content to an existing wiki page
+     * @param id Wiki page identifier
+     * @param requestBody
+     * @returns PageResponseDto Wiki page content appended successfully
+     * @throws ApiError
+     */
+    public static wikirooControllerAppendToPage(
+        id: string,
+        requestBody: AppendPageDto,
+    ): CancelablePromise<PageResponseDto> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/wikiroo/pages/{id}/append',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Delete a wiki page
+     * @param id Wiki page identifier
+     * @returns void Wiki page deleted successfully
+     * @throws ApiError
+     */
+    public static wikirooControllerDeletePage(
+        id: string,
+    ): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
             url: '/api/v1/wikiroo/pages/{id}',
             path: {
                 'id': id,


### PR DESCRIPTION
## Summary
- add REST DTOs and controller routes for updating, appending to, and deleting Wikiroo pages
- extend the Wikiroo MCP gateway to expose the new page management capabilities
- refresh the shared OpenAPI contract, generated client, and backend e2e coverage for the new workflows

## Testing
- npm run test:e2e *(fails: `nest` CLI is unavailable in the environment)*
- npm -w backend run test:e2e *(fails: `jest` CLI is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912c961e414832f8d06639b52f4f0d7)