### PR TITLE
Create Rich Editor Component Structure

### DIFF
--- a/apps/ui/src/wikiroo/RichEditor.tsx
+++ b/apps/ui/src/wikiroo/RichEditor.tsx
@@ -1,0 +1,40 @@
+import { MarkdownPreview } from './MarkdownPreview';
+import './Wikiroo.css';
+
+interface RichEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function RichEditor({ value, onChange, placeholder, disabled }: RichEditorProps) {
+  return (
+    <div className="rich-editor">
+      <div className="rich-editor-panes">
+        <div className="rich-editor-pane rich-editor-edit">
+          <div className="rich-editor-label">Edit</div>
+          <textarea
+            className="rich-editor-textarea"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={placeholder || 'Write in markdown...'}
+            disabled={disabled}
+            aria-label="Markdown editor"
+          />
+        </div>
+
+        <div className="rich-editor-pane rich-editor-preview">
+          <div className="rich-editor-label">Preview</div>
+          <div className="rich-editor-preview-content">
+            {value ? (
+              <MarkdownPreview content={value} />
+            ) : (
+              <div className="rich-editor-empty">Nothing to preview yet</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -359,6 +359,68 @@
   box-shadow: 0 4px 12px rgba(231, 76, 60, 0.3);
 }
 
+/* Rich Editor Styles */
+.rich-editor {
+  width: 100%;
+  border: 1px solid #dce4ec;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.rich-editor-panes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  min-height: 400px;
+}
+
+.rich-editor-pane {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.rich-editor-edit {
+  border-right: 1px solid #dce4ec;
+}
+
+.rich-editor-label {
+  padding: 12px 16px;
+  background: #f8f9fa;
+  border-bottom: 1px solid #dce4ec;
+  font-size: 13px;
+  font-weight: 600;
+  color: #7f8c8d;
+}
+
+.rich-editor-textarea {
+  flex: 1;
+  border: none;
+  padding: 16px;
+  font-size: 14px;
+  font-family: inherit;
+  resize: none;
+  outline: none;
+  line-height: 1.6;
+}
+
+.rich-editor-textarea::placeholder {
+  color: #95a5a6;
+}
+
+.rich-editor-preview-content {
+  flex: 1;
+  padding: 16px;
+  overflow-y: auto;
+}
+
+.rich-editor-empty {
+  color: #95a5a6;
+  font-size: 14px;
+  font-style: italic;
+}
+
 @media (max-width: 768px) {
   .wikiroo {
     padding: 16px;
@@ -379,5 +441,19 @@
 
   .wikiroo-page-detail-meta {
     flex-wrap: wrap;
+  }
+
+  .rich-editor-panes {
+    grid-template-columns: 1fr;
+    min-height: 600px;
+  }
+
+  .rich-editor-edit {
+    border-right: none;
+    border-bottom: 1px solid #dce4ec;
+  }
+
+  .rich-editor-pane {
+    min-height: 300px;
   }
 }


### PR DESCRIPTION
## Summary
- Created RichEditor component with split-pane markdown editor layout
- Added responsive CSS styling with mobile support
- Reused existing MarkdownPreview component for live preview

## Implementation Details

### Component Structure
The RichEditor component provides a split-pane interface:
- **Left Pane**: Textarea for editing markdown
- **Right Pane**: Live preview using ReactMarkdown

### Component Interface
```typescript
interface RichEditorProps {
  value: string;
  onChange: (value: string) => void;
  placeholder?: string;
  disabled?: boolean;
}
```

### Key Features
- Clean split-pane layout with labeled sections
- Real-time markdown preview
- Reuses existing MarkdownPreview component (includes GFM and line breaks support)
- Accessible with ARIA labels
- Matches Wikiroo design system colors and styling

### Responsive Design
- **Desktop**: Side-by-side layout (50/50 split)
- **Mobile** (< 768px): Stacked vertically (edit on top, preview below)
- Proper min-heights for usability on all screen sizes

### Styling
Added CSS classes:
- `.rich-editor` - Container with border and rounded corners
- `.rich-editor-panes` - Grid layout for split panes
- `.rich-editor-pane` - Individual pane styling
- `.rich-editor-label` - Section headers
- `.rich-editor-textarea` - Text input area
- `.rich-editor-preview-content` - Preview container

## Test Plan
- [ ] Verify split-pane layout renders correctly on desktop
- [ ] Test text input and live preview functionality
- [ ] Verify markdown rendering (headings, lists, code, etc.)
- [ ] Check mobile responsive layout (stacked panes)
- [ ] Test disabled state
- [ ] Verify placeholder text displays
- [ ] Check keyboard accessibility
- [ ] Ensure styling matches Wikiroo design

🤖 Generated with [Claude Code](https://claude.com/claude-code)