### PR TITLE
Fix Taskeroo comment line breaks

### DIFF
--- a/apps/ui/src/taskeroo/TaskBoard.css
+++ b/apps/ui/src/taskeroo/TaskBoard.css
@@ -617,6 +617,7 @@ body {
   margin: 6px 0;
   color: #34495e;
   font-size: 14px;
+  white-space: pre-wrap;
 }
 
 .comment-date {


### PR DESCRIPTION
## Summary
- Fixed comment display to preserve line breaks by adding `white-space: pre-wrap` to `.comment p` CSS rule
- Comments with `\n` characters now display with proper line breaks instead of showing all text on one line

## Test plan
- Add a comment with multiple lines (containing `\n`) in Taskeroo task detail view
- Verify the comment displays with proper line breaks
- Verify existing single-line comments still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)