### PR TITLE
Update mobile components for nested pages

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -646,3 +646,30 @@
   color: #2c3e50;
   font-weight: 500;
 }
+
+/* Mobile-specific styles for touch targets */
+@media (max-width: 768px) {
+  .tree-toggle {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px;
+  }
+
+  .tree-item-link {
+    padding: 12px 4px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+  }
+
+  .breadcrumb {
+    padding: 8px 0;
+  }
+
+  .breadcrumb-link {
+    padding: 8px 4px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+}

--- a/apps/ui/src/wikiroo/WikirooHomeMobile.tsx
+++ b/apps/ui/src/wikiroo/WikirooHomeMobile.tsx
@@ -12,6 +12,7 @@ export function WikirooHomeMobile() {
   const [author, setAuthor] = useState('');
   const [content, setContent] = useState('');
   const [tagNames, setTagNames] = useState<string[]>([]);
+  const [parentId, setParentId] = useState<string | null>(null);
 
   const handleCreatePage = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -24,6 +25,7 @@ export function WikirooHomeMobile() {
       author: author.trim(),
       content: content.trim(),
       ...(tagNames.length > 0 && { tagNames }),
+      ...(parentId && { parentId }),
     });
 
     // Reset form and close modal
@@ -31,6 +33,7 @@ export function WikirooHomeMobile() {
     setAuthor('');
     setContent('');
     setTagNames([]);
+    setParentId(null);
     setShowCreateModal(false);
   };
 
@@ -173,6 +176,22 @@ export function WikirooHomeMobile() {
                     placeholder="Your name"
                     required
                   />
+                </div>
+
+                <div className="mobile-wikiroo-form-group">
+                  <label className="mobile-wikiroo-form-label">Parent Page</label>
+                  <select
+                    className="mobile-wikiroo-form-input"
+                    value={parentId ?? ''}
+                    onChange={(e) => setParentId(e.target.value || null)}
+                  >
+                    <option value="">None (top level)</option>
+                    {pages.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.title}
+                      </option>
+                    ))}
+                  </select>
                 </div>
 
                 <div className="mobile-wikiroo-form-group">

--- a/apps/ui/src/wikiroo/WikirooPageViewMobile.tsx
+++ b/apps/ui/src/wikiroo/WikirooPageViewMobile.tsx
@@ -4,6 +4,7 @@ import { useWikiroo } from './useWikiroo';
 import { MarkdownPreview } from './MarkdownPreview';
 import { WikiPageForm } from './WikiPageForm';
 import { ConfirmDialog } from '../components/ConfirmDialog';
+import { Breadcrumb } from './Breadcrumb';
 import type { UpdatePageDto } from 'shared';
 import './WikirooMobile.css';
 
@@ -120,6 +121,7 @@ export function WikirooPageViewMobile() {
       {/* Page Detail */}
       {!showEditModal && (
       <div className="mobile-wikiroo-page-detail">
+        {pageId && <Breadcrumb pageId={pageId} pages={pages} />}
         <h1 className="mobile-wikiroo-page-detail-title">{selectedPage.title}</h1>
         <div className="mobile-wikiroo-page-detail-meta">
           <span>By {selectedPage.author}</span>


### PR DESCRIPTION
## Summary
- Added breadcrumb navigation to mobile page view
- Added parent selector dropdown to mobile create page form
- Added mobile-specific CSS with touch-friendly targets (min 44x44px)
- Optimized tree controls, links, and breadcrumbs for touch interaction

## Test plan
- [ ] Verify breadcrumb appears on mobile page view
- [ ] Verify parent selector in mobile create form
- [ ] Verify touch targets are at least 44x44px
- [ ] Verify breadcrumbs wrap properly on narrow screens
- [ ] Verify tree expand/collapse works with touch
- [ ] Verify production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)