### PR TITLE
feat(wikiroo): unify create/edit page UI and restrict tag deletion

### DIFF
--- a/apps/ui/src/wikiroo/WikiPageForm.tsx
+++ b/apps/ui/src/wikiroo/WikiPageForm.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect, FormEvent } from 'react';
+import type { WikiPage } from './types';
+import type { CreatePageDto, UpdatePageDto } from 'shared';
+import { TagInput } from './TagInput';
+
+type WikiPageFormProps =
+  | {
+      mode: 'create';
+      page?: never;
+      onSubmit: (data: CreatePageDto) => Promise<void>;
+      onCancel: () => void;
+      isSubmitting: boolean;
+    }
+  | {
+      mode: 'edit';
+      page: WikiPage;
+      onSubmit: (data: UpdatePageDto) => Promise<void>;
+      onCancel: () => void;
+      isSubmitting: boolean;
+    };
+
+export function WikiPageForm({
+  mode,
+  page,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}: WikiPageFormProps) {
+  const [title, setTitle] = useState(page?.title || '');
+  const [content, setContent] = useState(page?.content || '');
+  const [author, setAuthor] = useState(page?.author || '');
+  const [tagNames, setTagNames] = useState<string[]>(page?.tags?.map(t => t.name) || []);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onCancel]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    try {
+      if (mode === 'create') {
+        // Create mode: send all fields
+        const payload: CreatePageDto = {
+          title: title.trim(),
+          author: author.trim(),
+          content: content.trim(),
+          ...(tagNames.length > 0 && { tagNames }),
+        };
+        await onSubmit(payload);
+      } else {
+        // Edit mode: only send changed fields
+        const payload: UpdatePageDto = {};
+        let hasChanges = false;
+
+        if (title !== page.title) {
+          payload.title = title;
+          hasChanges = true;
+        }
+        if (content !== page.content) {
+          payload.content = content;
+          hasChanges = true;
+        }
+        if (author !== page.author) {
+          payload.author = author;
+          hasChanges = true;
+        }
+
+        const currentTagNames = page.tags?.map(t => t.name) || [];
+        const tagsChanged = JSON.stringify(tagNames.sort()) !== JSON.stringify(currentTagNames.sort());
+        if (tagsChanged) {
+          payload.tagNames = tagNames;
+          hasChanges = true;
+        }
+
+        if (!hasChanges) {
+          setErrorMessage('No changes to save');
+          return;
+        }
+
+        await onSubmit(payload);
+      }
+      setErrorMessage('');
+    } catch (err: any) {
+      const errorMsg = err?.body?.detail || err?.message || `Failed to ${mode === 'create' ? 'create' : 'update'} page`;
+      setErrorMessage(errorMsg);
+    }
+  };
+
+  return (
+    <form className="wikiroo-form" onSubmit={handleSubmit}>
+      {errorMessage && (
+        <div className="wikiroo-error" style={{ margin: '0 0 16px 0' }}>
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="wikiroo-form-group">
+        <label htmlFor={`${mode}-title`}>Title *</label>
+        <input
+          id={`${mode}-title`}
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Give your page a headline"
+          required
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div className="wikiroo-form-group">
+        <label htmlFor={`${mode}-author`}>Author *</label>
+        <input
+          id={`${mode}-author`}
+          type="text"
+          value={author}
+          onChange={(e) => setAuthor(e.target.value)}
+          placeholder="Who wrote this?"
+          required
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div className="wikiroo-form-group">
+        <label htmlFor={`${mode}-content`}>Content *</label>
+        <textarea
+          id={`${mode}-content`}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Write in markdown or plain text"
+          rows={mode === 'create' ? 6 : 15}
+          required
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div className="wikiroo-form-group">
+        <label htmlFor={`${mode}-tags`}>Tags</label>
+        <TagInput
+          value={tagNames}
+          onChange={setTagNames}
+          placeholder="Type to add tags..."
+        />
+      </div>
+
+      <div className="wikiroo-form-actions">
+        <button
+          type="button"
+          className="wikiroo-button secondary"
+          onClick={onCancel}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="wikiroo-button primary"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Saving…' : mode === 'create' ? 'Create page' : 'Save Changes'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/ui/src/wikiroo/WikirooHomePage.tsx
+++ b/apps/ui/src/wikiroo/WikirooHomePage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { HomeLink } from '../components/HomeLink';
 import './Wikiroo.css';
@@ -7,7 +7,8 @@ import { usePageTitle } from '../hooks/usePageTitle';
 import { useToast } from '../hooks/useToast';
 import { Toast } from '../components/Toast';
 import { TagBadge } from './TagBadge';
-import { TagInput } from './TagInput';
+import { WikiPageForm } from './WikiPageForm';
+import type { CreatePageDto } from 'shared';
 
 function formatDate(value: string) {
   try {
@@ -30,36 +31,13 @@ export function WikirooHomePage() {
   const navigate = useNavigate();
   const { toasts, showToast, removeToast } = useToast();
   const [showForm, setShowForm] = useState(false);
-  const [title, setTitle] = useState('');
-  const [author, setAuthor] = useState('');
-  const [content, setContent] = useState('');
-  const [tagNames, setTagNames] = useState<string[]>([]);
 
   usePageTitle('Wikiroo');
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!title.trim() || !author.trim() || !content.trim()) {
-      return;
-    }
-
-    try {
-      const created = await createPage({
-        title: title.trim(),
-        author: author.trim(),
-        content: content.trim(),
-        ...(tagNames.length > 0 && { tagNames }),
-      });
-      setTitle('');
-      setAuthor('');
-      setContent('');
-      setTagNames([]);
-      setShowForm(false);
-      navigate(`/wikiroo/${created.id}`);
-    } catch (err: any) {
-      const message = err?.body?.detail || err?.message || 'Failed to create page';
-      showToast(message, 'error');
-    }
+  const handleCreatePage = async (data: CreatePageDto) => {
+    const created = await createPage(data);
+    setShowForm(false);
+    navigate(`/wikiroo/${created.id}`);
   };
 
   return (
@@ -90,63 +68,12 @@ export function WikirooHomePage() {
       </header>
 
       {showForm && (
-        <form className="wikiroo-form" onSubmit={handleSubmit}>
-          <div className="wikiroo-form-group">
-            <label htmlFor="wikiroo-title">Title *</label>
-            <input
-              id="wikiroo-title"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="Give your page a headline"
-              required
-            />
-          </div>
-          <div className="wikiroo-form-group">
-            <label htmlFor="wikiroo-author">Author *</label>
-            <input
-              id="wikiroo-author"
-              value={author}
-              onChange={(event) => setAuthor(event.target.value)}
-              placeholder="Who wrote this?"
-              required
-            />
-          </div>
-          <div className="wikiroo-form-group">
-            <label htmlFor="wikiroo-content">Content *</label>
-            <textarea
-              id="wikiroo-content"
-              value={content}
-              onChange={(event) => setContent(event.target.value)}
-              placeholder="Write in markdown or plain text"
-              rows={6}
-              required
-            />
-          </div>
-          <div className="wikiroo-form-group">
-            <label htmlFor="wikiroo-tags">Tags</label>
-            <TagInput
-              value={tagNames}
-              onChange={setTagNames}
-              placeholder="Type to add tags..."
-            />
-          </div>
-          <div className="wikiroo-form-actions">
-            <button
-              type="button"
-              className="wikiroo-button secondary"
-              onClick={() => setShowForm(false)}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="wikiroo-button primary"
-              disabled={isCreating}
-            >
-              {isCreating ? 'Saving…' : 'Create page'}
-            </button>
-          </div>
-        </form>
+        <WikiPageForm
+          mode="create"
+          onSubmit={handleCreatePage}
+          onCancel={() => setShowForm(false)}
+          isSubmitting={isCreating}
+        />
       )}
 
       <section className="wikiroo-grid" aria-live="polite">


### PR DESCRIPTION
## Summary
- Created a unified `WikiPageForm` component that handles both create and edit modes with the same simple UI
- Edit mode now opens an inline form instead of a modal, matching the create page experience  
- Removed tag deletion functionality from page view - users can only add/remove tags in edit mode
- Applied changes to both desktop and mobile views

## Implementation Details
- **New component**: `WikiPageForm.tsx` with discriminated union types for type-safe create vs edit operations
- **Updated components**:
  - `WikirooHomePage.tsx`: Simplified to use unified form for create
  - `WikirooPageView.tsx`: Uses unified form for edit, removed tag deletion from view
  - `WikirooPageViewMobile.tsx`: Same updates for mobile experience

## Test Plan
- [x] Build passes successfully (`npm run build:prod`)
- [ ] Manual test: Create a new page
- [ ] Manual test: Edit an existing page  
- [ ] Manual test: Verify tags cannot be deleted from page view
- [ ] Manual test: Verify tags can be added/removed in edit mode
- [ ] Manual test: Test on mobile view

🤖 Generated with [Claude Code](https://claude.com/claude-code)