### PR TITLE
Improve Wikiroo UI with modern top bar and collapsible sidebar

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -1,27 +1,33 @@
 .wikiroo {
   min-height: 100vh;
-  background: #f8f9fa;
-  padding: 24px;
+  background: #ffffff;
+  padding: 0;
   color: #2c3e50;
 }
 
 .wikiroo-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 24px;
+  padding: 12px 24px;
+  background: #ffffff;
+  border-bottom: 1px solid #e4e6eb;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 100;
 }
 
 .wikiroo-header h1 {
   margin: 0;
-  font-size: 32px;
-  font-weight: 600;
+  font-size: 24px;
+  font-weight: 700;
+  color: #1877f2;
 }
 
 .wikiroo-header p {
-  margin: 4px 0 0;
-  color: #95a5a6;
+  display: none;
 }
 
 .wikiroo-actions {
@@ -68,10 +74,9 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  margin-bottom: 24px;
-  padding: 16px;
-  border-radius: 12px;
-  background: #f5f7fa;
+  padding: 24px;
+  background: #ffffff;
+  border-bottom: 1px solid #e4e6eb;
 }
 
 .wikiroo-form-group {
@@ -180,22 +185,27 @@
 
 .wikiroo-main-container {
   display: flex;
-  gap: 24px;
+  gap: 0;
   flex: 1;
   align-items: flex-start;
+  min-height: calc(100vh - 60px);
 }
 
 .wikiroo-sidebar {
   width: 300px;
   min-width: 300px;
-  background: #ffffff;
-  border-radius: 8px;
+  background: #f8f9fa;
   padding: 16px;
-  border: 1px solid #dce4ec;
-  max-height: calc(100vh - 200px);
+  border-right: 1px solid #e4e6eb;
+  max-height: calc(100vh - 60px);
   overflow-y: auto;
   position: sticky;
-  top: 24px;
+  top: 60px;
+  transition: margin-left 0.3s ease;
+}
+
+.wikiroo-sidebar.collapsed {
+  margin-left: -300px;
 }
 
 .wikiroo-sidebar-title {
@@ -215,10 +225,9 @@
 .wikiroo-content {
   flex: 1;
   background: #ffffff;
-  border-radius: 8px;
   padding: 24px;
-  border: 1px solid #dce4ec;
-  min-width: 0; /* Allow flex item to shrink below content size */
+  min-width: 0;
+  overflow-y: auto;
 }
 
 .wikiroo-welcome {

--- a/apps/ui/src/wikiroo/WikirooLayout.tsx
+++ b/apps/ui/src/wikiroo/WikirooLayout.tsx
@@ -46,6 +46,7 @@ export function WikirooLayout() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [pageTree, setPageTree] = useState<WikiPageTree[]>([]);
   const [isLoadingTree, setIsLoadingTree] = useState(false);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
   const pageSummary = pages.find((page) => page.id === pageId);
   const pageTitle = selectedPage?.title || pageSummary?.title;
@@ -141,9 +142,16 @@ export function WikirooLayout() {
   return (
     <div className="wikiroo wikiroo-layout">
       <header className="wikiroo-header">
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+          <button
+            className="wikiroo-button secondary"
+            type="button"
+            onClick={() => setIsSidebarCollapsed((prev) => !prev)}
+            title={isSidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+          >
+            {isSidebarCollapsed ? '☰' : '←'}
+          </button>
           <h1>Wikiroo</h1>
-          <p>Lightweight knowledge base for agents</p>
         </div>
         <div className="wikiroo-actions">
           <HomeLink />
@@ -177,7 +185,7 @@ export function WikirooLayout() {
 
       <div className="wikiroo-main-container">
         {/* Left sidebar with tree navigation */}
-        <aside className="wikiroo-sidebar">
+        <aside className={`wikiroo-sidebar ${isSidebarCollapsed ? 'collapsed' : ''}`}>
           <h2 className="wikiroo-sidebar-title">Pages</h2>
           {isLoadingTree && <div className="wikiroo-status">Loading pages…</div>}
           {pageTree.length > 0 && (
@@ -198,8 +206,7 @@ export function WikirooLayout() {
         <main className="wikiroo-content">
           {!pageId && (
             <div className="wikiroo-welcome">
-              <h2>Welcome to Wikiroo</h2>
-              <p>Select a page from the sidebar or create a new one to get started.</p>
+              <h2>Wikiroo</h2>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Removed gray background throughout the application, replaced with clean white background
- Added Facebook-like sticky top bar with blue branding and shadow
- Implemented collapsible sidebar with smooth animation and toggle button
- Simplified welcome message to just show "Wikiroo"
- Updated form styling for cleaner, more modern appearance

## Test plan
- [x] Build passes (`npm run build:prod`)
- [ ] Navigate to /wikiroo and verify white background
- [ ] Test top bar is sticky when scrolling
- [ ] Test sidebar collapse/expand functionality
- [ ] Create new page and verify form has white background
- [ ] Verify welcome message shows "Wikiroo" when no page selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)