### PR TITLE
Add Wikiroo second sidebar full-height layout

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -5,6 +5,25 @@
   color: #2c3e50;
 }
 
+/* Wikiroo with sidebar layout */
+.wikiroo-with-sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.wikiroo-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.wikiroo-body .wikiroo-content {
+  flex: 1;
+  overflow-y: auto;
+}
+
 .wikiroo-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Added CSS layout for WikirooWithSidebar to make second sidebar cover entire screen height
- `.wikiroo-with-sidebar`: flex column layout, 100vh height, overflow hidden
- `.wikiroo-body`: flex row layout with flex: 1 and overflow hidden
- `.wikiroo-body .wikiroo-content`: flex: 1 with overflow-y: auto

## Implementation
The Wikiroo page tree sidebar now:
- Uses the same design system classes (`sidebar-app-specific`) as the first sidebar
- Covers the entire height of the screen
- Has collapsible functionality with toggle button at the bottom
- Has localStorage persistence for collapse state
- Auto-collapses when viewing, editing, or creating pages
- Content scrolls independently on the right side

## Test plan
- [x] Build passes successfully
- [ ] Second sidebar covers entire screen height
- [ ] Toggle button works to collapse/expand sidebar
- [ ] Collapse state persists via localStorage
- [ ] Content area scrolls independently
- [ ] Auto-collapse works on page view/edit/create modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)