### PR TITLE
fix(wikiroo): hide page detail when editing

### DIFF
--- a/apps/ui/src/wikiroo/WikirooPageView.tsx
+++ b/apps/ui/src/wikiroo/WikirooPageView.tsx
@@ -104,7 +104,7 @@ export function WikirooPageView() {
         </div>
       )}
 
-      {selectedPage && (
+      {selectedPage && !showEditForm && (
         <div className="wikiroo-page-detail">
           <div className="wikiroo-page-detail-header">
             <h1 className="wikiroo-page-detail-title">{selectedPage.title}</h1>

--- a/apps/ui/src/wikiroo/WikirooPageViewMobile.tsx
+++ b/apps/ui/src/wikiroo/WikirooPageViewMobile.tsx
@@ -117,6 +117,7 @@ export function WikirooPageViewMobile() {
       </div>
 
       {/* Page Detail */}
+      {!showEditModal && (
       <div className="mobile-wikiroo-page-detail">
         <h1 className="mobile-wikiroo-page-detail-title">{selectedPage.title}</h1>
         <div className="mobile-wikiroo-page-detail-meta">
@@ -165,6 +166,7 @@ export function WikirooPageViewMobile() {
           </button>
         </div>
       </div>
+      )}
 
       {/* Edit Modal */}
       {showEditModal && selectedPage && (


### PR DESCRIPTION
## Summary
- Fixed issue where page detail and edit form were both visible simultaneously when clicking Edit
- Now only the edit form is shown when in edit mode (page detail is hidden)

## Changes
- `WikirooPageView.tsx`: Added `!showEditForm` condition to page detail rendering (line 107)
- `WikirooPageViewMobile.tsx`: Added `!showEditModal` condition to page detail rendering (line 120)

## Test Plan
- [x] Build passes successfully
- [ ] Manual test: Click Edit button and verify only edit form is visible
- [ ] Manual test: Verify page detail is visible when not editing
- [ ] Manual test: Test on mobile view

🤖 Generated with [Claude Code](https://claude.com/claude-code)