### PR TITLE
Remove old sidebar styles from Wikiroo.css

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -191,37 +191,6 @@
   min-height: calc(100vh - 60px);
 }
 
-.wikiroo-sidebar {
-  width: 300px;
-  min-width: 300px;
-  background: #ffffff;
-  padding: 16px;
-  border-right: 1px solid #e4e6eb;
-  height: calc(100vh - 60px);
-  overflow-y: auto;
-  position: sticky;
-  top: 60px;
-  transition: margin-left 0.3s ease;
-}
-
-.wikiroo-sidebar.collapsed {
-  margin-left: -300px;
-}
-
-.wikiroo-sidebar-title {
-  margin: 0 0 16px 0;
-  font-size: 18px;
-  font-weight: 600;
-  color: #2c3e50;
-}
-
-.wikiroo-empty-sidebar {
-  padding: 16px;
-  text-align: center;
-  color: #95a5a6;
-  font-size: 14px;
-}
-
 .wikiroo-content {
   flex: 1;
   background: #ffffff;
@@ -252,12 +221,6 @@
 @media (max-width: 1024px) {
   .wikiroo-main-container {
     flex-direction: column;
-  }
-
-  .wikiroo-sidebar {
-    width: 100%;
-    max-height: 400px;
-    position: static;
   }
 }
 


### PR DESCRIPTION
Implements task #13: Update Wikiroo.css - remove old sidebar styles

## Changes
- Removed `.wikiroo-sidebar` and `.wikiroo-sidebar.collapsed` classes
- Removed `.wikiroo-sidebar-title` class
- Removed `.wikiroo-empty-sidebar` class
- Removed responsive sidebar styles from media query

## Impact
Sidebar layout is now fully handled by the global sidebar.css design system. This cleanup removes duplication and prepares for the new stacking sidebar implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)