### PR TITLE
Manual UI touches for Wikiroo

### DIFF
--- a/apps/ui/src/taskeroo/TaskBoard.css
+++ b/apps/ui/src/taskeroo/TaskBoard.css
@@ -401,9 +401,6 @@ body {
 }
 
 /* Form */
-form {
-  padding: 0 24px 24px 24px;
-}
 
 .form-group {
   margin-bottom: 20px;

--- a/apps/ui/src/wikiroo/PageTree.tsx
+++ b/apps/ui/src/wikiroo/PageTree.tsx
@@ -1,4 +1,4 @@
-import { useState, memo, useMemo, useEffect } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { WikiPageTree } from './types';
 

--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -61,7 +61,7 @@
   justify-content: center;
   gap: 8px;
   border: none;
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 10px 16px;
   font-size: 14px;
   font-weight: 600;
@@ -70,8 +70,8 @@
 }
 
 .wikiroo-button.primary {
-  background: #3498db;
-  color: #ffffff;
+  background: #3b82f6;
+  color: white;
 }
 
 .wikiroo-button.secondary {
@@ -93,7 +93,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 24px;
+  /* padding: 24px; */
   background: #ffffff;
   border-bottom: 1px solid #e4e6eb;
 }
@@ -215,6 +215,8 @@
   background: #ffffff;
   min-width: 0;
   overflow-y: auto;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .wikiroo-welcome {
@@ -377,7 +379,7 @@
 .wikiroo-page-detail {
   max-width: 900px;
   margin: 0 auto;
-  padding: 0 16px;
+  padding: 0;
 }
 
 .wikiroo-page-detail-header {
@@ -590,9 +592,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 12px;
-  padding-bottom: 12px;
+  /* gap: 12px; */
+  /* margin-bottom: 12px; */
+  /* padding-bottom: 12px; */
   border-bottom: 1px solid #e4e6eb;
 }
 
@@ -600,6 +602,7 @@
   margin: 0;
   font-size: 16px;
   font-weight: 600;
+  padding: 10px;
   color: #2c3e50;
   white-space: nowrap;
   overflow: hidden;
@@ -607,6 +610,7 @@
 
 .wikiroo-sidebar-new-page {
   padding: 6px 12px;
+  margin-right: 10px;
   font-size: 13px;
   white-space: nowrap;
   flex-shrink: 0;
@@ -650,6 +654,7 @@
 
 /* Page Tree Styles */
 .sidebar-app-specific .sidebar-content {
+  padding: 0;
   padding-left: 0;
   padding-right: 0;
 }
@@ -668,7 +673,7 @@
 .tree-item-content {
   display: flex;
   align-items: center;
-  padding: 4px 8px;
+  /* padding: 4px 8px; */
   transition: background-color 0.2s ease;
 }
 
@@ -686,7 +691,7 @@
   border: none;
   cursor: pointer;
   padding: 0;
-  margin-right: 8px;
+  margin-right: 3px;
   width: 16px;
   height: 16px;
   display: flex;
@@ -709,7 +714,7 @@
 
 .tree-spacer {
   display: inline-block;
-  width: 24px;
+  width: 19px;
 }
 
 .tree-item-link {

--- a/apps/ui/src/wikiroo/WikirooHome.tsx
+++ b/apps/ui/src/wikiroo/WikirooHome.tsx
@@ -1,7 +1,21 @@
+import { useNavigate } from 'react-router-dom';
+
 export function WikirooHome() {
+
+  const navigate = useNavigate();
+
   return (
     <div className="wikiroo-welcome">
       <h2>Wikiroo</h2>
+      <br />
+      <button
+        className="wikiroo-button primary"
+        type="button"
+        onClick={() => navigate('/wikiroo/new')}
+        title="Create new page"
+      >
+        + New page
+      </button>
     </div>
   );
 }

--- a/apps/ui/src/wikiroo/WikirooWithSidebar.tsx
+++ b/apps/ui/src/wikiroo/WikirooWithSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useParams, useNavigate, Outlet } from 'react-router-dom';
+import { useParams, useNavigate, Outlet, Link } from 'react-router-dom';
 import { PageTree } from './PageTree';
 import { useWikiroo } from './useWikiroo';
 import type { WikiPageTree } from './types';
@@ -57,28 +57,34 @@ export function WikirooWithSidebar() {
     <div className="wikiroo-with-sidebar">
       <aside className={`sidebar-app-specific ${wikirooSidebarCollapsed ? 'collapsed' : ''}`}>
         <nav className="sidebar-content">
-          <div className="wikiroo-sidebar-header">
-            <h2 className="wikiroo-sidebar-title">Pages</h2>
-            <button
-              className="wikiroo-button primary wikiroo-sidebar-new-page"
-              type="button"
-              onClick={() => navigate('/wikiroo/new')}
-              title="Create new page"
-            >
-              + New
-            </button>
-          </div>
-          {isLoadingTree && <div className="wikiroo-status">Loading pages…</div>}
-          {pageTree.length > 0 && (
-            <PageTree
-              pages={pageTree}
-              currentPageId={pageId}
-              onPageClick={handlePageClick}
-            />
-          )}
-          {pageTree.length === 0 && !isLoadingTree && (
-            <div className="wikiroo-empty-sidebar">
-              <span>No pages yet</span>
+          {!wikirooSidebarCollapsed && (
+            <div>
+
+
+              <div className="wikiroo-sidebar-header">
+                <h2 className="wikiroo-sidebar-title">📚 Wikiroo</h2>
+                <button
+                  className="wikiroo-button primary wikiroo-sidebar-new-page"
+                  type="button"
+                  onClick={() => navigate('/wikiroo/new')}
+                  title="Create new page"
+                >
+                  + New page
+                </button>
+              </div>
+              {isLoadingTree && <div className="wikiroo-status">Loading pages…</div>}
+              {pageTree.length > 0 && (
+                <PageTree
+                  pages={pageTree}
+                  currentPageId={pageId}
+                  onPageClick={handlePageClick}
+                />
+              )}
+              {pageTree.length === 0 && !isLoadingTree && (
+                <div className="wikiroo-empty-sidebar">
+                  <span>No pages yet</span>
+                </div>
+              )}
             </div>
           )}
         </nav>


### PR DESCRIPTION
## Summary
- Refined Wikiroo UI styling and layout improvements
- Added "New page" button to Wikiroo home screen
- Improved sidebar header with emoji icon
- Tightened spacing and padding throughout Wikiroo components
- Fixed import ordering in PageTree
- Removed unnecessary form padding in TaskBoard

## Changes
- [WikirooHome.tsx](apps/ui/src/wikiroo/WikirooHome.tsx): Added "New page" button
- [WikirooWithSidebar.tsx](apps/ui/src/wikiroo/WikirooWithSidebar.tsx): Updated sidebar header and layout
- [Wikiroo.css](apps/ui/src/wikiroo/Wikiroo.css): Various spacing and styling refinements
- [PageTree.tsx](apps/ui/src/wikiroo/PageTree.tsx): Fixed import order
- [TaskBoard.css](apps/ui/src/taskeroo/TaskBoard.css): Removed form padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)