### PR TITLE
Tighten Wikiroo page tree layout

### DIFF
--- a/apps/ui/src/wikiroo/PageTree.tsx
+++ b/apps/ui/src/wikiroo/PageTree.tsx
@@ -1,4 +1,4 @@
-import { useState, memo, useMemo } from 'react';
+import { useState, memo, useMemo, useEffect } from 'react';
 import type { WikiPageTree } from './types';
 
 interface PageTreeProps {
@@ -15,9 +15,30 @@ interface PageTreeItemProps {
   onPageClick: (pageId: string) => void;
 }
 
+// Helper function to check if current page is in this subtree
+function hasCurrentPageInSubtree(page: WikiPageTree, currentPageId?: string): boolean {
+  if (!currentPageId) return false;
+  if (page.id === currentPageId) return true;
+  if (page.children) {
+    return page.children.some(child => hasCurrentPageInSubtree(child, currentPageId));
+  }
+  return false;
+}
+
 const PageTreeItem = memo(function PageTreeItem({ page, level, isActive, currentPageId, onPageClick }: PageTreeItemProps) {
-  const [expanded, setExpanded] = useState(true);
   const hasChildren = page.children && page.children.length > 0;
+
+  // Check if current page is in this page's subtree
+  const shouldAutoExpand = hasChildren && hasCurrentPageInSubtree(page, currentPageId);
+
+  const [expanded, setExpanded] = useState(shouldAutoExpand);
+
+  // Auto-expand when current page changes and is in this subtree
+  useEffect(() => {
+    if (shouldAutoExpand) {
+      setExpanded(true);
+    }
+  }, [shouldAutoExpand]);
 
   const handleToggle = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -650,6 +650,11 @@
 }
 
 /* Page Tree Styles */
+.sidebar-app-specific .sidebar-content {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .page-tree {
   background: white;
   border: none;
@@ -664,8 +669,7 @@
 .tree-item-content {
   display: flex;
   align-items: center;
-  padding: 8px 12px;
-  border-bottom: 1px solid #f0f4f8;
+  padding: 4px 8px;
   transition: background-color 0.2s ease;
 }
 
@@ -713,9 +717,9 @@
   flex: 1;
   color: #2c3e50;
   text-decoration: none;
-  font-size: 14px;
+  font-size: 13px;
   cursor: pointer;
-  padding: 4px 0;
+  padding: 2px 0;
   transition: color 0.2s ease;
 }
 


### PR DESCRIPTION
## Summary
Made the Wikiroo page tree more compact and space-efficient by reducing padding, removing borders, and implementing auto-expand functionality.

## Changes

### CSS Styling (Wikiroo.css)
- Removed left/right padding from `.sidebar-app-specific .sidebar-content` (was 16px)
- Reduced `.tree-item-content` padding from `8px 12px` to `4px 8px`
- Removed gray bottom border from tree items
- Reduced `.tree-item-link` font size from 14px to 13px
- Reduced `.tree-item-link` padding from `4px 0` to `2px 0`

### Component Logic (PageTree.tsx)
- Added `hasCurrentPageInSubtree()` helper function to detect if selected page is in a subtree
- Implemented auto-expand: tree nodes automatically expand when the current page or any of its children are selected
- Added `useEffect` to handle expansion state updates when `currentPageId` changes

## Result
The page tree now:
- Fits more items in the same vertical space
- Has cleaner appearance without unnecessary borders
- Automatically expands parent nodes when navigating to child pages
- Maintains comfortable readability with 13px font size

## Test plan
- [ ] Verify reduced padding makes tree more compact
- [ ] Verify no visual borders between tree items
- [ ] Verify font size is readable but smaller
- [ ] Verify clicking a child page auto-expands its parent
- [ ] Verify manual collapse/expand still works
- [ ] Build validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)