### PR TITLE
Add parent selector to page forms

### DIFF
--- a/apps/ui/src/wikiroo/WikiPageForm.tsx
+++ b/apps/ui/src/wikiroo/WikiPageForm.tsx
@@ -1,13 +1,34 @@
-import { useState, useEffect, FormEvent } from 'react';
-import type { WikiPage } from './types';
+import { useState, useEffect, FormEvent, useMemo } from 'react';
+import type { WikiPage, WikiPageSummary } from './types';
 import type { CreatePageDto, UpdatePageDto } from 'shared';
 import { TagInput } from './TagInput';
 import { RichEditor } from './RichEditor';
+
+// Helper to get all descendant IDs of a page (to prevent circular references)
+function getDescendantIds(pageId: string, allPages: WikiPageSummary[]): Set<string> {
+  const descendants = new Set<string>();
+  const queue = [pageId];
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()!;
+    descendants.add(currentId);
+
+    // Find all children of current page
+    const children = allPages.filter(p => {
+      const pid = p.parentId;
+      return typeof pid === 'string' && pid === currentId;
+    });
+    children.forEach(child => queue.push(child.id));
+  }
+
+  return descendants;
+}
 
 type WikiPageFormProps =
   | {
       mode: 'create';
       page?: never;
+      pages: WikiPageSummary[];
       onSubmit: (data: CreatePageDto) => Promise<void>;
       onCancel: () => void;
       isSubmitting: boolean;
@@ -15,6 +36,7 @@ type WikiPageFormProps =
   | {
       mode: 'edit';
       page: WikiPage;
+      pages: WikiPageSummary[];
       onSubmit: (data: UpdatePageDto) => Promise<void>;
       onCancel: () => void;
       isSubmitting: boolean;
@@ -23,6 +45,7 @@ type WikiPageFormProps =
 export function WikiPageForm({
   mode,
   page,
+  pages,
   onSubmit,
   onCancel,
   isSubmitting,
@@ -31,7 +54,23 @@ export function WikiPageForm({
   const [content, setContent] = useState(page?.content || '');
   const [author, setAuthor] = useState(page?.author || '');
   const [tagNames, setTagNames] = useState<string[]>(page?.tags?.map(t => t.name) || []);
+  const [parentId, setParentId] = useState<string | null>(() => {
+    const pid = page?.parentId;
+    return typeof pid === 'string' ? pid : null;
+  });
   const [errorMessage, setErrorMessage] = useState('');
+
+  // Compute available parents based on mode
+  const availableParents = useMemo(() => {
+    if (mode === 'create') {
+      // When creating, all pages are valid parents
+      return pages;
+    } else {
+      // When editing, exclude current page and its descendants
+      const excludedIds = getDescendantIds(page.id, pages);
+      return pages.filter(p => !excludedIds.has(p.id));
+    }
+  }, [mode, pages, page]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -57,6 +96,7 @@ export function WikiPageForm({
           author: author.trim(),
           content: content.trim(),
           ...(tagNames.length > 0 && { tagNames }),
+          ...(parentId && { parentId }),
         };
         await onSubmit(payload);
       } else {
@@ -81,6 +121,12 @@ export function WikiPageForm({
         const tagsChanged = JSON.stringify(tagNames.sort()) !== JSON.stringify(currentTagNames.sort());
         if (tagsChanged) {
           payload.tagNames = tagNames;
+          hasChanges = true;
+        }
+
+        const currentParentId = typeof page.parentId === 'string' ? page.parentId : null;
+        if (parentId !== currentParentId) {
+          payload.parentId = parentId ?? undefined;
           hasChanges = true;
         }
 
@@ -130,6 +176,23 @@ export function WikiPageForm({
           required
           disabled={isSubmitting}
         />
+      </div>
+
+      <div className="wikiroo-form-group">
+        <label htmlFor={`${mode}-parent`}>Parent Page</label>
+        <select
+          id={`${mode}-parent`}
+          value={parentId ?? ''}
+          onChange={(e) => setParentId(e.target.value || null)}
+          disabled={isSubmitting}
+        >
+          <option value="">None (top level)</option>
+          {availableParents.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.title}
+            </option>
+          ))}
+        </select>
       </div>
 
       <div className="wikiroo-form-group">

--- a/apps/ui/src/wikiroo/WikirooHomePage.tsx
+++ b/apps/ui/src/wikiroo/WikirooHomePage.tsx
@@ -70,6 +70,7 @@ export function WikirooHomePage() {
       {showForm && (
         <WikiPageForm
           mode="create"
+          pages={pages}
           onSubmit={handleCreatePage}
           onCancel={() => setShowForm(false)}
           isSubmitting={isCreating}

--- a/apps/ui/src/wikiroo/WikirooPageView.tsx
+++ b/apps/ui/src/wikiroo/WikirooPageView.tsx
@@ -164,6 +164,7 @@ export function WikirooPageView() {
           <WikiPageForm
             mode="edit"
             page={selectedPage}
+            pages={pages}
             onSubmit={handleUpdate}
             onCancel={() => setShowEditForm(false)}
             isSubmitting={isUpdating}

--- a/apps/ui/src/wikiroo/WikirooPageViewMobile.tsx
+++ b/apps/ui/src/wikiroo/WikirooPageViewMobile.tsx
@@ -11,6 +11,7 @@ export function WikirooPageViewMobile() {
   const { pageId } = useParams<{ pageId: string }>();
   const navigate = useNavigate();
   const {
+    pages,
     selectedPage,
     isLoadingPage,
     error,
@@ -181,6 +182,7 @@ export function WikirooPageViewMobile() {
             <WikiPageForm
               mode="edit"
               page={selectedPage}
+              pages={pages}
               onSubmit={handleUpdate}
               onCancel={() => setShowEditModal(false)}
               isSubmitting={isUpdating}


### PR DESCRIPTION
## Summary
- Added parent page selector to WikiPageForm for creating nested page hierarchies
- Implemented circular reference prevention logic (excludes current page and descendants when editing)
- Updated all form usage locations to pass pages data

## Test plan
- [ ] Verify parent selector appears in create page form
- [ ] Verify parent selector appears in edit page form
- [ ] Verify "None (top level)" option creates a root page
- [ ] Verify selecting a parent page correctly sets parentId in API payload
- [ ] Verify editing a page excludes itself and descendants from available parents
- [ ] Verify form works on mobile devices
- [ ] Verify production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)