### PR TITLE
feat(taskeroo): mobile-friendly task modal UI

### DIFF
--- a/apps/ui/src/taskeroo/TaskBoard.css
+++ b/apps/ui/src/taskeroo/TaskBoard.css
@@ -795,7 +795,123 @@ form {
     align-items: flex-start;
   }
 
-  .review-shortcuts {
+  /* Mobile modal optimizations */
+  .modal-overlay {
+    padding: 0;
+    align-items: flex-end;
+  }
+
+  .modal-content {
+    max-width: 100%;
+    width: 100%;
+    max-height: 95vh;
+    border-radius: 16px 16px 0 0;
+    margin: 0;
+  }
+
+  .modal-header {
+    padding: 12px 16px;
+    position: sticky;
+    top: 0;
+    background: white;
+    z-index: 10;
+    border-bottom: 1px solid #ecf0f1;
+  }
+
+  .modal-header h2 {
+    font-size: 18px;
+  }
+
+  /* Form optimizations */
+  form {
+    padding: 0 16px 16px 16px;
+  }
+
+  .form-group {
+    margin-bottom: 16px;
+  }
+
+  .form-group input,
+  .form-group textarea {
+    font-size: 16px; /* Prevents iOS zoom */
+    padding: 12px 14px; /* Better touch targets */
+  }
+
+  /* Task detail optimizations */
+  .detail-section {
+    padding: 12px 16px;
+  }
+
+  .detail-section h3 {
+    font-size: 13px;
+    margin-bottom: 10px;
+  }
+
+  /* Status buttons wrap on mobile */
+  .status-buttons {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .status-btn {
+    flex: 1 1 calc(50% - 4px); /* 2 buttons per row */
+    min-width: 0;
+    padding: 10px 12px;
+    font-size: 13px;
+  }
+
+  /* Assignee form - stack vertically */
+  .form-row {
     flex-direction: column;
+  }
+
+  .form-field {
+    width: 100%;
+  }
+
+  /* Comments list */
+  .comments-list {
+    max-height: 200px;
+  }
+
+  .add-comment input,
+  .add-comment textarea {
+    font-size: 16px; /* Prevents iOS zoom */
+  }
+
+  /* Action buttons */
+  .form-actions {
+    gap: 8px;
+    flex-direction: column-reverse;
+  }
+
+  .form-actions button {
+    width: 100%;
+  }
+
+  .task-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .review-shortcuts {
+    display: flex;
+    gap: 8px;
+    width: 100%;
+  }
+
+  .review-shortcuts button {
+    flex: 1;
+  }
+
+  .delete-confirm {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .delete-confirm button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- Made task modals (TaskDetail and CreateTaskForm) mobile-friendly with responsive CSS
- Modal now slides up from bottom on mobile devices (sheet-style UI)
- Status buttons wrap to 2-column grid on narrow screens
- Form inputs use 16px font to prevent iOS zoom
- Better touch targets throughout

## Changes
- Added comprehensive mobile breakpoint styles (@media max-width: 768px)
- Modal transitions to full-width bottom sheet on mobile
- Sticky modal header for better scrolling UX
- Action buttons stack vertically with full width
- Optimized padding and font sizes for compact mobile layout

## Test plan
- [ ] Test modal on desktop (should remain unchanged)
- [ ] Test modal on mobile/tablet (<768px width)
- [ ] Verify status buttons wrap properly on narrow screens
- [ ] Verify iOS doesn't zoom when focusing inputs
- [ ] Test TaskDetail modal on mobile
- [ ] Test CreateTaskForm modal on mobile
- [ ] Verify all buttons are touch-friendly

🤖 Generated with [Claude Code](https://claude.com/claude-code)