### PR TITLE
Add page list view to Wikiroo home

### DIFF
--- a/apps/ui/src/wikiroo/WikirooHome.tsx
+++ b/apps/ui/src/wikiroo/WikirooHome.tsx
@@ -1,21 +1,78 @@
 import { useNavigate } from 'react-router-dom';
+import { useWikiroo } from './useWikiroo';
+import { TagBadge } from './TagBadge';
 
 export function WikirooHome() {
-
   const navigate = useNavigate();
+  const { pages, isLoadingList } = useWikiroo();
+
+  if (isLoadingList) {
+    return (
+      <div className="wikiroo-welcome">
+        <p>Loading pages...</p>
+      </div>
+    );
+  }
+
+  if (pages.length === 0) {
+    return (
+      <div className="wikiroo-welcome">
+        <h2>Wikiroo</h2>
+        <br />
+        <button
+          className="wikiroo-button primary"
+          type="button"
+          onClick={() => navigate('/wikiroo/new')}
+          title="Create new page"
+        >
+          + New page
+        </button>
+      </div>
+    );
+  }
 
   return (
-    <div className="wikiroo-welcome">
-      <h2>Wikiroo</h2>
-      <br />
-      <button
-        className="wikiroo-button primary"
-        type="button"
-        onClick={() => navigate('/wikiroo/new')}
-        title="Create new page"
-      >
-        + New page
-      </button>
+    <div className="wikiroo-content" style={{ padding: '24px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
+        <h2 style={{ margin: 0 }}>All Pages</h2>
+        <button
+          className="wikiroo-button primary"
+          type="button"
+          onClick={() => navigate('/wikiroo/new')}
+          title="Create new page"
+        >
+          + New page
+        </button>
+      </div>
+
+      <div className="wikiroo-grid">
+        {pages.map((page) => (
+          <div
+            key={page.id}
+            className="wikiroo-card"
+            onClick={() => navigate(`/wikiroo/page/${page.id}`)}
+            style={{ cursor: 'pointer' }}
+          >
+            <h3>{page.title}</h3>
+
+            {page.tags && page.tags.length > 0 && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                {page.tags.map((tag) => (
+                  <TagBadge key={tag.name} tag={tag} />
+                ))}
+              </div>
+            )}
+
+            <div className="wikiroo-card-meta">
+              <span>By {page.author}</span>
+              <span>Created {new Date(page.createdAt).toLocaleDateString()}</span>
+              {page.updatedAt !== page.createdAt && (
+                <span>Updated {new Date(page.updatedAt).toLocaleDateString()}</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Updated WikirooHome component to display a card-based list of all existing pages
- Each card shows title, tags, author, created date, and updated date
- Uses existing wikiroo-grid and wikiroo-card CSS classes for consistent styling
- Maintains the "New page" button for easy access
- Shows loading state while pages are being fetched
- Falls back to welcome screen when no pages exist

## Test plan
- [ ] Navigate to /wikiroo with no pages - should show welcome screen with "New page" button
- [ ] Create some pages with tags and authors
- [ ] Navigate to /wikiroo - should show card grid with all pages
- [ ] Click on a card - should navigate to the page detail view
- [ ] Verify tags display correctly with colors
- [ ] Verify dates display in correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)