### PR TITLE
Improve Wikiroo sidebar styling

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -194,10 +194,10 @@
 .wikiroo-sidebar {
   width: 300px;
   min-width: 300px;
-  background: #f8f9fa;
+  background: #ffffff;
   padding: 16px;
   border-right: 1px solid #e4e6eb;
-  max-height: calc(100vh - 60px);
+  height: calc(100vh - 60px);
   overflow-y: auto;
   position: sticky;
   top: 60px;
@@ -607,8 +607,8 @@
 /* Page Tree Styles */
 .page-tree {
   background: white;
-  border: 1px solid #dce4ec;
-  border-radius: 4px;
+  border: none;
+  border-radius: 0;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- Removed gray background from sidebar, changed to white to match main content
- Changed from max-height to height for consistent full-height sidebar coverage
- Removed border and border-radius from page-tree component for cleaner integration
- Sidebar maintains independent scrolling with thin border separating it from main content

## Changes
- Modified [Wikiroo.css:194-205](apps/ui/src/wikiroo/Wikiroo.css#L194-L205) - Updated sidebar background and height
- Modified [Wikiroo.css:607-613](apps/ui/src/wikiroo/Wikiroo.css#L607-L613) - Removed page-tree border for cleaner look

## Test plan
- [x] Sidebar has white background matching main content area
- [x] Thin border (1px solid #e4e6eb) separates sidebar from main content
- [x] Sidebar covers full viewport height (calc(100vh - 60px))
- [x] Sidebar has independent scrolling when content overflows
- [x] Build validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)