### PR TITLE
feat(wikiroo): redesign page detail view UI

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -287,6 +287,81 @@
   color: #e74c3c;
 }
 
+/* Page Detail View Styles */
+.wikiroo-page-navigation {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.wikiroo-page-detail {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 48px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.wikiroo-page-detail-header {
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #ecf0f1;
+}
+
+.wikiroo-page-detail-title {
+  margin: 0 0 12px 0;
+  font-size: 42px;
+  font-weight: 700;
+  color: #2c3e50;
+  line-height: 1.2;
+}
+
+.wikiroo-page-detail-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  color: #95a5a6;
+  font-size: 14px;
+}
+
+.wikiroo-page-detail-meta span {
+  white-space: nowrap;
+}
+
+.wikiroo-page-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 32px;
+}
+
+.wikiroo-page-detail-content {
+  margin-bottom: 48px;
+  font-size: 16px;
+  line-height: 1.8;
+  color: #2c3e50;
+}
+
+.wikiroo-page-detail-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-start;
+  padding-top: 24px;
+  border-top: 1px solid #ecf0f1;
+}
+
+.wikiroo-button-danger {
+  background: #e74c3c;
+  color: #ffffff;
+}
+
+.wikiroo-button-danger:not(:disabled):hover {
+  background: #c0392b;
+  box-shadow: 0 4px 12px rgba(231, 76, 60, 0.3);
+}
+
 @media (max-width: 768px) {
   .wikiroo {
     padding: 16px;
@@ -295,5 +370,17 @@
   .wikiroo-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .wikiroo-page-detail {
+    padding: 24px;
+  }
+
+  .wikiroo-page-detail-title {
+    font-size: 32px;
+  }
+
+  .wikiroo-page-detail-meta {
+    flex-wrap: wrap;
   }
 }

--- a/apps/ui/src/wikiroo/WikirooMobile.css
+++ b/apps/ui/src/wikiroo/WikirooMobile.css
@@ -622,3 +622,95 @@
   color: #ff3b30;
   font-size: 17px;
 }
+
+/* New Page Detail View Styles */
+.mobile-wikiroo-page-detail {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  background: #fff;
+  padding: 20px 16px;
+}
+
+.mobile-wikiroo-page-detail-title {
+  font-size: 32px;
+  font-weight: 700;
+  color: #000;
+  margin: 0 0 12px 0;
+  line-height: 1.2;
+}
+
+.mobile-wikiroo-page-detail-meta {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: #8e8e93;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 0.5px solid #e5e5ea;
+}
+
+.mobile-wikiroo-page-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+
+.mobile-wikiroo-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+}
+
+.mobile-wikiroo-page-detail-content {
+  margin-bottom: 32px;
+  font-size: 16px;
+  line-height: 1.6;
+  color: #000;
+}
+
+.mobile-wikiroo-page-detail-actions {
+  display: flex;
+  gap: 12px;
+  padding-top: 20px;
+  border-top: 0.5px solid #e5e5ea;
+}
+
+.mobile-wikiroo-action-button {
+  flex: 1;
+  padding: 14px;
+  border: none;
+  border-radius: 12px;
+  font-size: 17px;
+  font-weight: 600;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: opacity 0.2s ease;
+}
+
+.mobile-wikiroo-action-button:active {
+  opacity: 0.7;
+}
+
+.mobile-wikiroo-action-button:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.mobile-wikiroo-edit-button {
+  background: #007aff;
+  color: #fff;
+}
+
+.mobile-wikiroo-delete-button {
+  background: #ff3b30;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- Redesigned wikiroo page detail view with clean, elegant layout
- Large title at the top with prominent font
- Author and date metadata in small, subtle font below title
- Tags displayed as elegant chips that are not distracting
- Main content area with proper spacing and typography
- Edit and Delete buttons positioned at the bottom
- Added delete confirmation dialog (same pattern as MCP registry)
- Implemented for both desktop and mobile views

## Implementation Details
- Updated WikirooPageView.tsx with new layout structure
- Updated WikirooPageViewMobile.tsx to match design
- Added new CSS styles for page detail sections
- Integrated ConfirmDialog component for delete confirmation
- Maintained existing functionality while improving UX

## Test Plan
- [x] Build passes successfully
- [ ] Verify page detail view displays correctly on desktop
- [ ] Verify page detail view displays correctly on mobile
- [ ] Test edit button opens edit modal
- [ ] Test delete button shows confirmation dialog
- [ ] Test delete confirmation works as expected
- [ ] Verify tags display as elegant chips
- [ ] Check metadata formatting (author, dates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)