### PR TITLE
Add responsive styles for HamburgerMenu (#6)

### DIFF
--- a/apps/ui/src/components/HamburgerMenu.css
+++ b/apps/ui/src/components/HamburgerMenu.css
@@ -178,3 +178,10 @@
 body.hamburger-menu-open {
   overflow: hidden;
 }
+
+/* Desktop: Hide hamburger, sidebars visible */
+@media (min-width: 769px) {
+  .hamburger-button {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Added media query to hide hamburger button on desktop (>769px)
- Hamburger button now only visible on mobile where sidebars are hidden
- Breakpoint at 769px matches sidebar.css responsive design system

## Test plan
- [x] Build passes successfully
- [ ] Desktop (>769px): Hamburger should be hidden, sidebars visible
- [ ] Mobile (<768px): Hamburger visible, sidebars hidden
- [ ] Resize browser to test breakpoint transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)