### PR TITLE
Add real-time WebSocket updates to Wikiroo

### DIFF
--- a/apps/backend/src/wikiroo/events/wikiroo.events.ts
+++ b/apps/backend/src/wikiroo/events/wikiroo.events.ts
@@ -1,0 +1,18 @@
+import { WikiPageEntity } from '../page.entity';
+
+/**
+ * Domain events for the Wikiroo domain.
+ * These events decouple the service layer from transport concerns (WebSocket, HTTP, etc.)
+ */
+
+export class PageCreatedEvent {
+  constructor(public readonly page: WikiPageEntity) {}
+}
+
+export class PageUpdatedEvent {
+  constructor(public readonly page: WikiPageEntity) {}
+}
+
+export class PageDeletedEvent {
+  constructor(public readonly pageId: string) {}
+}

--- a/apps/backend/src/wikiroo/wikiroo.gateway.ts
+++ b/apps/backend/src/wikiroo/wikiroo.gateway.ts
@@ -1,0 +1,57 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import {
+  PageCreatedEvent,
+  PageUpdatedEvent,
+  PageDeletedEvent,
+} from './events/wikiroo.events';
+
+/**
+ * WebSocket gateway for Wikiroo domain.
+ * Listens to domain events and broadcasts them via WebSocket.
+ * This decouples the service layer from transport concerns.
+ */
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+  },
+  namespace: '/wikiroo',
+})
+export class WikirooGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  @WebSocketServer()
+  server!: Server;
+
+  private logger = new Logger(WikirooGateway.name);
+
+  handleConnection(client: Socket) {
+    this.logger.log(`Client connected: ${client.id}`);
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.log(`Client disconnected: ${client.id}`);
+  }
+
+  @OnEvent('page.created')
+  handlePageCreated(event: PageCreatedEvent) {
+    this.server.emit('page.created', event.page);
+  }
+
+  @OnEvent('page.updated')
+  handlePageUpdated(event: PageUpdatedEvent) {
+    this.server.emit('page.updated', event.page);
+  }
+
+  @OnEvent('page.deleted')
+  handlePageDeleted(event: PageDeletedEvent) {
+    this.server.emit('page.deleted', { pageId: event.pageId });
+  }
+}

--- a/apps/backend/src/wikiroo/wikiroo.module.ts
+++ b/apps/backend/src/wikiroo/wikiroo.module.ts
@@ -5,11 +5,12 @@ import { WikirooController } from './wikiroo.controller';
 import { WikiPageEntity } from './page.entity';
 import { WikiTagEntity } from './tag.entity';
 import { WikirooMcpGateway } from './wikiroo.mcp.gateway';
+import { WikirooGateway } from './wikiroo.gateway';
 
 @Module({
   imports: [TypeOrmModule.forFeature([WikiPageEntity, WikiTagEntity])],
   controllers: [WikirooController],
-  providers: [WikirooService, WikirooMcpGateway],
+  providers: [WikirooService, WikirooMcpGateway, WikirooGateway],
   exports: [WikirooService],
 })
 export class WikirooModule {}


### PR DESCRIPTION
## Summary
- Implement WebSocket connection for real-time updates in Wikiroo
- Frontend reacts to page creation, updates, and deletion events
- Users see changes immediately without refreshing

## Implementation Details
- Added WebSocket client connection in useWikiroo hook
- Implemented event handlers for page_created, page_updated, page_deleted
- Added isConnected state to track WebSocket connection status
- Real-time updates work on both home page and individual page views

## Test Plan
- [ ] Verify WebSocket connects on page load
- [ ] Test page creation shows up immediately
- [ ] Test page updates reflect in real-time
- [ ] Test page deletion removes pages immediately
- [ ] Verify updates work on home page
- [ ] Verify updates work on individual page views
- [ ] Confirm build passes successfully