### PR TITLE
Implement route-based navigation for Wikiroo

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -29,7 +29,9 @@ export default function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/taskeroo" element={<TaskerooRouter />} />
         <Route path="/wikiroo" element={<WikirooRouter />} />
-        <Route path="/wikiroo/:pageId" element={<WikirooRouter />} />
+        <Route path="/wikiroo/new" element={<WikirooRouter />} />
+        <Route path="/wikiroo/page/:pageId" element={<WikirooRouter />} />
+        <Route path="/wikiroo/page/:pageId/edit" element={<WikirooRouter />} />
         <Route path="/mcp-registry" element={<McpRegistryDashboard />} />
         <Route path="/mcp-registry/:serverId" element={<McpServerDetail />} />
         <Route path="/consent" element={<ConsentScreen />} />

--- a/apps/ui/src/wikiroo/Breadcrumb.tsx
+++ b/apps/ui/src/wikiroo/Breadcrumb.tsx
@@ -36,7 +36,7 @@ export function Breadcrumb({ pageId, pages }: BreadcrumbProps) {
           {index === breadcrumbs.length - 1 ? (
             <span className="breadcrumb-current">{page.title}</span>
           ) : (
-            <Link to={`/wikiroo/${page.id}`} className="breadcrumb-link">
+            <Link to={`/wikiroo/page/${page.id}`} className="breadcrumb-link">
               {page.title}
             </Link>
           )}

--- a/apps/ui/src/wikiroo/WikirooHomeMobile.tsx
+++ b/apps/ui/src/wikiroo/WikirooHomeMobile.tsx
@@ -100,7 +100,7 @@ export function WikirooHomeMobile() {
         {!isLoadingList && !error && pages.map((page) => (
           <Link
             key={page.id}
-            to={`/wikiroo/${page.id}`}
+            to={`/wikiroo/page/${page.id}`}
             className="mobile-wikiroo-page-item"
           >
             <h3 className="mobile-wikiroo-page-title">{page.title}</h3>

--- a/apps/ui/src/wikiroo/WikirooHomePage.tsx
+++ b/apps/ui/src/wikiroo/WikirooHomePage.tsx
@@ -51,7 +51,7 @@ export function WikirooHomePage() {
     // Reload tree to show new page
     const tree = await getPageTree();
     setPageTree(tree);
-    navigate(`/wikiroo/${created.id}`);
+    navigate(`/wikiroo/page/${created.id}`);
   };
 
   const handleRefresh = async () => {
@@ -109,7 +109,7 @@ export function WikirooHomePage() {
           <PageTree
             pages={pageTree}
             currentPageId={undefined}
-            onPageClick={(id) => navigate(`/wikiroo/${id}`)}
+            onPageClick={(id) => navigate(`/wikiroo/page/${id}`)}
           />
         )}
       </section>


### PR DESCRIPTION
## Summary
- Implements route-based navigation for Wikiroo instead of using state flags
- Routes: `/wikiroo` (home), `/wikiroo/new` (create), `/wikiroo/page/:pageId` (view), `/wikiroo/page/:pageId/edit` (edit)
- Sidebar automatically collapses when viewing a page and expands for create/edit
- Updated all navigation links to use new route structure

## Test plan
- [ ] Navigate to /wikiroo - should show home with sidebar expanded
- [ ] Click "New page" - should navigate to /wikiroo/new with sidebar expanded
- [ ] Create a page - should navigate to /wikiroo/page/:pageId with sidebar collapsed
- [ ] Click "Edit" - should navigate to /wikiroo/page/:pageId/edit with sidebar expanded
- [ ] Click page links in breadcrumb/tree - should navigate to /wikiroo/page/:pageId
- [ ] Verify mobile routes still work correctly
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)