### PR TITLE
Create WikirooPageEdit component

### DIFF
--- a/apps/ui/src/wikiroo/WikirooPageEdit.tsx
+++ b/apps/ui/src/wikiroo/WikirooPageEdit.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useWikiroo } from './useWikiroo';
+import { WikiPageForm } from './WikiPageForm';
+import type { UpdatePageDto } from 'shared';
+
+export function WikirooPageEdit() {
+  const { pageId } = useParams<{ pageId: string }>();
+  const navigate = useNavigate();
+  const { selectedPage, pages, isUpdating, updatePage, getPageTree, selectPage } = useWikiroo();
+
+  useEffect(() => {
+    if (pageId) {
+      selectPage(pageId);
+    }
+  }, [pageId, selectPage]);
+
+  const handleUpdate = useCallback(
+    async (payload: UpdatePageDto) => {
+      if (!pageId) return;
+      await updatePage(pageId, payload);
+      // Reload tree in case title changed
+      await getPageTree();
+      // Navigate back to page view
+      navigate(`/wikiroo/page/${pageId}`);
+    },
+    [pageId, updatePage, getPageTree, navigate],
+  );
+
+  if (!selectedPage) {
+    return <div className="wikiroo-status">Loading...</div>;
+  }
+
+  return (
+    <div className="wikiroo-edit-container">
+      <div className="wikiroo-edit-header">
+        <h2>Edit Page</h2>
+        <button
+          onClick={() => navigate(`/wikiroo/page/${pageId}`)}
+          className="wikiroo-button secondary"
+        >
+          Close
+        </button>
+      </div>
+      <WikiPageForm
+        mode="edit"
+        page={selectedPage}
+        pages={pages}
+        onSubmit={handleUpdate}
+        onCancel={() => navigate(`/wikiroo/page/${pageId}`)}
+        isSubmitting={isUpdating}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Implements task #11: Create WikirooPageEdit component

## Changes
- Created `apps/ui/src/wikiroo/WikirooPageEdit.tsx`
- Extracted edit page form section from WikirooLayout.tsx (lines 226-248)
- Includes all required hooks: useParams, useNavigate, useWikiroo
- Includes handlers: handleUpdate with tree reload and navigation
- Uses WikiPageForm component for edit functionality

## Component Structure
Focused component for page editing only, designed to be used within a layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)