### PR TITLE
Fix parent field submission in Wikiroo edit page form

### DIFF
--- a/apps/backend/src/wikiroo/dto/update-page.dto.ts
+++ b/apps/backend/src/wikiroo/dto/update-page.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, MaxLength, IsArray, IsUUID, IsInt, Min } from 'class-validator';
+import { IsOptional, IsString, MaxLength, IsArray, IsUUID, IsInt, Min, ValidateIf } from 'class-validator';
 
 export class UpdatePageDto {
   @ApiPropertyOptional({
@@ -39,12 +39,15 @@ export class UpdatePageDto {
   tagNames?: string[];
 
   @ApiPropertyOptional({
-    description: 'Parent page ID',
+    description: 'Parent page ID (null to remove parent)',
     example: '123e4567-e89b-12d3-a456-426614174000',
+    type: String,
+    nullable: true,
   })
   @IsOptional()
-  @IsUUID()
-  parentId?: string;
+  @ValidateIf((o) => o.parentId !== null)
+  @IsUUID('4', { message: 'Parent ID must be a valid UUID' })
+  parentId?: string | null;
 
   @ApiPropertyOptional({
     description: 'Order within siblings',

--- a/apps/ui/src/wikiroo/WikiPageForm.tsx
+++ b/apps/ui/src/wikiroo/WikiPageForm.tsx
@@ -126,7 +126,7 @@ export function WikiPageForm({
 
         const currentParentId = typeof page.parentId === 'string' ? page.parentId : null;
         if (parentId !== currentParentId) {
-          payload.parentId = parentId ?? undefined;
+          payload.parentId = parentId;
           hasChanges = true;
         }
 

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -3669,8 +3669,9 @@
           },
           "parentId": {
             "type": "string",
-            "description": "Parent page ID",
-            "example": "123e4567-e89b-12d3-a456-426614174000"
+            "description": "Parent page ID (null to remove parent)",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "nullable": true
           },
           "order": {
             "type": "number",

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -1418,10 +1418,10 @@ export interface components {
              */
             tagNames?: string[];
             /**
-             * @description Parent page ID
+             * @description Parent page ID (null to remove parent)
              * @example 123e4567-e89b-12d3-a456-426614174000
              */
-            parentId?: string;
+            parentId?: string | null;
             /**
              * @description Order within siblings
              * @example 0

--- a/packages/shared/src/client/models/UpdatePageDto.ts
+++ b/packages/shared/src/client/models/UpdatePageDto.ts
@@ -20,9 +20,9 @@ export type UpdatePageDto = {
      */
     tagNames?: Array<string>;
     /**
-     * Parent page ID
+     * Parent page ID (null to remove parent)
      */
-    parentId?: string;
+    parentId?: string | null;
     /**
      * Order within siblings
      */


### PR DESCRIPTION
## Summary
- Fixed bug where changing a page's parent in the edit form was not being submitted
- Backend DTO now properly accepts null values for parentId to allow removing parent
- Frontend now correctly sends null instead of converting to undefined

## Technical Details
The issue had two parts:
1. **Frontend**: WikiPageForm was using `parentId ?? undefined` which converted null to undefined
2. **Backend**: UpdatePageDto's @IsUUID() validator rejected null values

### Changes
- **Backend** (`update-page.dto.ts`):
  - Added `type: String` and `nullable: true` to ApiPropertyOptional
  - Added `@ValidateIf((o) => o.parentId !== null)` to skip UUID validation when null
  - Updated type to `string | null`

- **Frontend** (`WikiPageForm.tsx`):
  - Changed `payload.parentId = parentId ?? undefined` to `payload.parentId = parentId`
  - Now correctly sends null to remove parent or string UUID to set parent

## Test plan
- [x] Build passes (`npm run build:prod`)
- [ ] Edit a page and change its parent - verify it saves
- [ ] Edit a page and remove its parent (select "None") - verify it saves
- [ ] Edit a page and try to set it as its own parent - verify error

🤖 Generated with [Claude Code](https://claude.com/claude-code)