### PR TITLE
Update App.tsx with Wikiroo nested routes (#12)

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -3,9 +3,11 @@ import { RootLayout } from './layouts/RootLayout';
 import { HomePage } from './home/HomePage';
 import { TaskBoard } from './taskeroo/TaskBoard';
 import { TaskBoardMobile } from './taskeroo/TaskBoardMobile';
-import { WikirooLayout } from './wikiroo/WikirooLayout';
-import { WikirooHomeMobile } from './wikiroo/WikirooHomeMobile';
-import { WikirooPageViewMobile } from './wikiroo/WikirooPageViewMobile';
+import { WikirooWithSidebar } from './wikiroo/WikirooWithSidebar';
+import { WikirooHome } from './wikiroo/WikirooHome';
+import { WikirooCreate } from './wikiroo/WikirooCreate';
+import { WikirooPageView } from './wikiroo/WikirooPageView';
+import { WikirooPageEdit } from './wikiroo/WikirooPageEdit';
 import { McpRegistryDashboard } from './mcp-registry/McpRegistryDashboard';
 import { McpServerDetail } from './mcp-registry/McpServerDetail';
 import { ConsentScreen } from './consent/ConsentScreen';
@@ -19,10 +21,6 @@ function TaskerooRouter() {
   return isMobile() ? <TaskBoardMobile /> : <TaskBoard />;
 }
 
-function WikirooRouter() {
-  return isMobile() ? <WikirooHomeMobile /> : <WikirooLayout />;
-}
-
 export default function App() {
   return (
     <BrowserRouter>
@@ -34,11 +32,13 @@ export default function App() {
           <Route path="mcp-registry/:serverId" element={<McpServerDetail />} />
           <Route path="consent" element={<ConsentScreen />} />
 
-          {/* Wikiroo routes stay flat for now - will be nested in task #12 */}
-          <Route path="wikiroo" element={<WikirooRouter />} />
-          <Route path="wikiroo/new" element={<WikirooRouter />} />
-          <Route path="wikiroo/page/:pageId" element={<WikirooRouter />} />
-          <Route path="wikiroo/page/:pageId/edit" element={<WikirooRouter />} />
+          {/* Wikiroo nested routes with WikirooWithSidebar layout */}
+          <Route path="wikiroo" element={<WikirooWithSidebar />}>
+            <Route index element={<WikirooHome />} />
+            <Route path="new" element={<WikirooCreate />} />
+            <Route path="page/:pageId" element={<WikirooPageView />} />
+            <Route path="page/:pageId/edit" element={<WikirooPageEdit />} />
+          </Route>
         </Route>
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- Replaced flat Wikiroo routes with nested route structure
- Removed WikirooLayout and WikirooRouter imports
- Added imports for WikirooWithSidebar, WikirooHome, WikirooCreate, WikirooPageView, WikirooPageEdit
- Implemented nested routes under WikirooWithSidebar layout:
  - `/wikiroo` - WikirooHome (index)
  - `/wikiroo/new` - WikirooCreate
  - `/wikiroo/page/:pageId` - WikirooPageView
  - `/wikiroo/page/:pageId/edit` - WikirooPageEdit
- Both sidebars (app nav and page tree) now work independently with their own collapse states

## Test plan
- [x] Build passes successfully
- [ ] Navigate to all Wikiroo routes and verify they render correctly
- [ ] Verify both sidebars appear and work independently
- [ ] Test collapse/expand on both sidebars
- [ ] Test auto-collapse on create/edit/view modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)