### PR TITLE
fix(wikiroo): remove white background container from page detail

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -296,12 +296,9 @@
 }
 
 .wikiroo-page-detail {
-  background: #ffffff;
-  border-radius: 16px;
-  padding: 48px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
   max-width: 900px;
   margin: 0 auto;
+  padding: 0 24px;
 }
 
 .wikiroo-page-detail-header {
@@ -373,7 +370,7 @@
   }
 
   .wikiroo-page-detail {
-    padding: 24px;
+    padding: 0 16px;
   }
 
   .wikiroo-page-detail-title {

--- a/apps/ui/src/wikiroo/WikirooMobile.css
+++ b/apps/ui/src/wikiroo/WikirooMobile.css
@@ -628,7 +628,6 @@
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  background: #fff;
   padding: 20px 16px;
 }
 


### PR DESCRIPTION
## Summary
- Removed white card/bubble wrapper from page detail view
- Content now sits directly against the page background

## Changes
- Removed background, border-radius, and box-shadow from page detail container
- Reduced padding to simple horizontal spacing
- Applied fix to both desktop and mobile views
- Updated responsive styles for consistency

## Context
Addressing feedback from previous PR - the white background container was too visually heavy. The content now sits cleanly against the page background (#f8f9fa on desktop, #f2f2f7 on mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)