### PR TITLE
Add breadcrumb navigation to page view

### DIFF
--- a/apps/ui/src/wikiroo/Breadcrumb.tsx
+++ b/apps/ui/src/wikiroo/Breadcrumb.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+import type { WikiPageSummary } from './types';
+
+interface BreadcrumbProps {
+  pageId: string;
+  pages: WikiPageSummary[];
+}
+
+function buildBreadcrumbPath(pageId: string, pages: WikiPageSummary[]): WikiPageSummary[] {
+  const path: WikiPageSummary[] = [];
+  let currentId: string | null = pageId;
+
+  while (currentId) {
+    const page = pages.find((p) => p.id === currentId);
+    if (!page) break;
+
+    path.unshift(page); // Add to beginning
+    const pid = page.parentId;
+    currentId = typeof pid === 'string' ? pid : null;
+  }
+
+  return path;
+}
+
+export function Breadcrumb({ pageId, pages }: BreadcrumbProps) {
+  const breadcrumbs = buildBreadcrumbPath(pageId, pages);
+
+  return (
+    <nav className="breadcrumb" aria-label="Breadcrumb">
+      <Link to="/wikiroo" className="breadcrumb-link">
+        Home
+      </Link>
+      {breadcrumbs.map((page, index) => (
+        <span key={page.id} className="breadcrumb-item">
+          <span className="breadcrumb-separator"> &gt; </span>
+          {index === breadcrumbs.length - 1 ? (
+            <span className="breadcrumb-current">{page.title}</span>
+          ) : (
+            <Link to={`/wikiroo/${page.id}`} className="breadcrumb-link">
+              {page.title}
+            </Link>
+          )}
+        </span>
+      ))}
+    </nav>
+  );
+}

--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -603,3 +603,46 @@
 .tree-item-children {
   /* Children are naturally indented via paddingLeft in PageTreeItem */
 }
+
+/* Breadcrumb Styles */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 12px 0;
+  margin-bottom: 16px;
+  font-size: 14px;
+  color: #7f8c8d;
+}
+
+.breadcrumb-link {
+  color: #2196f3;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.breadcrumb-link:hover {
+  color: #1976d2;
+  text-decoration: underline;
+}
+
+.breadcrumb-link:focus {
+  outline: 2px solid #2196f3;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.breadcrumb-separator {
+  margin: 0 8px;
+  color: #bdc3c7;
+}
+
+.breadcrumb-current {
+  color: #2c3e50;
+  font-weight: 500;
+}

--- a/apps/ui/src/wikiroo/WikirooPageView.tsx
+++ b/apps/ui/src/wikiroo/WikirooPageView.tsx
@@ -8,6 +8,7 @@ import { usePageTitle } from '../hooks/usePageTitle';
 import { WikiPageForm } from './WikiPageForm';
 import { TagBadge } from './TagBadge';
 import { ConfirmDialog } from '../components/ConfirmDialog';
+import { Breadcrumb } from './Breadcrumb';
 import type { UpdatePageDto } from 'shared';
 
 function formatDate(value: string) {
@@ -106,6 +107,7 @@ export function WikirooPageView() {
 
       {selectedPage && !showEditForm && (
         <div className="wikiroo-page-detail">
+          {pageId && <Breadcrumb pageId={pageId} pages={pages} />}
           <div className="wikiroo-page-detail-header">
             <h1 className="wikiroo-page-detail-title">{selectedPage.title}</h1>
             <div className="wikiroo-page-detail-meta">


### PR DESCRIPTION
## Summary
- Created Breadcrumb component showing hierarchical navigation path
- Integrated breadcrumb into WikirooPageView
- Added CSS styling for breadcrumb with proper accessibility

## Test plan
- [ ] Verify breadcrumb shows full path from root to current page
- [ ] Verify each breadcrumb item (except current) is clickable
- [ ] Verify clicking breadcrumb items navigates correctly
- [ ] Verify breadcrumb format: Home > Parent > Child > Current
- [ ] Verify breadcrumb updates when navigating to different pages
- [ ] Verify mobile-friendly layout with flex-wrap
- [ ] Verify production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)