### PR TITLE
Fix Wikiroo sidebar styling and collapsed state

### DIFF
--- a/apps/ui/src/styles/sidebar.css
+++ b/apps/ui/src/styles/sidebar.css
@@ -17,6 +17,7 @@
   --sidebar-app-nav-width: 240px;
   --sidebar-app-nav-collapsed-width: 64px;
   --sidebar-app-specific-width: 300px;
+  --sidebar-app-specific-collapsed-width: 64px;
   --sidebar-toggle-size: 40px;
   --sidebar-padding: 16px;
   --sidebar-gap: 8px;
@@ -78,10 +79,12 @@
 .sidebar-app-specific {
   width: var(--sidebar-app-specific-width);
   z-index: calc(var(--sidebar-z-index) - 1);
+  background-color: #ffffff;
+  color: #2c3e50;
 }
 
 .sidebar-app-specific.collapsed {
-  width: 0;
+  width: var(--sidebar-app-specific-collapsed-width);
 }
 
 /* ===========================

--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -594,27 +594,59 @@
   gap: 12px;
   margin-bottom: 12px;
   padding-bottom: 12px;
-  border-bottom: 1px solid #1e293b;
+  border-bottom: 1px solid #e4e6eb;
 }
 
 .wikiroo-sidebar-title {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: #e2e8f0;
+  color: #2c3e50;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .wikiroo-sidebar-new-page {
   padding: 6px 12px;
   font-size: 13px;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .wikiroo-empty-sidebar {
   padding: 16px 0;
   text-align: center;
-  color: #94a3b8;
+  color: #7f8c8d;
   font-size: 14px;
+}
+
+/* Collapsed sidebar state */
+.sidebar-app-specific.collapsed .wikiroo-sidebar-header {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-bottom: 8px;
+  gap: 8px;
+}
+
+.sidebar-app-specific.collapsed .wikiroo-sidebar-title {
+  display: none;
+}
+
+.sidebar-app-specific.collapsed .wikiroo-sidebar-new-page {
+  padding: 8px;
+  font-size: 18px;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sidebar-app-specific.collapsed .page-tree,
+.sidebar-app-specific.collapsed .wikiroo-status,
+.sidebar-app-specific.collapsed .wikiroo-empty-sidebar {
+  display: none;
 }
 
 /* Page Tree Styles */


### PR DESCRIPTION
## Summary
- Fixed collapsed width from 0px to 64px to match app sidebar behavior
- Updated sidebar background to white with dark text
- Added proper collapsed state styling to show only "+" button
- Sidebar now covers full height and matches app sidebar design

## Problem
The previous fix set collapsed width to 0, making the sidebar completely invisible. User wanted it to behave like the app sidebar with a visible collapsed state.

## Solution
**CSS Changes:**
- Added `--sidebar-app-specific-collapsed-width: 64px` variable
- Changed `.sidebar-app-specific.collapsed` width from 0 to 64px
- Set white background (`#ffffff`) and dark text (`#2c3e50`) for Wikiroo sidebar
- Updated border colors to match white background theme

**Collapsed State Styling:**
- Hide title and page tree when collapsed
- Center and enlarge "+" button (40x40px) when collapsed  
- Adjust header layout to column direction when collapsed

## Test plan
- [ ] Verify sidebar is visible with white background
- [ ] Verify clicking collapse shows 64px wide sidebar with "+" button
- [ ] Verify clicking expand shows full sidebar with title and pages
- [ ] Verify sidebar covers full screen height
- [ ] Verify collapsed width matches app sidebar
- [ ] Build validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)