### PR TITLE
Add WikiPageTree Type Export for Nested Pages

### DIFF
--- a/apps/ui/src/wikiroo/types.ts
+++ b/apps/ui/src/wikiroo/types.ts
@@ -2,6 +2,7 @@
 export type {
   PageResponseDto as WikiPage,
   PageSummaryDto as WikiPageSummary,
+  PageTreeResponseDto as WikiPageTree,
 } from 'shared';
 
 export interface SlashCommand {


### PR DESCRIPTION
## Summary
Export PageTreeResponseDto as WikiPageTree from the shared package to provide frontend components with proper TypeScript types for nested page hierarchies.

### Changes
**apps/ui/src/wikiroo/types.ts**
- Added `PageTreeResponseDto as WikiPageTree` to type exports
- Provides recursive tree structure for nested pages

### Type Structure
The WikiPageTree type includes:
- `id`: Unique page identifier
- `title`: Page title
- `author`: Page author  
- `parentId`: Parent page ID (null for root pages)
- `order`: Order within siblings
- `children`: Array<WikiPageTree> (recursive structure)
- `createdAt`: Creation timestamp
- `updatedAt`: Last update timestamp

### Already Complete
✅ **WikiPage** type includes `parentId` and `order` (from PageResponseDto)
✅ **WikiPageSummary** type includes `parentId` and `order` (from PageSummaryDto)

These were automatically updated when the backend DTOs were updated in earlier tasks, since they're re-exported from the shared package.

### Benefits
✅ Type-safe tree view components
✅ Consistent naming convention across all page types
✅ Support for parent-child page relationships
✅ Recursive structure for unlimited nesting depth
✅ Ready for tree navigation and breadcrumb components

## Test Plan
- [x] UI build passes (`npm -w ui run build`)
- [x] WikiPageTree type properly exported
- [x] No TypeScript compilation errors
- [x] All three page types available (WikiPage, WikiPageSummary, WikiPageTree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)