### PR TITLE
Create WikirooCreate component (#9)

### DIFF
--- a/apps/ui/src/wikiroo/WikirooCreate.tsx
+++ b/apps/ui/src/wikiroo/WikirooCreate.tsx
@@ -1,0 +1,37 @@
+import { useNavigate } from 'react-router-dom';
+import { useWikiroo } from './useWikiroo';
+import { WikiPageForm } from './WikiPageForm';
+import type { CreatePageDto } from 'shared';
+
+export function WikirooCreate() {
+  const navigate = useNavigate();
+  const { pages, isCreating, createPage, getPageTree } = useWikiroo();
+
+  const handleCreatePage = async (data: CreatePageDto) => {
+    const created = await createPage(data);
+    // Reload tree to show new page
+    await getPageTree();
+    navigate(`/wikiroo/page/${created.id}`);
+  };
+
+  return (
+    <div className="wikiroo-edit-container">
+      <div className="wikiroo-edit-header">
+        <h2>New Page</h2>
+        <button
+          onClick={() => navigate('/wikiroo')}
+          className="wikiroo-button secondary"
+        >
+          Close
+        </button>
+      </div>
+      <WikiPageForm
+        mode="create"
+        pages={pages}
+        onSubmit={handleCreatePage}
+        onCancel={() => navigate('/wikiroo')}
+        isSubmitting={isCreating}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Created WikirooCreate component for create page form
- Extracted from WikirooLayout create page section
- Uses useWikiroo hook for pages and createPage
- Handles page creation and navigation to new page
- Reloads page tree after creation
- Uses WikiPageForm in create mode
- Includes Close button and form header

## Test plan
- [x] Build passes successfully
- [ ] Component displays create form correctly on /wikiroo/new route
- [ ] Page creation works and navigates to new page
- [ ] Page tree reloads after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)