### PR TITLE
Add disconnected state styling to Wikiroo websocket status indicator

### DIFF
--- a/apps/ui/src/wikiroo/Wikiroo.css
+++ b/apps/ui/src/wikiroo/Wikiroo.css
@@ -824,11 +824,19 @@
   display: inline-block;
   width: 8px;
   height: 8px;
-  background-color: #10b981;
   border-radius: 50%;
   margin-left: 8px;
-  box-shadow: 0 0 6px rgba(16, 185, 129, 0.6);
   animation: pulse-dot 2s ease-in-out infinite;
+}
+
+.wikiroo-status-dot.connected {
+  background-color: #10b981;
+  box-shadow: 0 0 6px rgba(16, 185, 129, 0.6);
+}
+
+.wikiroo-status-dot.disconnected {
+  background-color: #ef4444;
+  box-shadow: 0 0 6px rgba(239, 68, 68, 0.6);
 }
 
 @keyframes pulse-dot {

--- a/apps/ui/src/wikiroo/WikirooWithSidebar.tsx
+++ b/apps/ui/src/wikiroo/WikirooWithSidebar.tsx
@@ -85,12 +85,12 @@ export function WikirooWithSidebar() {
     <div className="wikiroo-with-sidebar">
       <aside className={`sidebar-app-specific ${wikirooSidebarCollapsed ? 'collapsed' : ''}`}>
         <nav className="sidebar-content">
-          {wikirooSidebarCollapsed && isConnected && (
+          {wikirooSidebarCollapsed && (
             <div style={{ display: 'flex', justifyContent: 'center', padding: '8px' }}>
               <span
-                className="wikiroo-status-dot"
-                title="WebSocket connected"
-                aria-label="WebSocket connected"
+                className={`wikiroo-status-dot ${isConnected ? 'connected' : 'disconnected'}`}
+                title={isConnected ? 'WebSocket connected' : 'WebSocket disconnected'}
+                aria-label={isConnected ? 'WebSocket connected' : 'WebSocket disconnected'}
               />
             </div>
           )}
@@ -101,13 +101,11 @@ export function WikirooWithSidebar() {
               <div className="wikiroo-sidebar-header">
                 <h2 className="wikiroo-sidebar-title">
                   📚 Wikiroo
-                  {isConnected && (
-                    <span
-                      className="wikiroo-status-dot"
-                      title="WebSocket connected"
-                      aria-label="WebSocket connected"
-                    />
-                  )}
+                  <span
+                    className={`wikiroo-status-dot ${isConnected ? 'connected' : 'disconnected'}`}
+                    title={isConnected ? 'WebSocket connected' : 'WebSocket disconnected'}
+                    aria-label={isConnected ? 'WebSocket connected' : 'WebSocket disconnected'}
+                  />
                 </h2>
                 <button
                   className="wikiroo-button primary wikiroo-sidebar-new-page"


### PR DESCRIPTION
## Summary
- always render the Wikiroo status indicator and show connection state via class names
- add styling so the indicator turns red when the websocket is disconnected while keeping the green connected state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69373b9c6878832fbf6528eaf253e232)