### PR TITLE
Fix sidebar collapse button positioning to bottom

### DIFF
--- a/apps/ui/src/styles/sidebar.css
+++ b/apps/ui/src/styles/sidebar.css
@@ -62,8 +62,7 @@
   display: flex;
   flex-direction: column;
   transition: var(--sidebar-transition);
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
   border-right: 1px solid var(--sidebar-border);
 }
 
@@ -85,31 +84,30 @@
    Sidebar Content
    =========================== */
 .sidebar-content {
+  flex: 1;
   padding: var(--sidebar-padding);
   display: flex;
   flex-direction: column;
   gap: var(--sidebar-gap);
+  overflow-y: auto;
 }
 
 /* ===========================
    Sidebar Toggle Button
    =========================== */
 .sidebar-toggle {
-  position: fixed;
-  top: var(--sidebar-padding);
-  left: var(--sidebar-padding);
-  width: var(--sidebar-toggle-size);
+  width: 100%;
   height: var(--sidebar-toggle-size);
   background-color: var(--sidebar-bg);
   color: var(--sidebar-text);
-  border: 1px solid var(--sidebar-border);
-  border-radius: 4px;
+  border: none;
+  border-top: 1px solid var(--sidebar-border);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   transition: var(--sidebar-transition-fast);
-  z-index: var(--sidebar-toggle-z-index);
+  flex-shrink: 0;
 }
 
 .sidebar-toggle:hover {
@@ -118,12 +116,6 @@
 
 .sidebar-toggle:active {
   transform: scale(0.95);
-}
-
-/* Adjust toggle position when sidebar is collapsed */
-.sidebar-app-nav.collapsed ~ .sidebar-toggle,
-.root-layout:has(.sidebar-app-nav.collapsed) .sidebar-toggle {
-  left: calc(var(--sidebar-app-nav-collapsed-width) + var(--sidebar-padding));
 }
 
 /* ===========================


### PR DESCRIPTION
## Summary
- Moved toggle button from fixed top position to bottom of sidebar
- Made .sidebar-content use flex: 1 with overflow-y: auto to take available space
- Changed .sidebar-toggle from fixed positioning to flex layout
- Toggle now uses full width with border-top styling
- Added flex-shrink: 0 to keep button at fixed height
- Changed sidebar overflow handling - scrolling now in .sidebar-content

## Changes
- `.sidebar-content`: Added `flex: 1` and `overflow-y: auto`
- `.sidebar-toggle`: Removed fixed positioning, changed to full-width flex item at bottom
- `.sidebar-app-nav` and `.sidebar-app-specific`: Changed `overflow-y: auto` to `overflow: hidden`

## Test plan
- [x] Build passes successfully
- [ ] Toggle button appears at bottom of both sidebars
- [ ] Sidebar content scrolls independently of toggle button
- [ ] Toggle button remains visible when sidebar content scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)