### PR TITLE
feat(ui): add hamburger menu navigation for mobile UI

### DIFF
--- a/apps/ui/src/components/HamburgerMenu.css
+++ b/apps/ui/src/components/HamburgerMenu.css
@@ -1,0 +1,180 @@
+/* Hamburger Menu - iOS Mail App Style */
+
+/* Hamburger Button */
+.hamburger-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: transparent;
+  border: none;
+  color: #007aff;
+  cursor: pointer;
+  padding: 0;
+  transition: opacity 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.hamburger-button:active {
+  opacity: 0.6;
+}
+
+/* Overlay */
+.hamburger-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Drawer */
+.hamburger-drawer {
+  position: fixed;
+  top: 0;
+  left: -280px;
+  width: 280px;
+  height: 100%;
+  background: #f2f2f7;
+  z-index: 1001;
+  transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+}
+
+.hamburger-drawer.open {
+  left: 0;
+}
+
+/* Header */
+.hamburger-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: #f2f2f7;
+  border-bottom: 0.5px solid #c6c6c8;
+  min-height: 56px;
+}
+
+.hamburger-header h2 {
+  margin: 0;
+  font-size: 34px;
+  font-weight: 700;
+  color: #000;
+  letter-spacing: 0.4px;
+}
+
+.hamburger-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: transparent;
+  border: none;
+  color: #007aff;
+  cursor: pointer;
+  padding: 0;
+  transition: opacity 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.hamburger-close:active {
+  opacity: 0.6;
+}
+
+/* Navigation */
+.hamburger-nav {
+  flex: 1;
+  overflow-y: auto;
+  background: #fff;
+  -webkit-overflow-scrolling: touch;
+}
+
+.hamburger-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: #fff;
+  border-bottom: 0.5px solid #c6c6c8;
+  text-decoration: none;
+  color: #000;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.hamburger-nav-item:active {
+  background: #e5e5ea;
+}
+
+.hamburger-nav-item.active {
+  background: rgba(0, 122, 255, 0.05);
+}
+
+.hamburger-nav-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: rgba(142, 142, 147, 0.1);
+  flex-shrink: 0;
+}
+
+.hamburger-emoji {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.hamburger-nav-label {
+  flex: 1;
+  font-size: 17px;
+  font-weight: 400;
+  color: #000;
+}
+
+.hamburger-nav-item.active .hamburger-nav-label {
+  font-weight: 600;
+}
+
+.hamburger-nav-check {
+  color: #007aff;
+  flex-shrink: 0;
+}
+
+/* iOS Safe Area Support */
+@supports (padding: max(0px)) {
+  .hamburger-header {
+    padding-top: max(12px, env(safe-area-inset-top));
+    padding-left: max(16px, env(safe-area-inset-left));
+    padding-right: max(16px, env(safe-area-inset-right));
+  }
+
+  .hamburger-nav-item {
+    padding-left: max(16px, env(safe-area-inset-left));
+    padding-right: max(16px, env(safe-area-inset-right));
+  }
+}
+
+/* Prevent body scroll when menu is open */
+body.hamburger-menu-open {
+  overflow: hidden;
+}

--- a/apps/ui/src/components/HamburgerMenu.tsx
+++ b/apps/ui/src/components/HamburgerMenu.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import './HamburgerMenu.css';
+
+export function HamburgerMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+  const location = useLocation();
+
+  const toggleMenu = () => setIsOpen(!isOpen);
+  const closeMenu = () => setIsOpen(false);
+
+  const menuItems = [
+    {
+      name: 'Home',
+      path: '/',
+      icon: (
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+          <polyline points="9 22 9 12 15 12 15 22" />
+        </svg>
+      ),
+      color: '#8e8e93',
+    },
+    {
+      name: 'Taskeroo',
+      path: '/taskeroo',
+      icon: '📋',
+      color: '#3b82f6',
+    },
+    {
+      name: 'Wikiroo',
+      path: '/wikiroo',
+      icon: '📚',
+      color: '#10b981',
+    },
+    {
+      name: 'MCP Registry',
+      path: '/mcp-registry',
+      icon: '🔌',
+      color: '#8b5cf6',
+    },
+  ];
+
+  return (
+    <>
+      {/* Hamburger Button */}
+      <button
+        className="hamburger-button"
+        onClick={toggleMenu}
+        aria-label="Menu"
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </button>
+
+      {/* Overlay */}
+      {isOpen && (
+        <div
+          className="hamburger-overlay"
+          onClick={closeMenu}
+        />
+      )}
+
+      {/* Drawer */}
+      <div className={`hamburger-drawer ${isOpen ? 'open' : ''}`}>
+        <div className="hamburger-header">
+          <h2>Menu</h2>
+          <button
+            className="hamburger-close"
+            onClick={closeMenu}
+            aria-label="Close menu"
+          >
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <nav className="hamburger-nav">
+          {menuItems.map((item) => {
+            const isActive = location.pathname === item.path ||
+              (item.path !== '/' && location.pathname.startsWith(item.path));
+
+            return (
+              <Link
+                key={item.path}
+                to={item.path}
+                className={`hamburger-nav-item ${isActive ? 'active' : ''}`}
+                onClick={closeMenu}
+              >
+                <div className="hamburger-nav-icon" style={{ color: item.color }}>
+                  {typeof item.icon === 'string' ? (
+                    <span className="hamburger-emoji">{item.icon}</span>
+                  ) : (
+                    item.icon
+                  )}
+                </div>
+                <span className="hamburger-nav-label">{item.name}</span>
+                {isActive && (
+                  <svg
+                    className="hamburger-nav-check"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </>
+  );
+}

--- a/apps/ui/src/taskeroo/TaskBoardMobile.css
+++ b/apps/ui/src/taskeroo/TaskBoardMobile.css
@@ -22,6 +22,7 @@
   justify-content: space-between;
   padding: 12px 16px;
   min-height: 44px;
+  gap: 12px;
 }
 
 .mobile-header h1 {

--- a/apps/ui/src/taskeroo/TaskBoardMobile.tsx
+++ b/apps/ui/src/taskeroo/TaskBoardMobile.tsx
@@ -6,6 +6,7 @@ import { useTaskeroo } from './useTaskeroo';
 import { Task, TaskStatus } from './types';
 import { usePageTitle } from '../hooks/usePageTitle';
 import { TagBadge } from './TagBadge';
+import { HamburgerMenu } from '../components/HamburgerMenu';
 
 export function TaskBoardMobile() {
   const { tasks, isConnected } = useTaskeroo();
@@ -55,6 +56,7 @@ export function TaskBoardMobile() {
       {/* Header */}
       <div className="mobile-header">
         <div className="mobile-header-content">
+          <HamburgerMenu />
           <h1>Taskeroo</h1>
           <span className={`mobile-status-dot ${isConnected ? 'connected' : 'disconnected'}`} />
         </div>


### PR DESCRIPTION
## Summary
- Created HamburgerMenu component with iOS Mail app styling
- Added slide-out drawer navigation to mobile TaskBoard
- Includes navigation to Home, Taskeroo, Wikiroo, and MCP Registry
- Active state indicators with checkmarks
- Smooth animations and iOS-style design

## Test plan
- [ ] Test on mobile device or responsive view (width < 768px)
- [ ] Click hamburger icon to open menu
- [ ] Verify navigation to all sections works
- [ ] Check active state highlighting
- [ ] Verify drawer closes when clicking overlay
- [ ] Test iOS safe area support on notched devices
- [ ] Ensure build passes (`npm run build:prod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)