### PR TITLE
Fix Taskeroo column widths

### DIFF
--- a/apps/ui/src/taskeroo/TaskBoard.css
+++ b/apps/ui/src/taskeroo/TaskBoard.css
@@ -75,6 +75,8 @@ body {
   padding: 15px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   min-height: 400px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .column-header {
@@ -154,6 +156,8 @@ body {
   padding: 15px;
   cursor: pointer;
   transition: all 0.2s ease;
+  overflow: hidden;
+  word-wrap: break-word;
 }
 
 .task-card:hover {


### PR DESCRIPTION
## Summary
- Fixed Taskeroo kanban board column widths to remain equal regardless of content
- Columns now maintain consistent width and text wraps properly instead of expanding

## Changes
- Added `min-width: 0` and `overflow: hidden` to `.kanban-column` class
- Added `overflow: hidden` and `word-wrap: break-word` to `.task-card` class

## Test plan
- ✅ Build passes (`npm run build:prod`)
- Manual testing: Columns should now maintain equal width even with long text content

🤖 Generated with [Claude Code](https://claude.com/claude-code)