### PR TITLE
Implement Slash Command Detection in Rich Editor

### DIFF
--- a/apps/ui/src/wikiroo/RichEditor.tsx
+++ b/apps/ui/src/wikiroo/RichEditor.tsx
@@ -1,4 +1,7 @@
+import { useState, useRef, KeyboardEvent } from 'react';
 import { MarkdownPreview } from './MarkdownPreview';
+import { SlashCommandMenu } from './SlashCommandMenu';
+import type { SlashCommand } from './types';
 import './Wikiroo.css';
 
 interface RichEditorProps {
@@ -8,20 +11,252 @@ interface RichEditorProps {
   disabled?: boolean;
 }
 
+interface CommandMenuState {
+  active: boolean;
+  query: string;
+  position: { x: number; y: number };
+  selectedIndex: number;
+  startPosition: number;
+}
+
 export function RichEditor({ value, onChange, placeholder, disabled }: RichEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [commandMenu, setCommandMenu] = useState<CommandMenuState>({
+    active: false,
+    query: '',
+    position: { x: 0, y: 0 },
+    selectedIndex: 0,
+    startPosition: 0,
+  });
+
+  // Define available slash commands
+  const allCommands: SlashCommand[] = [
+    {
+      id: 'h1',
+      label: '/h1',
+      description: 'Heading 1',
+      action: () => insertText('# '),
+    },
+    {
+      id: 'h2',
+      label: '/h2',
+      description: 'Heading 2',
+      action: () => insertText('## '),
+    },
+    {
+      id: 'h3',
+      label: '/h3',
+      description: 'Heading 3',
+      action: () => insertText('### '),
+    },
+    {
+      id: 'bold',
+      label: '/bold',
+      description: 'Bold text',
+      action: () => insertText('**', '**'),
+    },
+    {
+      id: 'italic',
+      label: '/italic',
+      description: 'Italic text',
+      action: () => insertText('_', '_'),
+    },
+    {
+      id: 'code',
+      label: '/code',
+      description: 'Inline code',
+      action: () => insertText('`', '`'),
+    },
+    {
+      id: 'codeblock',
+      label: '/codeblock',
+      description: 'Code block',
+      action: () => insertText('```\n', '\n```'),
+    },
+    {
+      id: 'list',
+      label: '/list',
+      description: 'Bullet list',
+      action: () => insertText('- '),
+    },
+    {
+      id: 'numbered',
+      label: '/numbered',
+      description: 'Numbered list',
+      action: () => insertText('1. '),
+    },
+    {
+      id: 'quote',
+      label: '/quote',
+      description: 'Block quote',
+      action: () => insertText('> '),
+    },
+    {
+      id: 'link',
+      label: '/link',
+      description: 'Insert link',
+      action: () => insertText('[', '](url)'),
+    },
+  ];
+
+  // Filter commands based on query
+  const filteredCommands = commandMenu.query
+    ? allCommands.filter((cmd) =>
+        cmd.label.toLowerCase().includes(commandMenu.query.toLowerCase())
+      )
+    : allCommands;
+
+  const insertText = (before: string, after: string = '') => {
+    if (!textareaRef.current) return;
+
+    const textarea = textareaRef.current;
+    const start = commandMenu.startPosition;
+    const end = textarea.selectionEnd;
+
+    // Remove the slash command text
+    const beforeSlash = value.substring(0, start);
+    const afterCommand = value.substring(end);
+
+    // Insert the new text
+    const newValue = beforeSlash + before + after + afterCommand;
+    onChange(newValue);
+
+    // Close command menu
+    setCommandMenu({ ...commandMenu, active: false });
+
+    // Set cursor position
+    setTimeout(() => {
+      const cursorPos = start + before.length;
+      textarea.focus();
+      textarea.setSelectionRange(cursorPos, cursorPos);
+    }, 0);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!commandMenu.active) {
+      // Detect "/" to open menu
+      if (e.key === '/') {
+        const textarea = textareaRef.current;
+        if (!textarea) return;
+
+        const cursorPos = textarea.selectionStart;
+        const beforeCursor = value.substring(0, cursorPos);
+
+        // Only trigger if "/" is at start of line or after whitespace
+        if (cursorPos === 0 || beforeCursor[cursorPos - 1].match(/\s/)) {
+          // Calculate position for menu
+          const rect = textarea.getBoundingClientRect();
+          const lineHeight = 24; // Approximate line height
+          const lines = beforeCursor.split('\n').length;
+
+          setCommandMenu({
+            active: true,
+            query: '',
+            position: {
+              x: rect.left + 16,
+              y: rect.top + lines * lineHeight + 40,
+            },
+            selectedIndex: 0,
+            startPosition: cursorPos,
+          });
+        }
+      }
+      return;
+    }
+
+    // Handle keyboard navigation when menu is active
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        setCommandMenu({ ...commandMenu, active: false });
+        break;
+
+      case 'ArrowDown':
+        e.preventDefault();
+        setCommandMenu({
+          ...commandMenu,
+          selectedIndex: (commandMenu.selectedIndex + 1) % filteredCommands.length,
+        });
+        break;
+
+      case 'ArrowUp':
+        e.preventDefault();
+        setCommandMenu({
+          ...commandMenu,
+          selectedIndex:
+            commandMenu.selectedIndex === 0
+              ? filteredCommands.length - 1
+              : commandMenu.selectedIndex - 1,
+        });
+        break;
+
+      case 'Enter':
+      case 'Tab':
+        e.preventDefault();
+        if (filteredCommands[commandMenu.selectedIndex]) {
+          filteredCommands[commandMenu.selectedIndex].action();
+        }
+        break;
+
+      case 'Backspace':
+        // Close menu if we delete back to the slash
+        const textarea = textareaRef.current;
+        if (textarea && textarea.selectionStart <= commandMenu.startPosition) {
+          setCommandMenu({ ...commandMenu, active: false });
+        }
+        break;
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    onChange(newValue);
+
+    // Update query if command menu is active
+    if (commandMenu.active && textareaRef.current) {
+      const cursorPos = textareaRef.current.selectionStart;
+      const query = newValue.substring(commandMenu.startPosition + 1, cursorPos);
+
+      setCommandMenu({
+        ...commandMenu,
+        query,
+        selectedIndex: 0,
+      });
+    }
+  };
+
+  const handleCommandSelect = (command: SlashCommand) => {
+    command.action();
+  };
+
+  const handleCommandCancel = () => {
+    setCommandMenu({ ...commandMenu, active: false });
+  };
+
   return (
     <div className="rich-editor">
       <div className="rich-editor-panes">
         <div className="rich-editor-pane rich-editor-edit">
           <div className="rich-editor-label">Edit</div>
           <textarea
+            ref={textareaRef}
             className="rich-editor-textarea"
             value={value}
-            onChange={(e) => onChange(e.target.value)}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
             placeholder={placeholder || 'Write in markdown...'}
             disabled={disabled}
             aria-label="Markdown editor"
           />
+          {commandMenu.active && (
+            <SlashCommandMenu
+              commands={filteredCommands}
+              selectedIndex={commandMenu.selectedIndex}
+              position={commandMenu.position}
+              onSelect={handleCommandSelect}
+              onCancel={handleCommandCancel}
+            />
+          )}
         </div>
 
         <div className="rich-editor-pane rich-editor-preview">

--- a/apps/ui/src/wikiroo/SlashCommandMenu.tsx
+++ b/apps/ui/src/wikiroo/SlashCommandMenu.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import type { SlashCommand } from './types';
+import './Wikiroo.css';
+
+interface SlashCommandMenuProps {
+  commands: SlashCommand[];
+  selectedIndex: number;
+  position: { x: number; y: number };
+  onSelect: (command: SlashCommand) => void;
+  onCancel: () => void;
+}
+
+export function SlashCommandMenu({
+  commands,
+  selectedIndex,
+  position,
+  onSelect,
+  onCancel,
+}: SlashCommandMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onCancel();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [onCancel]);
+
+  if (commands.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={menuRef}
+      className="slash-command-menu"
+      style={{
+        left: `${position.x}px`,
+        top: `${position.y}px`,
+      }}
+      role="listbox"
+      aria-label="Slash commands"
+    >
+      {commands.map((command, index) => (
+        <button
+          key={command.id}
+          type="button"
+          className={`slash-command-item ${index === selectedIndex ? 'selected' : ''}`}
+          onClick={() => onSelect(command)}
+          role="option"
+          aria-selected={index === selectedIndex}
+        >
+          <div className="slash-command-label">{command.label}</div>
+          <div className="slash-command-description">{command.description}</div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -421,6 +421,54 @@
   font-style: italic;
 }
 
+/* Slash Command Menu Styles */
+.slash-command-menu {
+  position: absolute;
+  background: #ffffff;
+  border: 1px solid #dce4ec;
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  min-width: 280px;
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 1000;
+  padding: 8px 0;
+}
+
+.slash-command-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 16px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.slash-command-item:hover,
+.slash-command-item.selected {
+  background: #f8f9fa;
+}
+
+.slash-command-item.selected {
+  background: #e3f2fd;
+}
+
+.slash-command-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #2c3e50;
+  font-family: 'Source Code Pro', Consolas, 'Courier New', monospace;
+}
+
+.slash-command-description {
+  font-size: 12px;
+  color: #7f8c8d;
+}
+
 @media (max-width: 768px) {
   .wikiroo {
     padding: 16px;

--- a/apps/ui/src/wikiroo/types.ts
+++ b/apps/ui/src/wikiroo/types.ts
@@ -4,3 +4,9 @@ export type {
   PageSummaryDto as WikiPageSummary,
 } from 'shared';
 
+export interface SlashCommand {
+  id: string;
+  label: string;
+  description: string;
+  action: () => void;
+}


### PR DESCRIPTION
## Summary
- Added slash command detection to RichEditor component
- Created SlashCommandMenu component with keyboard navigation
- Implemented 11 built-in markdown commands with filtering
- Added complete keyboard and mouse interaction support

## Implementation Details

### Slash Command Detection
The RichEditor now detects when users type "/" at the start of a line or after whitespace:
- Triggers command menu automatically
- Tracks cursor position for menu placement
- Updates query as user continues typing

### SlashCommandMenu Component
New component that displays available commands:
- Shows filtered list based on user input
- Keyboard navigation (Arrow Up/Down, Enter, Tab, Escape)
- Click-outside-to-dismiss behavior
- Proper ARIA attributes for accessibility
- Positioned absolutely near cursor

### Built-in Commands
11 markdown commands available:
- `/h1`, `/h2`, `/h3` - Headings
- `/bold` - Bold text (**text**)
- `/italic` - Italic text (_text_)
- `/code` - Inline code (`code`)
- `/codeblock` - Code block (```code```)
- `/list` - Bullet list (- item)
- `/numbered` - Numbered list (1. item)
- `/quote` - Block quote (> quote)
- `/link` - Insert link ([text](url))

### User Experience
- Type `/` to open menu
- Type further to filter (e.g., `/h` shows only headings)
- Arrow keys to navigate
- Enter or Tab to execute
- Escape to cancel
- Click outside to dismiss
- Auto-closes after command execution
- Cursor positioned correctly after insertion

### Styling
Added CSS for command menu:
- Clean dropdown design with shadow
- Hover and selection states
- Monospace font for command labels
- Consistent with Wikiroo theme
- Proper z-index layering

## Test Plan
- [ ] Type "/" in editor and verify menu appears
- [ ] Test filtering by typing "/h" (should show h1-h3 only)
- [ ] Navigate with arrow keys
- [ ] Execute command with Enter
- [ ] Execute command with Tab
- [ ] Cancel with Escape
- [ ] Click outside to dismiss
- [ ] Verify markdown is inserted correctly
- [ ] Check cursor positioning after insertion
- [ ] Test all 11 commands
- [ ] Verify menu only shows at start of line or after whitespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)