### PR TITLE
feat(wikiroo): add edit and delete page functionality via UI

### DIFF
--- a/apps/ui/src/wikiroo/WikiPageEditForm.tsx
+++ b/apps/ui/src/wikiroo/WikiPageEditForm.tsx
@@ -1,0 +1,213 @@
+import { useState, useEffect } from 'react';
+import type { WikiPage } from './types';
+import type { UpdatePageDto } from 'shared';
+
+interface WikiPageEditFormProps {
+  page: WikiPage;
+  onClose: () => void;
+  onUpdate: (page: WikiPage) => void;
+  onDelete: () => void;
+  onError?: (error: string) => void;
+  isUpdating: boolean;
+  isDeleting: boolean;
+}
+
+export function WikiPageEditForm({
+  page,
+  onClose,
+  onUpdate,
+  onDelete,
+  onError,
+  isUpdating,
+  isDeleting,
+}: WikiPageEditFormProps) {
+  const [title, setTitle] = useState(page.title);
+  const [content, setContent] = useState(page.content);
+  const [author, setAuthor] = useState(page.author);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const payload: UpdatePageDto = {};
+    let hasChanges = false;
+
+    if (title !== page.title) {
+      payload.title = title;
+      hasChanges = true;
+    }
+    if (content !== page.content) {
+      payload.content = content;
+      hasChanges = true;
+    }
+    if (author !== page.author) {
+      payload.author = author;
+      hasChanges = true;
+    }
+
+    if (!hasChanges) {
+      setErrorMessage('No changes to save');
+      return;
+    }
+
+    try {
+      const updatedPage = { ...page, ...payload };
+      await onUpdate(updatedPage as WikiPage);
+      setErrorMessage('');
+    } catch (err: any) {
+      const errorMsg = err?.body?.detail || err?.message || 'Failed to update page';
+      setErrorMessage(errorMsg);
+      if (onError) {
+        onError(errorMsg);
+      }
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await onDelete();
+      setErrorMessage('');
+    } catch (err: any) {
+      const errorMsg = err?.body?.detail || err?.message || 'Failed to delete page';
+      setErrorMessage(errorMsg);
+      if (onError) {
+        onError(errorMsg);
+      }
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content wiki-edit-form" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2>Edit Page</h2>
+          <button onClick={onClose} className="btn-close">
+            ×
+          </button>
+        </div>
+
+        {errorMessage && (
+          <div className="error-message">
+            <strong>Error:</strong> {errorMessage}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <div className="detail-section">
+            <label htmlFor="title">
+              <strong>Title</strong>
+            </label>
+            <input
+              id="title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Enter page title..."
+              required
+              disabled={isUpdating || isDeleting}
+            />
+          </div>
+
+          <div className="detail-section">
+            <label htmlFor="author">
+              <strong>Author</strong>
+            </label>
+            <input
+              id="author"
+              type="text"
+              value={author}
+              onChange={(e) => setAuthor(e.target.value)}
+              placeholder="Enter author name..."
+              required
+              disabled={isUpdating || isDeleting}
+            />
+          </div>
+
+          <div className="detail-section">
+            <label htmlFor="content">
+              <strong>Content (Markdown)</strong>
+            </label>
+            <textarea
+              id="content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Enter page content in markdown format..."
+              className="content-textarea"
+              rows={15}
+              required
+              disabled={isUpdating || isDeleting}
+            />
+          </div>
+
+          <div className="detail-section">
+            <div className="form-actions">
+              <button
+                type="submit"
+                className="btn-primary"
+                disabled={isUpdating || isDeleting}
+              >
+                {isUpdating ? 'Saving...' : 'Save Changes'}
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="btn-secondary"
+                disabled={isUpdating || isDeleting}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+
+          <div className="detail-section">
+            <div className="task-actions">
+              {showDeleteConfirm ? (
+                <div className="delete-confirm">
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="btn-danger"
+                    disabled={isDeleting}
+                  >
+                    {isDeleting ? 'Deleting...' : 'Confirm Delete'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowDeleteConfirm(false)}
+                    className="btn-secondary"
+                    disabled={isDeleting}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="btn-danger"
+                  disabled={isUpdating || isDeleting}
+                >
+                  Delete Page
+                </button>
+              )}
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/wikiroo/WikirooPageView.tsx
+++ b/apps/ui/src/wikiroo/WikirooPageView.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect } from 'react';
-import { Link, Navigate, useParams } from 'react-router-dom';
+import { useCallback, useEffect, useState } from 'react';
+import { Link, Navigate, useParams, useNavigate } from 'react-router-dom';
 import { HomeLink } from '../components/HomeLink';
 import './Wikiroo.css';
 import { useWikiroo } from './useWikiroo';
 import { MarkdownPreview } from './MarkdownPreview';
 import { usePageTitle } from '../hooks/usePageTitle';
+import { WikiPageEditForm } from './WikiPageEditForm';
+import type { UpdatePageDto } from 'shared';
 
 function formatDate(value: string) {
   try {
@@ -16,7 +18,11 @@ function formatDate(value: string) {
 
 export function WikirooPageView() {
   const { pageId } = useParams<{ pageId: string }>();
-  const { pages, selectedPage, isLoadingPage, error, selectPage } = useWikiroo();
+  const navigate = useNavigate();
+  const { pages, selectedPage, isLoadingPage, error, selectPage, updatePage, deletePage, isUpdating, isDeleting } =
+    useWikiroo();
+  const [showEditForm, setShowEditForm] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
   const pageSummary = pages.find((page) => page.id === pageId);
   const pageTitle = selectedPage?.title || pageSummary?.title;
@@ -40,6 +46,40 @@ export function WikirooPageView() {
     }
   }, [pageId, selectPage]);
 
+  const handleUpdate = useCallback(
+    async (updatedPage: any) => {
+      if (!pageId) return;
+      const payload: UpdatePageDto = {};
+      if (updatedPage.title !== selectedPage?.title) payload.title = updatedPage.title;
+      if (updatedPage.content !== selectedPage?.content) payload.content = updatedPage.content;
+      if (updatedPage.author !== selectedPage?.author) payload.author = updatedPage.author;
+
+      try {
+        await updatePage(pageId, payload);
+        setShowEditForm(false);
+        setErrorMessage('');
+      } catch (err: any) {
+        const errorMsg = err?.body?.detail || err?.message || 'Failed to update page';
+        setErrorMessage(errorMsg);
+        throw err;
+      }
+    },
+    [pageId, selectedPage, updatePage],
+  );
+
+  const handleDelete = useCallback(async () => {
+    if (!pageId) return;
+    try {
+      await deletePage(pageId);
+      setShowEditForm(false);
+      navigate('/wikiroo');
+    } catch (err: any) {
+      const errorMsg = err?.body?.detail || err?.message || 'Failed to delete page';
+      setErrorMessage(errorMsg);
+      throw err;
+    }
+  }, [pageId, deletePage, navigate]);
+
   return (
     <div className="wikiroo wikiroo-page-view">
       <header className="wikiroo-header">
@@ -62,6 +102,16 @@ export function WikirooPageView() {
         </div>
         <div className="wikiroo-actions">
           <HomeLink />
+          {selectedPage && (
+            <button
+              className="wikiroo-button"
+              type="button"
+              onClick={() => setShowEditForm(true)}
+              disabled={isLoadingPage || isUpdating || isDeleting}
+            >
+              Edit Page
+            </button>
+          )}
           <button
             className="wikiroo-button secondary"
             type="button"
@@ -76,6 +126,7 @@ export function WikirooPageView() {
       <section className="wikiroo-content-panel">
         {isLoadingPage && <div className="wikiroo-status">Loading page…</div>}
         {error && <div className="wikiroo-error">{error}</div>}
+        {errorMessage && <div className="wikiroo-error">{errorMessage}</div>}
         {showNotFound && (
           <div className="wikiroo-empty">
             <strong>Page not found</strong>
@@ -84,6 +135,18 @@ export function WikirooPageView() {
         )}
         {selectedPage && <MarkdownPreview content={selectedPage.content} />}
       </section>
+
+      {showEditForm && selectedPage && (
+        <WikiPageEditForm
+          page={selectedPage}
+          onClose={() => setShowEditForm(false)}
+          onUpdate={handleUpdate}
+          onDelete={handleDelete}
+          onError={setErrorMessage}
+          isUpdating={isUpdating}
+          isDeleting={isDeleting}
+        />
+      )}
     </div>
   );
 }

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -1898,6 +1898,15 @@
             }
           },
           {
+            "name": "scope",
+            "required": false,
+            "in": "query",
+            "description": "Scopes that were granted",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "error_description",
             "required": false,
             "in": "query",
@@ -2299,39 +2308,6 @@
           "author"
         ]
       },
-      "AppendPageDto": {
-        "type": "object",
-        "properties": {
-          "content": {
-            "type": "string",
-            "description": "Markdown content to append to the existing page content",
-            "example": "\\n## Additional details"
-          }
-        },
-        "required": [
-          "content"
-        ]
-      },
-      "UpdatePageDto": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "Updated title of the wiki page",
-            "example": "Updated onboarding guide"
-          },
-          "content": {
-            "type": "string",
-            "description": "Updated markdown content of the page",
-            "example": "## Updated content"
-          },
-          "author": {
-            "type": "string",
-            "description": "Updated author of the page",
-            "example": "Agent Roo"
-          }
-        }
-      },
       "PageResponseDto": {
         "type": "object",
         "properties": {
@@ -2425,6 +2401,39 @@
         },
         "required": [
           "items"
+        ]
+      },
+      "UpdatePageDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Updated title of the wiki page",
+            "example": "Updated onboarding guide"
+          },
+          "content": {
+            "type": "string",
+            "description": "Updated markdown content of the page",
+            "example": "## Updated content"
+          },
+          "author": {
+            "type": "string",
+            "description": "Updated author of the page",
+            "example": "Agent Roo"
+          }
+        }
+      },
+      "AppendPageDto": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Markdown content to append to the existing page content",
+            "example": "\n## Additional details"
+          }
+        },
+        "required": [
+          "content"
         ]
       },
       "CreateServerDto": {

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -154,12 +154,12 @@ export interface paths {
         get: operations["WikirooController_getPage"];
         put?: never;
         post?: never;
-        /** Update an existing wiki page */
-        patch: operations["WikirooController_updatePage"];
         /** Delete a wiki page */
         delete: operations["WikirooController_deletePage"];
         options?: never;
         head?: never;
+        /** Update an existing wiki page */
+        patch: operations["WikirooController_updatePage"];
         trace?: never;
     };
     "/api/v1/wikiroo/pages/{id}/append": {
@@ -169,10 +169,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Append content to an existing wiki page */
-        post: operations["WikirooController_appendToPage"];
         get?: never;
         put?: never;
+        /** Append content to an existing wiki page */
+        post: operations["WikirooController_appendToPage"];
         delete?: never;
         options?: never;
         head?: never;
@@ -769,30 +769,6 @@ export interface components {
              */
             author: string;
         };
-        AppendPageDto: {
-            /**
-             * @description Markdown content to append to the existing page content
-             * @example ## Additional details
-             */
-            content: string;
-        };
-        UpdatePageDto: {
-            /**
-             * @description Updated title of the wiki page
-             * @example Updated onboarding guide
-             */
-            title?: string;
-            /**
-             * @description Updated markdown content of the page
-             * @example ## Updated content
-             */
-            content?: string;
-            /**
-             * @description Updated author of the page
-             * @example Agent Roo
-             */
-            author?: string;
-        };
         PageResponseDto: {
             /**
              * @description Unique identifier for the page
@@ -855,6 +831,30 @@ export interface components {
         PageListResponseDto: {
             /** @description List of wiki pages */
             items: components["schemas"]["PageSummaryDto"][];
+        };
+        UpdatePageDto: {
+            /**
+             * @description Updated title of the wiki page
+             * @example Updated onboarding guide
+             */
+            title?: string;
+            /**
+             * @description Updated markdown content of the page
+             * @example ## Updated content
+             */
+            content?: string;
+            /**
+             * @description Updated author of the page
+             * @example Agent Roo
+             */
+            author?: string;
+        };
+        AppendPageDto: {
+            /**
+             * @description Markdown content to append to the existing page content
+             * @example ## Additional details
+             */
+            content: string;
         };
         CreateServerDto: {
             /**
@@ -2051,6 +2051,27 @@ export interface operations {
             };
         };
     };
+    WikirooController_deletePage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Wiki page identifier */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Wiki page deleted successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     WikirooController_updatePage: {
         parameters: {
             query?: never;
@@ -2078,27 +2099,6 @@ export interface operations {
             };
             /** @description No update fields provided */
             400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    WikirooController_deletePage: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Wiki page identifier */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Wiki page deleted successfully */
-            204: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3099,6 +3099,8 @@ export interface operations {
                 state: string;
                 /** @description Error code if authorization failed */
                 error?: string;
+                /** @description Scopes that were granted */
+                scope?: string;
                 /** @description Error description if authorization failed */
                 error_description?: string;
             };

--- a/packages/shared/src/client/index.ts
+++ b/packages/shared/src/client/index.ts
@@ -7,6 +7,7 @@ export { CancelablePromise, CancelError } from './core/CancelablePromise';
 export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
+export type { AppendPageDto } from './models/AppendPageDto';
 export type { AssignTaskDto } from './models/AssignTaskDto';
 export type { AuthorizationServerMetadataDto } from './models/AuthorizationServerMetadataDto';
 export { ChangeTaskStatusDto } from './models/ChangeTaskStatusDto';
@@ -21,7 +22,6 @@ export type { CreatePageDto } from './models/CreatePageDto';
 export type { CreateScopeDto } from './models/CreateScopeDto';
 export type { CreateServerDto } from './models/CreateServerDto';
 export type { CreateTaskDto } from './models/CreateTaskDto';
-export type { AppendPageDto } from './models/AppendPageDto';
 export type { DeleteConnectionResponseDto } from './models/DeleteConnectionResponseDto';
 export type { DeleteMappingResponseDto } from './models/DeleteMappingResponseDto';
 export type { DeleteScopeResponseDto } from './models/DeleteScopeResponseDto';

--- a/packages/shared/src/client/services/AuthorizationServerService.ts
+++ b/packages/shared/src/client/services/AuthorizationServerService.ts
@@ -243,6 +243,7 @@ export class AuthorizationServerService {
      * @param code Authorization code from downstream OAuth provider
      * @param state State parameter that identifies the connection flow
      * @param error Error code if authorization failed
+     * @param scope Scopes that were granted
      * @param errorDescription Error description if authorization failed
      * @returns void
      * @throws ApiError
@@ -251,6 +252,7 @@ export class AuthorizationServerService {
         code: string,
         state: string,
         error?: string,
+        scope?: string,
         errorDescription?: string,
     ): CancelablePromise<void> {
         return __request(OpenAPI, {
@@ -260,6 +262,7 @@ export class AuthorizationServerService {
                 'code': code,
                 'state': state,
                 'error': error,
+                'scope': scope,
                 'error_description': errorDescription,
             },
             errors: {

--- a/packages/shared/src/client/services/WikirooService.ts
+++ b/packages/shared/src/client/services/WikirooService.ts
@@ -83,6 +83,23 @@ export class WikirooService {
         });
     }
     /**
+     * Delete a wiki page
+     * @param id Wiki page identifier
+     * @returns void
+     * @throws ApiError
+     */
+    public static wikirooControllerDeletePage(
+        id: string,
+    ): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/wikiroo/pages/{id}',
+            path: {
+                'id': id,
+            },
+        });
+    }
+    /**
      * Append content to an existing wiki page
      * @param id Wiki page identifier
      * @param requestBody
@@ -101,23 +118,6 @@ export class WikirooService {
             },
             body: requestBody,
             mediaType: 'application/json',
-        });
-    }
-    /**
-     * Delete a wiki page
-     * @param id Wiki page identifier
-     * @returns void Wiki page deleted successfully
-     * @throws ApiError
-     */
-    public static wikirooControllerDeletePage(
-        id: string,
-    ): CancelablePromise<void> {
-        return __request(OpenAPI, {
-            method: 'DELETE',
-            url: '/api/v1/wikiroo/pages/{id}',
-            path: {
-                'id': id,
-            },
         });
     }
     /**


### PR DESCRIPTION
## Summary
- Extended useWikiroo hook with updatePage and deletePage methods with proper state management
- Created WikiPageEditForm component following Taskeroo's TaskDetail modal pattern
- Updated WikirooPageView with Edit button and modal integration
- Added comprehensive error handling and loading states for all operations
- Implemented two-step delete confirmation to prevent accidental deletions

## Implementation Details
Following the Taskeroo pattern for consistency:
- Hook pattern: updatePage() and deletePage() methods with isUpdating/isDeleting states
- Modal pattern: Edit form in modal with escape key support
- Error handling: Display errors inline with proper error messages from API
- Delete confirmation: Two-step process (Delete → Confirm Delete + Cancel)

## Test Plan
- [ ] Create a new wiki page
- [ ] Click Edit Page button and verify modal opens
- [ ] Edit title, author, and content
- [ ] Save changes and verify page updates
- [ ] Attempt to save with no changes
- [ ] Test delete confirmation flow
- [ ] Delete page and verify redirect to home
- [ ] Verify error handling for network failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)