### PR TITLE
Add MCP tools for Wikiroo hierarchical page operations

### DIFF
--- a/apps/backend/src/wikiroo/wikiroo.service.ts
+++ b/apps/backend/src/wikiroo/wikiroo.service.ts
@@ -416,6 +416,22 @@ export class WikirooService {
     }
   }
 
+  async getChildPages(parentId: string | null): Promise<PageSummaryResult[]> {
+    this.logger.log({ message: 'Fetching child pages', parentId });
+
+    const whereClause = parentId === null
+      ? { parentId: null as any }
+      : { parentId };
+
+    const children = await this.pageRepository.find({
+      where: whereClause,
+      relations: ['tags'],
+      order: { order: 'ASC' },
+    });
+
+    return children.map((page) => this.mapToSummary(page));
+  }
+
   async getPageTree(): Promise<PageTreeResult[]> {
     this.logger.log({ message: 'Fetching page tree' });
 


### PR DESCRIPTION
Enhancements to Wikiroo MCP server to support the new hierarchical page features.

## Changes

### New MCP Tools
- **get_child_pages**: Retrieve all child pages for a given parent ID (or null for root pages)
- **get_page_tree**: Get the complete hierarchical tree structure of all pages

### Enhanced MCP Tools
- **create_page**: Added `parentId` and `tagNames` parameters to support creating pages with parent relationships and tags
- **update_page**: Added `parentId` and `tagNames` parameters to support moving pages and updating tags

### Service Layer
- Added `getChildPages` method to fetch child pages by parent ID

## Task Requirements Fulfilled
✅ Get all pages for a given tag - Already existed via `list_pages` with tag parameter
✅ Get all child pages for a given page - New `get_child_pages` tool
✅ Assign parent when creating/editing a page - Enhanced `create_page` and `update_page` tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)