### PR TITLE
Fix Wikiroo nav tree not updating on page changes

### DIFF
--- a/apps/ui/src/wikiroo/useWikiroo.ts
+++ b/apps/ui/src/wikiroo/useWikiroo.ts
@@ -401,6 +401,7 @@ export const useWikiroo = () => {
     isDeleting,
     error,
     isConnected,
+    socket,
     loadPages,
     createPage,
     selectPage,


### PR DESCRIPTION
## Summary
- Fixed issue where Wikiroo sidebar tree didn't update when pages were created, updated, or deleted
- Exposed WebSocket socket from useWikiroo hook
- Added event listeners in WikirooWithSidebar to reload tree on page.created, page.updated, and page.deleted events

## Test plan
- Create a new page and verify it appears in the sidebar without refresh
- Edit a page title and verify it updates in the sidebar without refresh
- Move a page to a different parent and verify the tree structure updates without refresh
- Test with remote changes via WebSocket to ensure they also update the tree

Closes task: 5878dc19-5470-489b-b58b-0ff150a7397b