### PR TITLE
Add Agent entity with CRUD operations

### DIFF
--- a/apps/backend/src/agents/agent.entity.ts
+++ b/apps/backend/src/agents/agent.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+  VersionColumn,
+} from 'typeorm';
+
+@Entity({ name: 'agents' })
+export class AgentEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'text', unique: true })
+  slug!: string;
+
+  @Column({ type: 'text' })
+  name!: string;
+
+  @Column({ type: 'text', nullable: true })
+  description!: string | null;
+
+  @Column({ type: 'text', name: 'system_prompt' })
+  systemPrompt!: string;
+
+  @Column({ type: 'simple-json', name: 'allowed_tools' })
+  allowedTools!: string[];
+
+  @Column({ type: 'boolean', name: 'is_active', default: true })
+  isActive!: boolean;
+
+  @Column({ type: 'integer', nullable: true, name: 'concurrency_limit' })
+  concurrencyLimit!: number | null;
+
+  @VersionColumn({ name: 'row_version' })
+  rowVersion!: number;
+
+  @CreateDateColumn({ type: 'datetime', name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'datetime', name: 'updated_at' })
+  updatedAt!: Date;
+
+  @DeleteDateColumn({ type: 'datetime', name: 'deleted_at', nullable: true })
+  deletedAt?: Date | null;
+}

--- a/apps/backend/src/agents/agents.controller.ts
+++ b/apps/backend/src/agents/agents.controller.ts
@@ -1,0 +1,122 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiOkResponse,
+  ApiCreatedResponse,
+} from '@nestjs/swagger';
+import { AgentsService } from './agents.service';
+import { CreateAgentDto } from './dto/create-agent.dto';
+import { UpdateAgentDto } from './dto/update-agent.dto';
+import { AgentResponseDto } from './dto/agent-response.dto';
+import { AgentListResponseDto } from './dto/agent-list-response.dto';
+import { ListAgentsQueryDto } from './dto/list-agents-query.dto';
+import { AgentParamsDto } from './dto/agent-params.dto';
+import { AgentResult } from './dto/service/agents.service.types';
+
+@ApiTags('Agent')
+@Controller('agents')
+export class AgentsController {
+  constructor(private readonly agentsService: AgentsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new agent' })
+  @ApiCreatedResponse({ type: AgentResponseDto })
+  async createAgent(@Body() dto: CreateAgentDto): Promise<AgentResponseDto> {
+    const result = await this.agentsService.createAgent({
+      slug: dto.slug,
+      name: dto.name,
+      description: dto.description,
+      systemPrompt: dto.systemPrompt,
+      allowedTools: dto.allowedTools,
+      isActive: dto.isActive,
+      concurrencyLimit: dto.concurrencyLimit,
+    });
+    return this.mapResultToResponse(result);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'List agents with optional filtering and pagination',
+  })
+  @ApiOkResponse({ type: AgentListResponseDto })
+  async listAgents(
+    @Query() query: ListAgentsQueryDto,
+  ): Promise<AgentListResponseDto> {
+    const result = await this.agentsService.listAgents({
+      isActive: query.isActive,
+      page: query.page ?? 1,
+      limit: query.limit ?? 20,
+    });
+
+    return {
+      items: result.items.map((item) => this.mapResultToResponse(item)),
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
+      totalPages: Math.ceil(result.total / result.limit),
+    };
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get an agent by ID' })
+  @ApiOkResponse({ type: AgentResponseDto })
+  async getAgent(@Param() params: AgentParamsDto): Promise<AgentResponseDto> {
+    const result = await this.agentsService.getAgentById(params.id);
+    return this.mapResultToResponse(result);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update an agent' })
+  @ApiOkResponse({ type: AgentResponseDto })
+  async updateAgent(
+    @Param() params: AgentParamsDto,
+    @Body() dto: UpdateAgentDto,
+  ): Promise<AgentResponseDto> {
+    const result = await this.agentsService.updateAgent(params.id, {
+      slug: dto.slug,
+      name: dto.name,
+      description: dto.description,
+      systemPrompt: dto.systemPrompt,
+      allowedTools: dto.allowedTools,
+      isActive: dto.isActive,
+      concurrencyLimit: dto.concurrencyLimit,
+    });
+    return this.mapResultToResponse(result);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete an agent' })
+  async deleteAgent(@Param() params: AgentParamsDto): Promise<void> {
+    await this.agentsService.deleteAgent(params.id);
+  }
+
+  private mapResultToResponse(result: AgentResult): AgentResponseDto {
+    return {
+      id: result.id,
+      slug: result.slug,
+      name: result.name,
+      description: result.description,
+      systemPrompt: result.systemPrompt,
+      allowedTools: result.allowedTools,
+      isActive: result.isActive,
+      concurrencyLimit: result.concurrencyLimit,
+      rowVersion: result.rowVersion,
+      createdAt: result.createdAt.toISOString(),
+      updatedAt: result.updatedAt.toISOString(),
+      deletedAt: result.deletedAt ? result.deletedAt.toISOString() : null,
+    };
+  }
+}

--- a/apps/backend/src/agents/agents.module.ts
+++ b/apps/backend/src/agents/agents.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AgentEntity } from './agent.entity';
+import { AgentsService } from './agents.service';
+import { AgentsController } from './agents.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AgentEntity])],
+  controllers: [AgentsController],
+  providers: [AgentsService],
+  exports: [AgentsService],
+})
+export class AgentsModule {}

--- a/apps/backend/src/agents/agents.service.ts
+++ b/apps/backend/src/agents/agents.service.ts
@@ -1,0 +1,208 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Repository } from 'typeorm';
+import { AgentEntity } from './agent.entity';
+import {
+  CreateAgentInput,
+  UpdateAgentInput,
+  AgentResult,
+  ListAgentsInput,
+  ListAgentsResult,
+} from './dto/service/agents.service.types';
+import {
+  AgentNotFoundError,
+  AgentSlugConflictError,
+} from './errors/agents.errors';
+import {
+  AgentCreatedEvent,
+  AgentUpdatedEvent,
+  AgentDeletedEvent,
+} from './events/agents.events';
+
+@Injectable()
+export class AgentsService {
+  private readonly logger = new Logger(AgentsService.name);
+
+  constructor(
+    @InjectRepository(AgentEntity)
+    private readonly agentRepository: Repository<AgentEntity>,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async createAgent(input: CreateAgentInput): Promise<AgentResult> {
+    this.logger.log(`Creating agent with slug: ${input.slug}`);
+
+    // Check for slug conflict
+    const existingAgent = await this.agentRepository.findOne({
+      where: { slug: input.slug },
+    });
+
+    if (existingAgent) {
+      throw new AgentSlugConflictError(input.slug);
+    }
+
+    const agent = this.agentRepository.create({
+      slug: input.slug,
+      name: input.name,
+      description: input.description ?? null,
+      systemPrompt: input.systemPrompt,
+      allowedTools: input.allowedTools,
+      isActive: input.isActive ?? true,
+      concurrencyLimit: input.concurrencyLimit ?? null,
+    });
+
+    const savedAgent = await this.agentRepository.save(agent);
+
+    // Load with relations (none for now, but following the pattern)
+    const agentWithRelations = await this.agentRepository.findOne({
+      where: { id: savedAgent.id },
+    });
+
+    if (!agentWithRelations) {
+      throw new AgentNotFoundError(savedAgent.id);
+    }
+
+    this.eventEmitter.emit(
+      'agent.created',
+      new AgentCreatedEvent(agentWithRelations),
+    );
+
+    return this.mapAgentToResult(agentWithRelations);
+  }
+
+  async listAgents(input: ListAgentsInput): Promise<ListAgentsResult> {
+    this.logger.log(
+      `Listing agents with filters: ${JSON.stringify(input)}`,
+    );
+
+    const skip = (input.page - 1) * input.limit;
+
+    const whereClause: Record<string, unknown> = {};
+    if (input.isActive !== undefined) {
+      whereClause.isActive = input.isActive;
+    }
+
+    const [agents, total] = await this.agentRepository.findAndCount({
+      where: whereClause,
+      order: { createdAt: 'DESC' },
+      skip,
+      take: input.limit,
+    });
+
+    return {
+      items: agents.map((agent) => this.mapAgentToResult(agent)),
+      total,
+      page: input.page,
+      limit: input.limit,
+    };
+  }
+
+  async getAgentById(agentId: string): Promise<AgentResult> {
+    this.logger.log(`Getting agent by ID: ${agentId}`);
+
+    const agent = await this.agentRepository.findOne({
+      where: { id: agentId },
+    });
+
+    if (!agent) {
+      throw new AgentNotFoundError(agentId);
+    }
+
+    return this.mapAgentToResult(agent);
+  }
+
+  async getAgentBySlug(slug: string): Promise<AgentResult> {
+    this.logger.log(`Getting agent by slug: ${slug}`);
+
+    const agent = await this.agentRepository.findOne({
+      where: { slug },
+    });
+
+    if (!agent) {
+      throw new AgentNotFoundError(slug);
+    }
+
+    return this.mapAgentToResult(agent);
+  }
+
+  async updateAgent(
+    agentId: string,
+    input: UpdateAgentInput,
+  ): Promise<AgentResult> {
+    this.logger.log(`Updating agent: ${agentId}`);
+
+    const agent = await this.agentRepository.findOne({
+      where: { id: agentId },
+    });
+
+    if (!agent) {
+      throw new AgentNotFoundError(agentId);
+    }
+
+    // Check for slug conflict if slug is being updated
+    if (input.slug !== undefined && input.slug !== agent.slug) {
+      const existingAgent = await this.agentRepository.findOne({
+        where: { slug: input.slug },
+      });
+
+      if (existingAgent) {
+        throw new AgentSlugConflictError(input.slug);
+      }
+    }
+
+    // Apply partial updates
+    if (input.slug !== undefined) agent.slug = input.slug;
+    if (input.name !== undefined) agent.name = input.name;
+    if (input.description !== undefined) agent.description = input.description;
+    if (input.systemPrompt !== undefined)
+      agent.systemPrompt = input.systemPrompt;
+    if (input.allowedTools !== undefined)
+      agent.allowedTools = input.allowedTools;
+    if (input.isActive !== undefined) agent.isActive = input.isActive;
+    if (input.concurrencyLimit !== undefined)
+      agent.concurrencyLimit = input.concurrencyLimit;
+
+    const updatedAgent = await this.agentRepository.save(agent);
+
+    this.eventEmitter.emit(
+      'agent.updated',
+      new AgentUpdatedEvent(updatedAgent),
+    );
+
+    return this.mapAgentToResult(updatedAgent);
+  }
+
+  async deleteAgent(agentId: string): Promise<void> {
+    this.logger.log(`Deleting agent: ${agentId}`);
+
+    const agent = await this.agentRepository.findOne({
+      where: { id: agentId },
+    });
+
+    if (!agent) {
+      throw new AgentNotFoundError(agentId);
+    }
+
+    await this.agentRepository.softRemove(agent);
+
+    this.eventEmitter.emit('agent.deleted', new AgentDeletedEvent(agentId));
+  }
+
+  private mapAgentToResult(agent: AgentEntity): AgentResult {
+    return {
+      id: agent.id,
+      slug: agent.slug,
+      name: agent.name,
+      description: agent.description,
+      systemPrompt: agent.systemPrompt,
+      allowedTools: agent.allowedTools,
+      isActive: agent.isActive,
+      concurrencyLimit: agent.concurrencyLimit,
+      rowVersion: agent.rowVersion,
+      createdAt: agent.createdAt,
+      updatedAt: agent.updatedAt,
+      deletedAt: agent.deletedAt ?? null,
+    };
+  }
+}

--- a/apps/backend/src/agents/dto/agent-list-response.dto.ts
+++ b/apps/backend/src/agents/dto/agent-list-response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+import { AgentResponseDto } from './agent-response.dto';
+
+export class AgentListResponseDto {
+  @ApiProperty({
+    description: 'List of agents',
+    type: [AgentResponseDto],
+  })
+  @ValidateNested({ each: true })
+  @Type(() => AgentResponseDto)
+  items!: AgentResponseDto[];
+
+  @ApiProperty({
+    description: 'Total number of agents matching the query',
+    example: 42,
+  })
+  total!: number;
+
+  @ApiProperty({
+    description: 'Current page number',
+    example: 1,
+  })
+  page!: number;
+
+  @ApiProperty({
+    description: 'Number of items per page',
+    example: 20,
+  })
+  limit!: number;
+
+  @ApiProperty({
+    description: 'Total number of pages',
+    example: 3,
+  })
+  totalPages!: number;
+}

--- a/apps/backend/src/agents/dto/agent-params.dto.ts
+++ b/apps/backend/src/agents/dto/agent-params.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AgentParamsDto {
+  @ApiProperty({
+    description: 'Agent ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+}

--- a/apps/backend/src/agents/dto/agent-response.dto.ts
+++ b/apps/backend/src/agents/dto/agent-response.dto.ts
@@ -1,0 +1,76 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AgentResponseDto {
+  @ApiProperty({
+    description: 'Unique identifier for the agent',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'Unique, human-readable identifier',
+    example: 'buddy',
+  })
+  slug!: string;
+
+  @ApiProperty({
+    description: 'Display name for the agent',
+    example: 'Buddy',
+  })
+  name!: string;
+
+  @ApiPropertyOptional({
+    description: 'Short description of what this agent does',
+    example: 'A helpful assistant agent',
+  })
+  description!: string | null;
+
+  @ApiProperty({
+    description: 'Core instructions/persona for this agent',
+    example: 'You are a helpful assistant that helps users with tasks.',
+  })
+  systemPrompt!: string;
+
+  @ApiProperty({
+    description: 'List of tool identifiers this agent is allowed to use',
+    example: ['taskeroo.createTask', 'taskeroo.readTask', 'wikiroo.search'],
+    type: [String],
+  })
+  allowedTools!: string[];
+
+  @ApiProperty({
+    description: 'Whether this agent is available for assignment',
+    example: true,
+  })
+  isActive!: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Max number of tasks this agent can process in parallel',
+    example: 5,
+  })
+  concurrencyLimit!: number | null;
+
+  @ApiProperty({
+    description: 'Row version for optimistic locking',
+    example: 1,
+  })
+  rowVersion!: number;
+
+  @ApiProperty({
+    description: 'Agent creation timestamp',
+    example: '2025-11-28T10:30:00.000Z',
+  })
+  createdAt!: string;
+
+  @ApiProperty({
+    description: 'Agent last update timestamp',
+    example: '2025-11-28T10:30:00.000Z',
+  })
+  updatedAt!: string;
+
+  @ApiPropertyOptional({
+    description: 'Agent deletion timestamp (soft delete)',
+    example: null,
+  })
+  deletedAt!: string | null;
+}

--- a/apps/backend/src/agents/dto/create-agent.dto.ts
+++ b/apps/backend/src/agents/dto/create-agent.dto.ts
@@ -1,0 +1,71 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsArray,
+  IsBoolean,
+  IsInt,
+  Min,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateAgentDto {
+  @ApiProperty({
+    description: 'Unique, human-readable identifier for the agent',
+    example: 'buddy',
+  })
+  @IsString()
+  @IsNotEmpty()
+  slug!: string;
+
+  @ApiProperty({
+    description: 'Display name for the agent',
+    example: 'Buddy',
+  })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiPropertyOptional({
+    description: 'Short description of what this agent does',
+    example: 'A helpful assistant agent',
+  })
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @ApiProperty({
+    description: 'Core instructions/persona for this agent',
+    example: 'You are a helpful assistant that helps users with tasks.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  systemPrompt!: string;
+
+  @ApiProperty({
+    description: 'List of tool identifiers this agent is allowed to use',
+    example: ['taskeroo.createTask', 'taskeroo.readTask', 'wikiroo.search'],
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  allowedTools!: string[];
+
+  @ApiPropertyOptional({
+    description: 'Whether this agent is available for assignment',
+    example: true,
+    default: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Max number of tasks this agent can process in parallel',
+    example: 5,
+  })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  concurrencyLimit?: number;
+}

--- a/apps/backend/src/agents/dto/list-agents-query.dto.ts
+++ b/apps/backend/src/agents/dto/list-agents-query.dto.ts
@@ -1,0 +1,36 @@
+import { IsOptional, IsBoolean, IsInt, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class ListAgentsQueryDto {
+  @ApiPropertyOptional({
+    description: 'Filter by active status',
+    example: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  @Type(() => Boolean)
+  isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Page number for pagination',
+    example: 1,
+    default: 1,
+  })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  @Type(() => Number)
+  page?: number;
+
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    example: 20,
+    default: 20,
+  })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number;
+}

--- a/apps/backend/src/agents/dto/service/agents.service.types.ts
+++ b/apps/backend/src/agents/dto/service/agents.service.types.ts
@@ -1,0 +1,47 @@
+export type CreateAgentInput = {
+  slug: string;
+  name: string;
+  description?: string;
+  systemPrompt: string;
+  allowedTools: string[];
+  isActive?: boolean;
+  concurrencyLimit?: number;
+};
+
+export type UpdateAgentInput = {
+  slug?: string;
+  name?: string;
+  description?: string;
+  systemPrompt?: string;
+  allowedTools?: string[];
+  isActive?: boolean;
+  concurrencyLimit?: number;
+};
+
+export type AgentResult = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  systemPrompt: string;
+  allowedTools: string[];
+  isActive: boolean;
+  concurrencyLimit: number | null;
+  rowVersion: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+};
+
+export type ListAgentsInput = {
+  isActive?: boolean;
+  page: number;
+  limit: number;
+};
+
+export type ListAgentsResult = {
+  items: AgentResult[];
+  total: number;
+  page: number;
+  limit: number;
+};

--- a/apps/backend/src/agents/dto/update-agent.dto.ts
+++ b/apps/backend/src/agents/dto/update-agent.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAgentDto } from './create-agent.dto';
+
+export class UpdateAgentDto extends PartialType(CreateAgentDto) {}

--- a/apps/backend/src/agents/errors/agents.errors.ts
+++ b/apps/backend/src/agents/errors/agents.errors.ts
@@ -1,0 +1,33 @@
+import { ErrorCodes } from '../../../../../packages/shared/errors/error-codes';
+
+export const AgentsErrorCodes = {
+  AGENT_NOT_FOUND: ErrorCodes.AGENT_NOT_FOUND,
+  AGENT_SLUG_CONFLICT: ErrorCodes.AGENT_SLUG_CONFLICT,
+} as const;
+
+export abstract class AgentsDomainError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly context?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export class AgentNotFoundError extends AgentsDomainError {
+  constructor(agentId: string) {
+    super('Agent not found.', AgentsErrorCodes.AGENT_NOT_FOUND, { agentId });
+  }
+}
+
+export class AgentSlugConflictError extends AgentsDomainError {
+  constructor(slug: string) {
+    super(
+      'An agent with this slug already exists.',
+      AgentsErrorCodes.AGENT_SLUG_CONFLICT,
+      { slug },
+    );
+  }
+}

--- a/apps/backend/src/agents/events/agents.events.ts
+++ b/apps/backend/src/agents/events/agents.events.ts
@@ -1,0 +1,13 @@
+import { AgentEntity } from '../agent.entity';
+
+export class AgentCreatedEvent {
+  constructor(public readonly agent: AgentEntity) {}
+}
+
+export class AgentUpdatedEvent {
+  constructor(public readonly agent: AgentEntity) {}
+}
+
+export class AgentDeletedEvent {
+  constructor(public readonly agentId: string) {}
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { McpRegistryModule } from './mcp-registry/mcp-registry.module';
 import { AuthorizationServerModule } from './authorization-server/authorization-server.module';
 import { DiscoveryModule } from './discovery/discovery.module';
 import { AuthJourneysModule } from './auth-journeys/auth-journeys.module';
+import { AgentsModule } from './agents/agents.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { AuthJourneysModule } from './auth-journeys/auth-journeys.module';
     AuthJourneysModule,
     AuthorizationServerModule,
     DiscoveryModule,
+    AgentsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -2368,6 +2368,189 @@
           "Discovery"
         ]
       }
+    },
+    "/api/v1/agents": {
+      "post": {
+        "operationId": "AgentsController_createAgent",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Create a new agent",
+        "tags": [
+          "Agent"
+        ]
+      },
+      "get": {
+        "operationId": "AgentsController_listAgents",
+        "parameters": [
+          {
+            "name": "isActive",
+            "required": false,
+            "in": "query",
+            "description": "Filter by active status",
+            "schema": {
+              "example": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number for pagination",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of items per page",
+            "schema": {
+              "default": 20,
+              "example": 20,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "List agents with optional filtering and pagination",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/v1/agents/{id}": {
+      "get": {
+        "operationId": "AgentsController_getAgent",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Agent ID",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get an agent by ID",
+        "tags": [
+          "Agent"
+        ]
+      },
+      "patch": {
+        "operationId": "AgentsController_updateAgent",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Agent ID",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAgentDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Update an agent",
+        "tags": [
+          "Agent"
+        ]
+      },
+      "delete": {
+        "operationId": "AgentsController_deleteAgent",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Agent ID",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Delete an agent",
+        "tags": [
+          "Agent"
+        ]
+      }
     }
   },
   "info": {
@@ -4075,6 +4258,230 @@
           "token_endpoint_auth_methods_supported",
           "code_challenge_methods_supported"
         ]
+      },
+      "CreateAgentDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Unique, human-readable identifier for the agent",
+            "example": "buddy"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name for the agent",
+            "example": "Buddy"
+          },
+          "description": {
+            "type": "string",
+            "description": "Short description of what this agent does",
+            "example": "A helpful assistant agent"
+          },
+          "systemPrompt": {
+            "type": "string",
+            "description": "Core instructions/persona for this agent",
+            "example": "You are a helpful assistant that helps users with tasks."
+          },
+          "allowedTools": {
+            "description": "List of tool identifiers this agent is allowed to use",
+            "example": [
+              "taskeroo.createTask",
+              "taskeroo.readTask",
+              "wikiroo.search"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether this agent is available for assignment",
+            "example": true,
+            "default": true
+          },
+          "concurrencyLimit": {
+            "type": "number",
+            "description": "Max number of tasks this agent can process in parallel",
+            "example": 5
+          }
+        },
+        "required": [
+          "slug",
+          "name",
+          "systemPrompt",
+          "allowedTools"
+        ]
+      },
+      "AgentResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the agent",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "slug": {
+            "type": "string",
+            "description": "Unique, human-readable identifier",
+            "example": "buddy"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name for the agent",
+            "example": "Buddy"
+          },
+          "description": {
+            "type": "object",
+            "description": "Short description of what this agent does",
+            "example": "A helpful assistant agent"
+          },
+          "systemPrompt": {
+            "type": "string",
+            "description": "Core instructions/persona for this agent",
+            "example": "You are a helpful assistant that helps users with tasks."
+          },
+          "allowedTools": {
+            "description": "List of tool identifiers this agent is allowed to use",
+            "example": [
+              "taskeroo.createTask",
+              "taskeroo.readTask",
+              "wikiroo.search"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether this agent is available for assignment",
+            "example": true
+          },
+          "concurrencyLimit": {
+            "type": "object",
+            "description": "Max number of tasks this agent can process in parallel",
+            "example": 5
+          },
+          "rowVersion": {
+            "type": "number",
+            "description": "Row version for optimistic locking",
+            "example": 1
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Agent creation timestamp",
+            "example": "2025-11-28T10:30:00.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Agent last update timestamp",
+            "example": "2025-11-28T10:30:00.000Z"
+          },
+          "deletedAt": {
+            "type": "object",
+            "description": "Agent deletion timestamp (soft delete)",
+            "example": null
+          }
+        },
+        "required": [
+          "id",
+          "slug",
+          "name",
+          "systemPrompt",
+          "allowedTools",
+          "isActive",
+          "rowVersion",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "AgentListResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of agents",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentResponseDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "description": "Total number of agents matching the query",
+            "example": 42
+          },
+          "page": {
+            "type": "number",
+            "description": "Current page number",
+            "example": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of items per page",
+            "example": 20
+          },
+          "totalPages": {
+            "type": "number",
+            "description": "Total number of pages",
+            "example": 3
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "limit",
+          "totalPages"
+        ]
+      },
+      "UpdateAgentDto": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Unique, human-readable identifier for the agent",
+            "example": "buddy"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name for the agent",
+            "example": "Buddy"
+          },
+          "description": {
+            "type": "string",
+            "description": "Short description of what this agent does",
+            "example": "A helpful assistant agent"
+          },
+          "systemPrompt": {
+            "type": "string",
+            "description": "Core instructions/persona for this agent",
+            "example": "You are a helpful assistant that helps users with tasks."
+          },
+          "allowedTools": {
+            "description": "List of tool identifiers this agent is allowed to use",
+            "example": [
+              "taskeroo.createTask",
+              "taskeroo.readTask",
+              "wikiroo.search"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether this agent is available for assignment",
+            "example": true,
+            "default": true
+          },
+          "concurrencyLimit": {
+            "type": "number",
+            "description": "Max number of tasks this agent can process in parallel",
+            "example": 5
+          }
+        }
       }
     }
   }

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -729,6 +729,43 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List agents with optional filtering and pagination */
+        get: operations["AgentsController_listAgents"];
+        put?: never;
+        /** Create a new agent */
+        post: operations["AgentsController_createAgent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agents/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an agent by ID */
+        get: operations["AgentsController_getAgent"];
+        put?: never;
+        post?: never;
+        /** Delete an agent */
+        delete: operations["AgentsController_deleteAgent"];
+        options?: never;
+        head?: never;
+        /** Update an agent */
+        patch: operations["AgentsController_updateAgent"];
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1891,6 +1928,180 @@ export interface components {
              *     ]
              */
             code_challenge_methods_supported: string[];
+        };
+        CreateAgentDto: {
+            /**
+             * @description Unique, human-readable identifier for the agent
+             * @example buddy
+             */
+            slug: string;
+            /**
+             * @description Display name for the agent
+             * @example Buddy
+             */
+            name: string;
+            /**
+             * @description Short description of what this agent does
+             * @example A helpful assistant agent
+             */
+            description?: string;
+            /**
+             * @description Core instructions/persona for this agent
+             * @example You are a helpful assistant that helps users with tasks.
+             */
+            systemPrompt: string;
+            /**
+             * @description List of tool identifiers this agent is allowed to use
+             * @example [
+             *       "taskeroo.createTask",
+             *       "taskeroo.readTask",
+             *       "wikiroo.search"
+             *     ]
+             */
+            allowedTools: string[];
+            /**
+             * @description Whether this agent is available for assignment
+             * @default true
+             * @example true
+             */
+            isActive: boolean;
+            /**
+             * @description Max number of tasks this agent can process in parallel
+             * @example 5
+             */
+            concurrencyLimit?: number;
+        };
+        AgentResponseDto: {
+            /**
+             * @description Unique identifier for the agent
+             * @example 123e4567-e89b-12d3-a456-426614174000
+             */
+            id: string;
+            /**
+             * @description Unique, human-readable identifier
+             * @example buddy
+             */
+            slug: string;
+            /**
+             * @description Display name for the agent
+             * @example Buddy
+             */
+            name: string;
+            /**
+             * @description Short description of what this agent does
+             * @example A helpful assistant agent
+             */
+            description?: Record<string, never>;
+            /**
+             * @description Core instructions/persona for this agent
+             * @example You are a helpful assistant that helps users with tasks.
+             */
+            systemPrompt: string;
+            /**
+             * @description List of tool identifiers this agent is allowed to use
+             * @example [
+             *       "taskeroo.createTask",
+             *       "taskeroo.readTask",
+             *       "wikiroo.search"
+             *     ]
+             */
+            allowedTools: string[];
+            /**
+             * @description Whether this agent is available for assignment
+             * @example true
+             */
+            isActive: boolean;
+            /**
+             * @description Max number of tasks this agent can process in parallel
+             * @example 5
+             */
+            concurrencyLimit?: Record<string, never>;
+            /**
+             * @description Row version for optimistic locking
+             * @example 1
+             */
+            rowVersion: number;
+            /**
+             * @description Agent creation timestamp
+             * @example 2025-11-28T10:30:00.000Z
+             */
+            createdAt: string;
+            /**
+             * @description Agent last update timestamp
+             * @example 2025-11-28T10:30:00.000Z
+             */
+            updatedAt: string;
+            /**
+             * @description Agent deletion timestamp (soft delete)
+             * @example null
+             */
+            deletedAt?: Record<string, never>;
+        };
+        AgentListResponseDto: {
+            /** @description List of agents */
+            items: components["schemas"]["AgentResponseDto"][];
+            /**
+             * @description Total number of agents matching the query
+             * @example 42
+             */
+            total: number;
+            /**
+             * @description Current page number
+             * @example 1
+             */
+            page: number;
+            /**
+             * @description Number of items per page
+             * @example 20
+             */
+            limit: number;
+            /**
+             * @description Total number of pages
+             * @example 3
+             */
+            totalPages: number;
+        };
+        UpdateAgentDto: {
+            /**
+             * @description Unique, human-readable identifier for the agent
+             * @example buddy
+             */
+            slug?: string;
+            /**
+             * @description Display name for the agent
+             * @example Buddy
+             */
+            name?: string;
+            /**
+             * @description Short description of what this agent does
+             * @example A helpful assistant agent
+             */
+            description?: string;
+            /**
+             * @description Core instructions/persona for this agent
+             * @example You are a helpful assistant that helps users with tasks.
+             */
+            systemPrompt?: string;
+            /**
+             * @description List of tool identifiers this agent is allowed to use
+             * @example [
+             *       "taskeroo.createTask",
+             *       "taskeroo.readTask",
+             *       "wikiroo.search"
+             *     ]
+             */
+            allowedTools?: string[];
+            /**
+             * @description Whether this agent is available for assignment
+             * @default true
+             * @example true
+             */
+            isActive: boolean;
+            /**
+             * @description Max number of tasks this agent can process in parallel
+             * @example 5
+             */
+            concurrencyLimit?: number;
         };
     };
     responses: never;
@@ -3801,6 +4012,123 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuthorizationServerMetadataDto"];
+                };
+            };
+        };
+    };
+    AgentsController_listAgents: {
+        parameters: {
+            query?: {
+                /** @description Filter by active status */
+                isActive?: boolean;
+                /** @description Page number for pagination */
+                page?: number;
+                /** @description Number of items per page */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentListResponseDto"];
+                };
+            };
+        };
+    };
+    AgentsController_createAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAgentDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentResponseDto"];
+                };
+            };
+        };
+    };
+    AgentsController_getAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentResponseDto"];
+                };
+            };
+        };
+    };
+    AgentsController_deleteAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AgentsController_updateAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateAgentDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentResponseDto"];
                 };
             };
         };

--- a/packages/shared/errors/error-codes.ts
+++ b/packages/shared/errors/error-codes.ts
@@ -8,6 +8,10 @@ export const ErrorCodes = {
   // Wiki errors
   PAGE_NOT_FOUND: 'PAGE_NOT_FOUND',
 
+  // Agent errors
+  AGENT_NOT_FOUND: 'AGENT_NOT_FOUND',
+  AGENT_SLUG_CONFLICT: 'AGENT_SLUG_CONFLICT',
+
   // Authorization Server - Client Registration errors
   CLIENT_ALREADY_REGISTERED: 'CLIENT_ALREADY_REGISTERED',
   CLIENT_NOT_FOUND: 'CLIENT_NOT_FOUND',

--- a/packages/shared/src/client/index.ts
+++ b/packages/shared/src/client/index.ts
@@ -9,6 +9,8 @@ export type { OpenAPIConfig } from './core/OpenAPI';
 
 export type { AddTagDto } from './models/AddTagDto';
 export type { AddWikiTagDto } from './models/AddWikiTagDto';
+export type { AgentListResponseDto } from './models/AgentListResponseDto';
+export type { AgentResponseDto } from './models/AgentResponseDto';
 export type { AppendPageDto } from './models/AppendPageDto';
 export type { AssignTaskDto } from './models/AssignTaskDto';
 export type { AuthorizationServerMetadataDto } from './models/AuthorizationServerMetadataDto';
@@ -17,6 +19,7 @@ export { ClientRegistrationResponseDto } from './models/ClientRegistrationRespon
 export type { CommentResponseDto } from './models/CommentResponseDto';
 export type { ConnectionResponseDto } from './models/ConnectionResponseDto';
 export type { ConsentDecisionDto } from './models/ConsentDecisionDto';
+export type { CreateAgentDto } from './models/CreateAgentDto';
 export type { CreateCommentDto } from './models/CreateCommentDto';
 export type { CreateConnectionDto } from './models/CreateConnectionDto';
 export type { CreateMappingDto } from './models/CreateMappingDto';
@@ -48,11 +51,13 @@ export type { TaskListResponseDto } from './models/TaskListResponseDto';
 export { TaskResponseDto } from './models/TaskResponseDto';
 export { TokenRequestDto } from './models/TokenRequestDto';
 export { TokenResponseDto } from './models/TokenResponseDto';
+export type { UpdateAgentDto } from './models/UpdateAgentDto';
 export type { UpdateConnectionDto } from './models/UpdateConnectionDto';
 export type { UpdatePageDto } from './models/UpdatePageDto';
 export type { UpdateTaskDto } from './models/UpdateTaskDto';
 export type { WikiTagResponseDto } from './models/WikiTagResponseDto';
 
+export { AgentService } from './services/AgentService';
 export { AppService } from './services/AppService';
 export { AuthorizationServerService } from './services/AuthorizationServerService';
 export { DiscoveryService } from './services/DiscoveryService';

--- a/packages/shared/src/client/models/AgentListResponseDto.ts
+++ b/packages/shared/src/client/models/AgentListResponseDto.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { AgentResponseDto } from './AgentResponseDto';
+export type AgentListResponseDto = {
+    /**
+     * List of agents
+     */
+    items: Array<AgentResponseDto>;
+    /**
+     * Total number of agents matching the query
+     */
+    total: number;
+    /**
+     * Current page number
+     */
+    page: number;
+    /**
+     * Number of items per page
+     */
+    limit: number;
+    /**
+     * Total number of pages
+     */
+    totalPages: number;
+};
+

--- a/packages/shared/src/client/models/AgentResponseDto.ts
+++ b/packages/shared/src/client/models/AgentResponseDto.ts
@@ -1,0 +1,55 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AgentResponseDto = {
+    /**
+     * Unique identifier for the agent
+     */
+    id: string;
+    /**
+     * Unique, human-readable identifier
+     */
+    slug: string;
+    /**
+     * Display name for the agent
+     */
+    name: string;
+    /**
+     * Short description of what this agent does
+     */
+    description?: Record<string, any>;
+    /**
+     * Core instructions/persona for this agent
+     */
+    systemPrompt: string;
+    /**
+     * List of tool identifiers this agent is allowed to use
+     */
+    allowedTools: Array<string>;
+    /**
+     * Whether this agent is available for assignment
+     */
+    isActive: boolean;
+    /**
+     * Max number of tasks this agent can process in parallel
+     */
+    concurrencyLimit?: Record<string, any>;
+    /**
+     * Row version for optimistic locking
+     */
+    rowVersion: number;
+    /**
+     * Agent creation timestamp
+     */
+    createdAt: string;
+    /**
+     * Agent last update timestamp
+     */
+    updatedAt: string;
+    /**
+     * Agent deletion timestamp (soft delete)
+     */
+    deletedAt?: Record<string, any>;
+};
+

--- a/packages/shared/src/client/models/CreateAgentDto.ts
+++ b/packages/shared/src/client/models/CreateAgentDto.ts
@@ -1,0 +1,35 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type CreateAgentDto = {
+    /**
+     * Unique, human-readable identifier for the agent
+     */
+    slug: string;
+    /**
+     * Display name for the agent
+     */
+    name: string;
+    /**
+     * Short description of what this agent does
+     */
+    description?: string;
+    /**
+     * Core instructions/persona for this agent
+     */
+    systemPrompt: string;
+    /**
+     * List of tool identifiers this agent is allowed to use
+     */
+    allowedTools: Array<string>;
+    /**
+     * Whether this agent is available for assignment
+     */
+    isActive?: boolean;
+    /**
+     * Max number of tasks this agent can process in parallel
+     */
+    concurrencyLimit?: number;
+};
+

--- a/packages/shared/src/client/models/UpdateAgentDto.ts
+++ b/packages/shared/src/client/models/UpdateAgentDto.ts
@@ -1,0 +1,35 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UpdateAgentDto = {
+    /**
+     * Unique, human-readable identifier for the agent
+     */
+    slug?: string;
+    /**
+     * Display name for the agent
+     */
+    name?: string;
+    /**
+     * Short description of what this agent does
+     */
+    description?: string;
+    /**
+     * Core instructions/persona for this agent
+     */
+    systemPrompt?: string;
+    /**
+     * List of tool identifiers this agent is allowed to use
+     */
+    allowedTools?: Array<string>;
+    /**
+     * Whether this agent is available for assignment
+     */
+    isActive?: boolean;
+    /**
+     * Max number of tasks this agent can process in parallel
+     */
+    concurrencyLimit?: number;
+};
+

--- a/packages/shared/src/client/services/AgentService.ts
+++ b/packages/shared/src/client/services/AgentService.ts
@@ -1,0 +1,107 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { AgentListResponseDto } from '../models/AgentListResponseDto';
+import type { AgentResponseDto } from '../models/AgentResponseDto';
+import type { CreateAgentDto } from '../models/CreateAgentDto';
+import type { UpdateAgentDto } from '../models/UpdateAgentDto';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class AgentService {
+    /**
+     * Create a new agent
+     * @param requestBody
+     * @returns AgentResponseDto
+     * @throws ApiError
+     */
+    public static agentsControllerCreateAgent(
+        requestBody: CreateAgentDto,
+    ): CancelablePromise<AgentResponseDto> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/agents',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * List agents with optional filtering and pagination
+     * @param isActive Filter by active status
+     * @param page Page number for pagination
+     * @param limit Number of items per page
+     * @returns AgentListResponseDto
+     * @throws ApiError
+     */
+    public static agentsControllerListAgents(
+        isActive?: boolean,
+        page: number = 1,
+        limit: number = 20,
+    ): CancelablePromise<AgentListResponseDto> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/agents',
+            query: {
+                'isActive': isActive,
+                'page': page,
+                'limit': limit,
+            },
+        });
+    }
+    /**
+     * Get an agent by ID
+     * @param id Agent ID
+     * @returns AgentResponseDto
+     * @throws ApiError
+     */
+    public static agentsControllerGetAgent(
+        id: string,
+    ): CancelablePromise<AgentResponseDto> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/agents/{id}',
+            path: {
+                'id': id,
+            },
+        });
+    }
+    /**
+     * Update an agent
+     * @param id Agent ID
+     * @param requestBody
+     * @returns AgentResponseDto
+     * @throws ApiError
+     */
+    public static agentsControllerUpdateAgent(
+        id: string,
+        requestBody: UpdateAgentDto,
+    ): CancelablePromise<AgentResponseDto> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/v1/agents/{id}',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Delete an agent
+     * @param id Agent ID
+     * @returns void
+     * @throws ApiError
+     */
+    public static agentsControllerDeleteAgent(
+        id: string,
+    ): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/agents/{id}',
+            path: {
+                'id': id,
+            },
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented Agent entity to represent AI agents in the system (e.g., Buddy, Architect, AdminAgent)
- Added database model with all required fields (slug, name, description, systemPrompt, allowedTools, isActive, concurrencyLimit)
- Created full CRUD service with repository pattern
- Implemented REST API endpoints (list, get, create, update, delete) 
- Added request validation via DTOs and domain error handling
- Generated TypeScript client and updated OpenAPI spec

## Test plan
- [x] Build passes successfully (`npm run build:prod`)
- [ ] CI tests pass
- [ ] Manual testing of API endpoints (can be done post-merge if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)