### PR TITLE
Remove mcp-portal from prod build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docker:down": "docker-compose down",
     "docker:logs": "docker-compose logs -f",
     "docker:rebuild": "docker-compose down && docker-compose build && docker-compose up -d",
-    "build:prod": "npm -w backend run build:prod && npm -w shared run build:prod && npm -w ui run build:prod && npm -w mcp-portal run build:prod",
+    "build:prod": "npm -w backend run build:prod && npm -w shared run build:prod && npm -w ui run build:prod",
     "zero-to-prod": "npm ci && npm run build:prod"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove the mcp-portal build step from the root build:prod script

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69374cc6cbc4832f9bb7c951e8eaa64e)