### PR TITLE
Add Agents admin pages with full CRUD functionality

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -14,7 +14,8 @@ import { ConsentScreen } from './consent/ConsentScreen';
 import { AgentsWithSidebar } from './agents/AgentsWithSidebar';
 import { AgentsHome } from './agents/AgentsHome';
 import { AgentsChatSession } from './agents/AgentsChatSession';
-import { AgentsAdmin } from './agents/AgentsAdmin';
+import { AgentsAdminList } from './agents/AgentsAdminList';
+import { AgentAdminDetail } from './agents/AgentAdminDetail';
 
 // Simple mobile detection
 const isMobile = () => {
@@ -48,7 +49,8 @@ export default function App() {
           {/* Agents nested routes with AgentsWithSidebar layout */}
           <Route path="agents" element={<AgentsWithSidebar />}>
             <Route index element={<AgentsHome />} />
-            <Route path="admin" element={<AgentsAdmin />} />
+            <Route path="admin" element={<AgentsAdminList />} />
+            <Route path=":agentId/admin" element={<AgentAdminDetail />} />
             <Route path=":agentId/session/:sessionId" element={<AgentsChatSession />} />
           </Route>
         </Route>

--- a/apps/ui/src/agents/AgentAdminDetail.tsx
+++ b/apps/ui/src/agents/AgentAdminDetail.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useAgents } from './useAgents';
+import { ConfirmDialog } from '../components/ConfirmDialog';
+
+interface ConfirmState {
+  message: string;
+  onConfirm: () => void;
+}
+
+export function AgentAdminDetail() {
+  const { agentId } = useParams<{ agentId: string }>();
+  const navigate = useNavigate();
+  const {
+    selectedAgent,
+    isLoading,
+    error,
+    loadAgentDetails,
+    updateAgent,
+    deleteAgent,
+  } = useAgents();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [confirmState, setConfirmState] = useState<ConfirmState | null>(null);
+  const [formData, setFormData] = useState({
+    slug: '',
+    name: '',
+    description: '',
+    systemPrompt: '',
+    allowedTools: '',
+    isActive: true,
+  });
+
+  useEffect(() => {
+    if (agentId) {
+      loadAgentDetails(agentId);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    if (selectedAgent) {
+      setFormData({
+        slug: selectedAgent.slug,
+        name: selectedAgent.name,
+        description: selectedAgent.description?.toString() || '',
+        systemPrompt: selectedAgent.systemPrompt,
+        allowedTools: selectedAgent.allowedTools.join(', '),
+        isActive: selectedAgent.isActive,
+      });
+    }
+  }, [selectedAgent]);
+
+  const handleUpdateAgent = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!agentId) return;
+    try {
+      await updateAgent(agentId, {
+        slug: formData.slug,
+        name: formData.name,
+        description: formData.description,
+        systemPrompt: formData.systemPrompt,
+        allowedTools: formData.allowedTools.split(',').map(tool => tool.trim()).filter(Boolean),
+        isActive: formData.isActive,
+      });
+      setIsEditing(false);
+    } catch (err) {
+      console.error('Failed to update agent', err);
+    }
+  };
+
+  const handleDeleteAgent = async () => {
+    if (!agentId) return;
+    setConfirmState({
+      message: 'Are you sure you want to delete this agent? This action cannot be undone.',
+      onConfirm: async () => {
+        try {
+          await deleteAgent(agentId);
+          setConfirmState(null);
+          navigate('/agents/admin');
+        } catch (err) {
+          console.error('Failed to delete agent', err);
+          setConfirmState(null);
+        }
+      },
+    });
+  };
+
+  if (isLoading && !selectedAgent) {
+    return <div className="loading">Loading agent details...</div>;
+  }
+
+  if (!selectedAgent) {
+    return <div className="error-message">Agent not found</div>;
+  }
+
+  return (
+    <div className="agent-admin-detail">
+      <div className="agent-admin-detail-header">
+        <div>
+          <button onClick={() => navigate('/agents/admin')} className="btn-back">
+            ← Back to Agents
+          </button>
+          <h1>{selectedAgent.name}</h1>
+          <p className="agent-slug">@{selectedAgent.slug}</p>
+          <span className={`agent-status ${selectedAgent.isActive ? 'active' : 'inactive'}`}>
+            {selectedAgent.isActive ? 'Active' : 'Inactive'}
+          </span>
+        </div>
+        <div className="header-actions">
+          {!isEditing ? (
+            <>
+              <button onClick={() => setIsEditing(true)} className="btn-secondary">
+                Edit Agent
+              </button>
+              <button onClick={handleDeleteAgent} className="btn-delete">
+                Delete Agent
+              </button>
+            </>
+          ) : (
+            <button onClick={() => setIsEditing(false)} className="btn-secondary">
+              Cancel Edit
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && <div className="error-message">{error}</div>}
+
+      {isEditing ? (
+        <form onSubmit={handleUpdateAgent} className="agent-edit-form">
+          <div className="form-group">
+            <label htmlFor="slug">Slug</label>
+            <input
+              type="text"
+              id="slug"
+              value={formData.slug}
+              onChange={(e) => setFormData({ ...formData, slug: e.target.value })}
+              placeholder="e.g., code-assistant"
+              required
+            />
+            <small>Unique identifier (lowercase, hyphens allowed)</small>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="name">Name</label>
+            <input
+              type="text"
+              id="name"
+              value={formData.name}
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              placeholder="e.g., Code Assistant"
+              required
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="description">Description</label>
+            <textarea
+              id="description"
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              placeholder="Brief description of this agent"
+              rows={2}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="systemPrompt">System Prompt</label>
+            <textarea
+              id="systemPrompt"
+              value={formData.systemPrompt}
+              onChange={(e) => setFormData({ ...formData, systemPrompt: e.target.value })}
+              placeholder="Core instructions/persona for this agent"
+              rows={10}
+              required
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="allowedTools">Allowed Tools</label>
+            <input
+              type="text"
+              id="allowedTools"
+              value={formData.allowedTools}
+              onChange={(e) => setFormData({ ...formData, allowedTools: e.target.value })}
+              placeholder="e.g., filesystem, browser, calculator (comma-separated)"
+            />
+            <small>Comma-separated list of tool identifiers</small>
+          </div>
+
+          <div className="form-group">
+            <label className="checkbox-label">
+              <input
+                type="checkbox"
+                checked={formData.isActive}
+                onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
+              />
+              <span>Active (available for assignment)</span>
+            </label>
+          </div>
+
+          <div className="form-actions">
+            <button type="button" onClick={() => setIsEditing(false)} className="btn-secondary">
+              Cancel
+            </button>
+            <button type="submit" className="btn-primary">
+              Save Changes
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="agent-detail-sections">
+          <div className="detail-section">
+            <h2>Basic Information</h2>
+            <div className="detail-content">
+              <div className="detail-field">
+                <label>Name</label>
+                <p>{selectedAgent.name}</p>
+              </div>
+              <div className="detail-field">
+                <label>Slug</label>
+                <p>@{selectedAgent.slug}</p>
+              </div>
+              <div className="detail-field">
+                <label>Description</label>
+                <p>{selectedAgent.description?.toString() || 'No description'}</p>
+              </div>
+              <div className="detail-field">
+                <label>Status</label>
+                <p>{selectedAgent.isActive ? 'Active' : 'Inactive'}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="detail-section">
+            <h2>System Prompt</h2>
+            <div className="detail-content">
+              <pre className="system-prompt-display">{selectedAgent.systemPrompt}</pre>
+            </div>
+          </div>
+
+          <div className="detail-section">
+            <h2>Allowed Tools</h2>
+            <div className="detail-content">
+              {selectedAgent.allowedTools.length > 0 ? (
+                <div className="tools-list">
+                  {selectedAgent.allowedTools.map((tool, index) => (
+                    <span key={index} className="tool-badge">{tool}</span>
+                  ))}
+                </div>
+              ) : (
+                <p className="empty-text">No tools configured</p>
+              )}
+            </div>
+          </div>
+
+          <div className="detail-section">
+            <h2>Metadata</h2>
+            <div className="detail-content">
+              <div className="detail-field">
+                <label>Created At</label>
+                <p>{new Date(selectedAgent.createdAt).toLocaleString()}</p>
+              </div>
+              <div className="detail-field">
+                <label>Last Updated</label>
+                <p>{new Date(selectedAgent.updatedAt).toLocaleString()}</p>
+              </div>
+              <div className="detail-field">
+                <label>Row Version</label>
+                <p>{selectedAgent.rowVersion}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {confirmState && (
+        <ConfirmDialog
+          message={confirmState.message}
+          onConfirm={confirmState.onConfirm}
+          onCancel={() => setConfirmState(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/agents/Agents.css
+++ b/apps/ui/src/agents/Agents.css
@@ -393,3 +393,436 @@
 .sidebar-app-specific.collapsed .agents-history-list {
   display: none;
 }
+
+/* Agents Admin List Page */
+.agents-admin-list {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.agents-admin-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 32px;
+}
+
+.agents-admin-header h1 {
+  margin: 0 0 8px 0;
+  font-size: 32px;
+  font-weight: 700;
+  color: #2c3e50;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 16px;
+  color: #7f8c8d;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.btn-primary {
+  background: #3b82f6;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-primary:hover {
+  background: #2563eb;
+  transform: translateY(-1px);
+}
+
+.btn-secondary {
+  background: white;
+  color: #3b82f6;
+  border: 1px solid #3b82f6;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-secondary:hover {
+  background: #eff6ff;
+}
+
+.btn-back {
+  background: transparent;
+  color: #3b82f6;
+  border: none;
+  padding: 8px 0;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: 12px;
+  transition: color 0.2s ease;
+}
+
+.btn-back:hover {
+  color: #2563eb;
+}
+
+.btn-delete {
+  background: #ef4444;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-delete:hover {
+  background: #dc2626;
+  transform: translateY(-1px);
+}
+
+.error-message {
+  background: #fee;
+  border: 1px solid #fcc;
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  color: #c00;
+}
+
+.loading {
+  text-align: center;
+  padding: 48px;
+  color: #7f8c8d;
+  font-size: 16px;
+}
+
+.agents-admin-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+}
+
+.empty-state {
+  text-align: center;
+  padding: 64px 24px;
+  background: white;
+  border-radius: 12px;
+  border: 2px dashed #e4e6eb;
+}
+
+.empty-state p {
+  margin: 0 0 16px 0;
+  font-size: 16px;
+  color: #7f8c8d;
+}
+
+.agent-admin-card {
+  background: white;
+  border: 1px solid #e4e6eb;
+  border-radius: 12px;
+  padding: 20px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.agent-admin-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-color: #3b82f6;
+}
+
+.agent-admin-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.agent-admin-card h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.agent-status {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.agent-status.active {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.agent-status.inactive {
+  background: #fee;
+  color: #991b1b;
+}
+
+.agent-slug {
+  margin: 0 0 8px 0;
+  font-size: 13px;
+  color: #7f8c8d;
+  font-family: monospace;
+}
+
+.agent-description {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  color: #2c3e50;
+  line-height: 1.5;
+}
+
+.agent-tools {
+  margin: 0;
+  font-size: 13px;
+  color: #7f8c8d;
+}
+
+/* Agents Admin Detail Page */
+.agent-admin-detail {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.agent-admin-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 32px;
+}
+
+.agent-admin-detail-header h1 {
+  margin: 8px 0;
+  font-size: 28px;
+  font-weight: 700;
+  color: #2c3e50;
+}
+
+.agent-edit-form {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  border: 1px solid #e4e6eb;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.form-group input[type="text"],
+.form-group textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #dce4ec;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: inherit;
+  transition: border-color 0.2s ease;
+}
+
+.form-group input[type="text"]:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+.form-group textarea {
+  resize: vertical;
+  font-family: 'SF Mono', 'Monaco', 'Courier New', monospace;
+  line-height: 1.5;
+}
+
+.form-group small {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: #7f8c8d;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.checkbox-label span {
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+
+.agent-detail-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.detail-section {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  border: 1px solid #e4e6eb;
+}
+
+.detail-section h2 {
+  margin: 0 0 16px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.detail-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.detail-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.detail-field label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #7f8c8d;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.detail-field p {
+  margin: 0;
+  font-size: 14px;
+  color: #2c3e50;
+}
+
+.system-prompt-display {
+  background: #f8f9fa;
+  padding: 16px;
+  border-radius: 8px;
+  font-family: 'SF Mono', 'Monaco', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #2c3e50;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  margin: 0;
+}
+
+.tools-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tool-badge {
+  background: #e3f2fd;
+  color: #1976d2;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.empty-text {
+  color: #7f8c8d;
+  font-size: 14px;
+  margin: 0;
+}
+
+/* Modal Styles */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-content h2 {
+  margin: 0 0 20px 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .agents-admin-list,
+  .agent-admin-detail {
+    padding: 16px;
+  }
+
+  .agents-admin-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .agents-admin-header,
+  .agent-admin-detail-header {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .header-actions button {
+    flex: 1;
+  }
+}

--- a/apps/ui/src/agents/AgentsAdminList.tsx
+++ b/apps/ui/src/agents/AgentsAdminList.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAgents } from './useAgents';
+
+export function AgentsAdminList() {
+  const { agents, isLoading, error, createAgent } = useAgents();
+  const navigate = useNavigate();
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [formData, setFormData] = useState({
+    slug: '',
+    name: '',
+    description: '',
+    systemPrompt: '',
+    allowedTools: '',
+    isActive: true,
+  });
+
+  const handleCreateAgent = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const createdAgent = await createAgent({
+        slug: formData.slug,
+        name: formData.name,
+        description: formData.description,
+        systemPrompt: formData.systemPrompt,
+        allowedTools: formData.allowedTools.split(',').map(tool => tool.trim()).filter(Boolean),
+        isActive: formData.isActive,
+      });
+      setShowCreateForm(false);
+      setFormData({ slug: '', name: '', description: '', systemPrompt: '', allowedTools: '', isActive: true });
+      // Navigate to the newly created agent's admin page
+      if (createdAgent) {
+        navigate(`/agents/${createdAgent.id}/admin`);
+      }
+    } catch (err) {
+      console.error('Failed to create agent', err);
+    }
+  };
+
+  return (
+    <div className="agents-admin-list">
+      <div className="agents-admin-header">
+        <div>
+          <h1>Agents Admin</h1>
+          <p className="subtitle">Manage agents and their configurations</p>
+        </div>
+        <div className="header-actions">
+          <button onClick={() => setShowCreateForm(true)} className="btn-primary">
+            + Create Agent
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="error-message">
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="loading">Loading agents...</div>
+      ) : (
+        <div className="agents-admin-grid">
+          {agents.length === 0 ? (
+            <div className="empty-state">
+              <p>No agents created yet.</p>
+              <button onClick={() => setShowCreateForm(true)} className="btn-primary">
+                Create your first agent
+              </button>
+            </div>
+          ) : (
+            agents.map((agent) => (
+              <div
+                key={agent.id}
+                className="agent-admin-card"
+                onClick={() => navigate(`/agents/${agent.id}/admin`)}
+              >
+                <div className="agent-admin-card-header">
+                  <h3>{agent.name}</h3>
+                  <span className={`agent-status ${agent.isActive ? 'active' : 'inactive'}`}>
+                    {agent.isActive ? 'Active' : 'Inactive'}
+                  </span>
+                </div>
+                <p className="agent-slug">@{agent.slug}</p>
+                <p className="agent-description">{typeof agent.description === 'string' ? agent.description : 'No description'}</p>
+                <p className="agent-tools">Tools: {agent.allowedTools.length > 0 ? agent.allowedTools.join(', ') : 'None'}</p>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {showCreateForm && (
+        <div className="modal-overlay" onClick={() => setShowCreateForm(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h2>Create Agent</h2>
+            <form onSubmit={handleCreateAgent}>
+              <div className="form-group">
+                <label htmlFor="slug">Slug</label>
+                <input
+                  type="text"
+                  id="slug"
+                  value={formData.slug}
+                  onChange={(e) => setFormData({ ...formData, slug: e.target.value })}
+                  placeholder="e.g., code-assistant"
+                  required
+                />
+                <small>Unique identifier (lowercase, hyphens allowed)</small>
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="name">Name</label>
+                <input
+                  type="text"
+                  id="name"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  placeholder="e.g., Code Assistant"
+                  required
+                />
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="description">Description</label>
+                <textarea
+                  id="description"
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  placeholder="Brief description of this agent"
+                  rows={2}
+                />
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="systemPrompt">System Prompt</label>
+                <textarea
+                  id="systemPrompt"
+                  value={formData.systemPrompt}
+                  onChange={(e) => setFormData({ ...formData, systemPrompt: e.target.value })}
+                  placeholder="Core instructions/persona for this agent"
+                  rows={5}
+                  required
+                />
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="allowedTools">Allowed Tools</label>
+                <input
+                  type="text"
+                  id="allowedTools"
+                  value={formData.allowedTools}
+                  onChange={(e) => setFormData({ ...formData, allowedTools: e.target.value })}
+                  placeholder="e.g., filesystem, browser, calculator (comma-separated)"
+                />
+                <small>Comma-separated list of tool identifiers</small>
+              </div>
+
+              <div className="form-group">
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={formData.isActive}
+                    onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
+                  />
+                  <span>Active (available for assignment)</span>
+                </label>
+              </div>
+
+              <div className="form-actions">
+                <button type="button" onClick={() => setShowCreateForm(false)} className="btn-secondary">
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary">
+                  Create Agent
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/agents/api.ts
+++ b/apps/ui/src/agents/api.ts
@@ -1,0 +1,7 @@
+import { OpenAPI, AgentService } from 'shared';
+import { API_BASE_URL } from '../config/api';
+
+// Use centralized API configuration
+OpenAPI.BASE = API_BASE_URL;
+
+export { AgentService };

--- a/apps/ui/src/agents/useAgents.ts
+++ b/apps/ui/src/agents/useAgents.ts
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import { AgentService } from './api';
+import type { AgentResponseDto, CreateAgentDto, UpdateAgentDto } from 'shared';
+
+export const useAgents = () => {
+  // UI feedback
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Data store
+  const [agents, setAgents] = useState<AgentResponseDto[]>([]);
+  const [selectedAgent, setSelectedAgent] = useState<AgentResponseDto | null>(null);
+
+  // Boot
+  useEffect(() => {
+    loadAgents();
+  }, []);
+
+  // Load agents
+  const loadAgents = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await AgentService.agentsControllerListAgents();
+      setAgents(response.items || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load agents');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Load agent details
+  const loadAgentDetails = async (agentId: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const agentData = await AgentService.agentsControllerGetAgent(agentId);
+      setSelectedAgent(agentData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load agent details');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Create agent
+  const createAgent = async (data: CreateAgentDto): Promise<AgentResponseDto | null> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const createdAgent = await AgentService.agentsControllerCreateAgent(data);
+      await loadAgents(); // Refresh the list
+      return createdAgent;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create agent');
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Update agent
+  const updateAgent = async (agentId: string, data: UpdateAgentDto): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const updatedAgent = await AgentService.agentsControllerUpdateAgent(agentId, data);
+      setSelectedAgent(updatedAgent);
+      await loadAgents(); // Refresh the list
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update agent');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Delete agent
+  const deleteAgent = async (agentId: string): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await AgentService.agentsControllerDeleteAgent(agentId);
+      await loadAgents(); // Refresh the list
+      if (selectedAgent?.id === agentId) {
+        setSelectedAgent(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete agent');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    agents,
+    selectedAgent,
+    isLoading,
+    error,
+    loadAgents,
+    loadAgentDetails,
+    createAgent,
+    updateAgent,
+    deleteAgent,
+  };
+};


### PR DESCRIPTION
## Summary

This PR implements comprehensive agent management pages following the MCP Registry pattern for consistency.

### Admin List Page (/agents/admin)
- Grid view displaying all agents with status badges (Active/Inactive)
- Create new agent button that opens a modal form
- Modal includes fields for:
  - Slug (unique identifier)
  - Name (display name)
  - Description
  - System Prompt (core instructions/persona)
  - Allowed Tools (comma-separated list)
  - Active status checkbox
- Click on agent card navigates to detail page

### Agent Detail Page (/agents/:agentId/admin)
- View mode displaying:
  - Basic information (name, slug, description, status)
  - System prompt in formatted code block
  - Allowed tools as badge list
  - Metadata (created/updated timestamps, row version)
- Edit mode with inline form for updating all agent fields
- Delete button with confirmation dialog
- Back navigation to admin list

### API Integration
- Created `api.ts` wrapper exporting AgentService from shared package
- Created `useAgents` hook managing:
  - Agent list state
  - Selected agent state
  - Loading/error states
  - CRUD operations (create, read, update, delete)
  - Automatic list refresh after mutations

### Routing Updates
- `/agents/admin` → AgentsAdminList component
- `/agents/:agentId/admin` → AgentAdminDetail component
- Removed placeholder AgentsAdmin component

### Styling
- Added 400+ lines of admin-specific styles to Agents.css
- Form styles, modal overlays, status badges, tool badges
- Responsive grid layout
- Consistent with MCP Registry visual design

## Test Plan
- [x] Build validation passed (npm run build:prod)
- [ ] Manual testing: Navigate to /agents/admin and verify grid renders
- [ ] Manual testing: Create a new agent and verify navigation to detail page
- [ ] Manual testing: Edit agent details and verify updates persist
- [ ] Manual testing: Delete agent and verify navigation back to list
- [ ] Manual testing: Verify form validation works correctly
- [ ] Responsive testing: Verify layout works on mobile/tablet

🤖 Generated with [Claude Code](https://claude.com/claude-code)