### PR TITLE
Fix Wikiroo sidebar layout to display side-by-side

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -8,7 +8,7 @@
 /* Wikiroo with sidebar layout */
 .wikiroo-with-sidebar {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   height: 100vh;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
Fixed the Wikiroo layout so the sidebar is positioned on the left side of the screen (covering full height) with content on the right, instead of stacking vertically.

## Problem
The `.wikiroo-with-sidebar` container had `flex-direction: column`, which stacked the sidebar vertically on top of the content area. This prevented the sidebar from covering the full height of the viewport and positioning content to the right.

## Solution
Changed `flex-direction: column` to `flex-direction: row` in `.wikiroo-with-sidebar`.

**Before:**
```
[Sidebar - full width]
[Content - full width]
```

**After:**
```
[Sidebar] [Content       ]
[       ] [              ]
[       ] [              ]
```

## Test plan
- [ ] Verify sidebar covers full height of viewport
- [ ] Verify content area is positioned to the right of sidebar
- [ ] Verify sidebar collapse/expand still works
- [ ] Verify layout is responsive
- [ ] Build validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)