### PR TITLE
Simplify Wikiroo WebSocket status indicator

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -819,6 +819,27 @@
   font-weight: 500;
 }
 
+/* WebSocket status indicator dot */
+.wikiroo-status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background-color: #10b981;
+  border-radius: 50%;
+  margin-left: 8px;
+  box-shadow: 0 0 6px rgba(16, 185, 129, 0.6);
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
 /* Mobile-specific styles for touch targets */
 @media (max-width: 768px) {
   .tree-toggle {

--- a/apps/ui/src/wikiroo/WikirooWithSidebar.tsx
+++ b/apps/ui/src/wikiroo/WikirooWithSidebar.tsx
@@ -86,10 +86,9 @@ export function WikirooWithSidebar() {
       <aside className={`sidebar-app-specific ${wikirooSidebarCollapsed ? 'collapsed' : ''}`}>
         <nav className="sidebar-content">
           {wikirooSidebarCollapsed && isConnected && (
-            <div style={{ position: 'relative', display: 'flex', justifyContent: 'center', padding: '8px' }}>
+            <div style={{ display: 'flex', justifyContent: 'center', padding: '8px' }}>
               <span
-                className="connection-status-dot"
-                style={{ position: 'static', margin: '0 auto' }}
+                className="wikiroo-status-dot"
                 title="WebSocket connected"
                 aria-label="WebSocket connected"
               />
@@ -100,16 +99,16 @@ export function WikirooWithSidebar() {
 
 
               <div className="wikiroo-sidebar-header">
-                <div style={{ position: 'relative', display: 'inline-block' }}>
-                  <h2 className="wikiroo-sidebar-title">📚 Wikiroo</h2>
+                <h2 className="wikiroo-sidebar-title">
+                  📚 Wikiroo
                   {isConnected && (
                     <span
-                      className="connection-status-dot"
+                      className="wikiroo-status-dot"
                       title="WebSocket connected"
                       aria-label="WebSocket connected"
                     />
                   )}
-                </div>
+                </h2>
                 <button
                   className="wikiroo-button primary wikiroo-sidebar-new-page"
                   type="button"


### PR DESCRIPTION
## Summary
- Reimplemented WebSocket status indicator as a simple green dot
- Removed chip-style background and "connected" text
- Dot now appears inline with the "📚 Wikiroo" title
- Added subtle pulse animation for visual feedback
- Works correctly in both expanded and collapsed sidebar states

## Test plan
- [ ] Open Wikiroo with sidebar expanded - verify green dot appears next to "📚 Wikiroo" title
- [ ] Collapse the sidebar - verify green dot displays centered at top
- [ ] Disconnect WebSocket - verify dot disappears in both states
- [ ] Reconnect WebSocket - verify dot reappears with animation
- [ ] Verify dot has subtle pulse animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)