### PR TITLE
Fix Wikiroo sidebar auto-collapse restriction

### DIFF
--- a/apps/ui/src/wikiroo/WikirooWithSidebar.tsx
+++ b/apps/ui/src/wikiroo/WikirooWithSidebar.tsx
@@ -21,21 +21,10 @@ export function WikirooWithSidebar() {
     return stored === 'true';
   });
 
-  // Determine current view from route
-  const isEditMode = location.pathname.endsWith('/edit');
-  const isCreateMode = location.pathname === '/wikiroo/new';
-  const isPageView = pageId && !isEditMode;
-
-  // Auto-collapse sidebar when viewing, editing, or creating a page
-  const autoCollapse = isPageView || isEditMode || isCreateMode;
-  const isSidebarCollapsed = autoCollapse || wikirooSidebarCollapsed;
-
-  // Save to localStorage on change (only when not auto-collapsed)
+  // Save to localStorage on change
   useEffect(() => {
-    if (!autoCollapse) {
-      localStorage.setItem(STORAGE_KEY, String(wikirooSidebarCollapsed));
-    }
-  }, [wikirooSidebarCollapsed, autoCollapse]);
+    localStorage.setItem(STORAGE_KEY, String(wikirooSidebarCollapsed));
+  }, [wikirooSidebarCollapsed]);
 
   // Load page tree on mount
   useEffect(() => {
@@ -66,7 +55,7 @@ export function WikirooWithSidebar() {
 
   return (
     <div className="wikiroo-with-sidebar">
-      <aside className={`sidebar-app-specific ${isSidebarCollapsed ? 'collapsed' : ''}`}>
+      <aside className={`sidebar-app-specific ${wikirooSidebarCollapsed ? 'collapsed' : ''}`}>
         <nav className="sidebar-content">
           <div className="wikiroo-sidebar-header">
             <h2 className="wikiroo-sidebar-title">Pages</h2>
@@ -96,10 +85,9 @@ export function WikirooWithSidebar() {
         <button
           className="sidebar-toggle"
           onClick={toggleSidebar}
-          aria-label={isSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          disabled={autoCollapse}
+          aria-label={wikirooSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
         >
-          {isSidebarCollapsed ? '→' : '←'}
+          {wikirooSidebarCollapsed ? '→' : '←'}
         </button>
       </aside>
 


### PR DESCRIPTION
## Summary
- Removed auto-collapse logic that forced the sidebar to collapse when viewing/editing/creating pages
- Removed disabled state from toggle button
- Sidebar state now fully controlled by user toggle and localStorage persistence

## Problem
The previous implementation had an auto-collapse feature that:
1. Automatically collapsed the sidebar when viewing/editing/creating pages
2. Disabled the toggle button during auto-collapse
3. Made it impossible for users to expand the sidebar in these views
4. Caused confusion when the sidebar appeared to "disappear"

## Solution
Simplified the sidebar behavior:
- Users can toggle the sidebar at any time
- State persists in localStorage across sessions
- No forced auto-collapse behavior
- Toggle button always enabled

## Test plan
- [ ] Verify sidebar is visible by default on Wikiroo home page
- [ ] Verify clicking toggle button collapses/expands sidebar
- [ ] Verify sidebar state persists after page navigation
- [ ] Verify sidebar state persists after browser refresh
- [ ] Build validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)