### PR TITLE
Add ADK support in backend

### DIFF
--- a/apps/backend/src/adk/adk.config.ts
+++ b/apps/backend/src/adk/adk.config.ts
@@ -1,0 +1,15 @@
+/**
+ * ADK (Agent Development Kit) configuration
+ *
+ * Provides the base URL for the ADK agent API service.
+ * The URL is configurable via environment variable with a sensible default.
+ */
+
+/**
+ * Get the ADK API base URL
+ *
+ * @returns The base URL for the ADK agent API (defaults to http://localhost:8000)
+ */
+export function getAdkBaseUrl(): string {
+  return process.env.ADK_URL || 'http://localhost:8000';
+}

--- a/apps/backend/src/adk/adk.controller.ts
+++ b/apps/backend/src/adk/adk.controller.ts
@@ -1,0 +1,119 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Sse,
+  MessageEvent,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiOkResponse,
+  ApiCreatedResponse,
+} from '@nestjs/swagger';
+import { Observable } from 'rxjs';
+import { AdkService } from './adk.service';
+import { CreateAdkSessionDto } from './dto/create-adk-session.dto';
+import { SendMessageDto } from './dto/send-message.dto';
+import { SessionParamsDto } from './dto/session-params.dto';
+import {
+  ChatEvent,
+  CreateSessionResponse,
+  GetSessionResponse,
+  ListAppsResponse,
+  ListSessionsResponse,
+  SendMessageResponse,
+} from './dto/adk.types';
+
+@ApiTags('ADK')
+@Controller('adk')
+export class AdkController {
+  constructor(private readonly adkService: AdkService) {}
+
+  @Get('apps')
+  @ApiOperation({ summary: 'List all available ADK apps' })
+  @ApiOkResponse({ type: [String] })
+  async listApps(): Promise<ListAppsResponse> {
+    return this.adkService.listApps();
+  }
+
+  @Post('sessions')
+  @ApiOperation({ summary: 'Create a new ADK session' })
+  @ApiCreatedResponse()
+  async createSession(
+    @Body() dto: CreateAdkSessionDto,
+  ): Promise<CreateSessionResponse> {
+    return this.adkService.createSession(dto.appId, dto.userId, dto.sessionId);
+  }
+
+  @Get('apps/:appId/users/:userId/sessions')
+  @ApiOperation({ summary: 'List sessions for an app and user' })
+  @ApiOkResponse()
+  async listSessions(
+    @Param('appId') appId: string,
+    @Param('userId') userId: string,
+  ): Promise<ListSessionsResponse> {
+    return this.adkService.listSessions(appId, userId);
+  }
+
+  @Get('apps/:appId/users/:userId/sessions/:sessionId')
+  @ApiOperation({ summary: 'Get a specific session' })
+  @ApiOkResponse()
+  async getSession(@Param() params: SessionParamsDto): Promise<GetSessionResponse> {
+    return this.adkService.getSession(
+      params.appId,
+      params.userId,
+      params.sessionId,
+    );
+  }
+
+  @Post('messages')
+  @ApiOperation({ summary: 'Send a message to an ADK agent (non-streaming)' })
+  @ApiOkResponse()
+  async sendMessage(@Body() dto: SendMessageDto): Promise<SendMessageResponse> {
+    return this.adkService.run({
+      app_name: dto.appId,
+      user_id: dto.userId,
+      session_id: dto.sessionId,
+      new_message: {
+        role: 'user',
+        parts: [{ text: dto.message }],
+      },
+    });
+  }
+
+  @Sse('messages/stream')
+  @ApiOperation({
+    summary: 'Send a message to an ADK agent with SSE streaming',
+  })
+  async sendMessageStream(
+    @Body() dto: SendMessageDto,
+  ): Promise<Observable<MessageEvent>> {
+    return new Observable<MessageEvent>((observer) => {
+      const generator = this.adkService.runSSE({
+        app_name: dto.appId,
+        user_id: dto.userId,
+        session_id: dto.sessionId,
+        new_message: {
+          role: 'user',
+          parts: [{ text: dto.message }],
+        },
+      });
+
+      (async () => {
+        try {
+          for await (const event of generator) {
+            observer.next({
+              data: event,
+            } as MessageEvent);
+          }
+          observer.complete();
+        } catch (error) {
+          observer.error(error);
+        }
+      })();
+    });
+  }
+}

--- a/apps/backend/src/adk/adk.module.ts
+++ b/apps/backend/src/adk/adk.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AdkService } from './adk.service';
+import { AdkController } from './adk.controller';
+
+@Module({
+  controllers: [AdkController],
+  providers: [AdkService],
+  exports: [AdkService],
+})
+export class AdkModule {}

--- a/apps/backend/src/adk/adk.service.ts
+++ b/apps/backend/src/adk/adk.service.ts
@@ -1,0 +1,234 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { getAdkBaseUrl } from './adk.config';
+import {
+  ChatEvent,
+  CreateSessionResponse,
+  GetSessionResponse,
+  ListAppsResponse,
+  ListSessionsResponse,
+  SendMessageRequest,
+  SendMessageResponse,
+} from './dto/adk.types';
+
+/**
+ * ADK Client Service
+ *
+ * Provides a client for interacting with the ADK (Agent Development Kit) API.
+ * Handles session management and message sending to ADK agents.
+ */
+@Injectable()
+export class AdkService {
+  private readonly logger = new Logger(AdkService.name);
+  private readonly baseUrl: string;
+
+  constructor() {
+    this.baseUrl = getAdkBaseUrl();
+    this.logger.log(`ADK Service initialized with base URL: ${this.baseUrl}`);
+  }
+
+  /**
+   * Build a full URL from a path
+   */
+  private buildUrl(path: string): string {
+    const base = this.baseUrl.replace(/\/$/, '');
+    return `${base}${path}`;
+  }
+
+  /**
+   * List all available apps
+   */
+  async listApps(): Promise<ListAppsResponse> {
+    this.logger.log('Listing ADK apps');
+    const url = this.buildUrl('/list-apps');
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to list apps: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Create a new session for an app and user
+   *
+   * @param appId - The app identifier
+   * @param userId - The user identifier
+   * @param sessionId - Optional session ID (will be generated if not provided)
+   */
+  async createSession(
+    appId: string,
+    userId: string,
+    sessionId?: string,
+  ): Promise<CreateSessionResponse> {
+    this.logger.log(
+      `Creating session for app: ${appId}, user: ${userId}${sessionId ? `, session: ${sessionId}` : ''}`,
+    );
+
+    const endpoint = sessionId
+      ? this.buildUrl(
+          `/apps/${encodeURIComponent(appId)}/users/${encodeURIComponent(userId)}/sessions/${encodeURIComponent(sessionId)}`,
+        )
+      : this.buildUrl(
+          `/apps/${encodeURIComponent(appId)}/users/${encodeURIComponent(userId)}/sessions`,
+        );
+
+    const response = await fetch(endpoint, { method: 'POST' });
+    if (!response.ok) {
+      throw new Error(`Failed to create session: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * List all sessions for an app and user
+   *
+   * @param appId - The app identifier
+   * @param userId - The user identifier
+   */
+  async listSessions(
+    appId: string,
+    userId: string,
+  ): Promise<ListSessionsResponse> {
+    this.logger.log(`Listing sessions for app: ${appId}, user: ${userId}`);
+
+    const url = this.buildUrl(
+      `/apps/${encodeURIComponent(appId)}/users/${encodeURIComponent(userId)}/sessions`,
+    );
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to list sessions: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Get a specific session
+   *
+   * @param appId - The app identifier
+   * @param userId - The user identifier
+   * @param sessionId - The session identifier
+   */
+  async getSession(
+    appId: string,
+    userId: string,
+    sessionId: string,
+  ): Promise<GetSessionResponse> {
+    this.logger.log(
+      `Getting session for app: ${appId}, user: ${userId}, session: ${sessionId}`,
+    );
+
+    const url = this.buildUrl(
+      `/apps/${encodeURIComponent(appId)}/users/${encodeURIComponent(userId)}/sessions/${encodeURIComponent(sessionId)}`,
+    );
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to get session: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Send a message to an agent (non-streaming)
+   *
+   * @param payload - The message request payload
+   */
+  async run(payload: SendMessageRequest): Promise<SendMessageResponse> {
+    this.logger.log(
+      `Sending message to app: ${payload.app_name}, session: ${payload.session_id}`,
+    );
+
+    const url = this.buildUrl('/run');
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to send message: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Send a message to an agent with Server-Sent Events (SSE) streaming
+   *
+   * This returns an async generator that yields chat events as they arrive
+   *
+   * @param payload - The message request payload
+   */
+  async *runSSE(payload: SendMessageRequest): AsyncGenerator<ChatEvent> {
+    this.logger.log(
+      `Sending streaming message to app: ${payload.app_name}, session: ${payload.session_id}`,
+    );
+
+    const url = this.buildUrl('/run_sse');
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to start streaming: ${response.status}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Response body is null');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Process complete lines
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmedLine = line.trim();
+
+          if (!trimmedLine || trimmedLine.startsWith(':')) {
+            continue;
+          }
+
+          if (trimmedLine.startsWith('data:')) {
+            const data = trimmedLine.slice(5).trim();
+
+            if (data === '[DONE]') {
+              return;
+            }
+
+            try {
+              const event = JSON.parse(data) as ChatEvent;
+              yield event;
+            } catch (e) {
+              this.logger.warn(`Failed to parse SSE event: ${data}`, e);
+            }
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}

--- a/apps/backend/src/adk/dto/adk.types.ts
+++ b/apps/backend/src/adk/dto/adk.types.ts
@@ -1,0 +1,71 @@
+// ADK Chat API types based on the ADK specification
+// These types mirror the Python ADK API structure
+
+export interface FunctionCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface FunctionResponse {
+  id: string;
+  name: string;
+  response: {
+    result: string;
+  };
+}
+
+export interface ChatMessagePart {
+  text?: string;
+  functionCall?: FunctionCall;
+  functionResponse?: FunctionResponse;
+}
+
+export interface ChatMessageContent {
+  role: string;
+  parts: ChatMessagePart[];
+}
+
+export interface UsageMetadata {
+  promptTokenCount: number;
+  candidatesTokenCount: number;
+  totalTokenCount: number;
+}
+
+export interface ChatEvent {
+  id: string;
+  timestamp: number;
+  author: string;
+  content: ChatMessageContent;
+  partial?: boolean;
+  invocationId?: string;
+  usageMetadata?: UsageMetadata;
+  [key: string]: unknown;
+}
+
+export interface Session {
+  id: string;
+  appName: string;
+  userId: string;
+  state: Record<string, unknown>;
+  events: ChatEvent[];
+  lastUpdateTime: number;
+}
+
+export interface NewMessage {
+  role: string;
+  parts: ChatMessagePart[];
+}
+
+export interface SendMessageRequest {
+  app_name: string;
+  user_id: string;
+  session_id: string;
+  new_message: NewMessage;
+}
+
+export type ListAppsResponse = string[];
+export type ListSessionsResponse = Session[];
+export type CreateSessionResponse = Session;
+export type GetSessionResponse = Session;
+export type SendMessageResponse = ChatEvent[];

--- a/apps/backend/src/adk/dto/create-adk-session.dto.ts
+++ b/apps/backend/src/adk/dto/create-adk-session.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateAdkSessionDto {
+  @ApiProperty({ description: 'App ID' })
+  @IsString()
+  @IsNotEmpty()
+  appId!: string;
+
+  @ApiProperty({ description: 'User ID' })
+  @IsString()
+  @IsNotEmpty()
+  userId!: string;
+
+  @ApiProperty({ description: 'Optional session ID', required: false })
+  @IsString()
+  @IsOptional()
+  sessionId?: string;
+}

--- a/apps/backend/src/adk/dto/send-message.dto.ts
+++ b/apps/backend/src/adk/dto/send-message.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SendMessageDto {
+  @ApiProperty({ description: 'App ID (agent name)' })
+  @IsString()
+  @IsNotEmpty()
+  appId!: string;
+
+  @ApiProperty({ description: 'User ID' })
+  @IsString()
+  @IsNotEmpty()
+  userId!: string;
+
+  @ApiProperty({ description: 'Session ID' })
+  @IsString()
+  @IsNotEmpty()
+  sessionId!: string;
+
+  @ApiProperty({ description: 'Message content' })
+  @IsString()
+  @IsNotEmpty()
+  message!: string;
+}

--- a/apps/backend/src/adk/dto/session-params.dto.ts
+++ b/apps/backend/src/adk/dto/session-params.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SessionParamsDto {
+  @ApiProperty({ description: 'App ID' })
+  @IsString()
+  @IsNotEmpty()
+  appId!: string;
+
+  @ApiProperty({ description: 'User ID' })
+  @IsString()
+  @IsNotEmpty()
+  userId!: string;
+
+  @ApiProperty({ description: 'Session ID' })
+  @IsString()
+  @IsNotEmpty()
+  sessionId!: string;
+}

--- a/apps/backend/src/agents/agents.module.ts
+++ b/apps/backend/src/agents/agents.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AgentEntity } from './agent.entity';
 import { AgentsService } from './agents.service';
 import { AgentsController } from './agents.controller';
+import { AdkModule } from '../adk/adk.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AgentEntity])],
+  imports: [TypeOrmModule.forFeature([AgentEntity]), AdkModule],
   controllers: [AgentsController],
   providers: [AgentsService],
   exports: [AgentsService],

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { AuthJourneysModule } from './auth-journeys/auth-journeys.module';
 import { AgentsModule } from './agents/agents.module';
 import { ChatModule } from './chat/chat.module';
 import { IdentityProviderModule } from './identity-provider/identity-provider.module';
+import { AdkModule } from './adk/adk.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { IdentityProviderModule } from './identity-provider/identity-provider.mo
     AgentsModule,
     ChatModule,
     IdentityProviderModule,
+    AdkModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -2666,6 +2666,181 @@
         ]
       }
     },
+    "/api/v1/adk/apps": {
+      "get": {
+        "operationId": "AdkController_listApps",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List all available ADK apps",
+        "tags": [
+          "ADK"
+        ]
+      }
+    },
+    "/api/v1/adk/sessions": {
+      "post": {
+        "operationId": "AdkController_createSession",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAdkSessionDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Create a new ADK session",
+        "tags": [
+          "ADK"
+        ]
+      }
+    },
+    "/api/v1/adk/apps/{appId}/users/{userId}/sessions": {
+      "get": {
+        "operationId": "AdkController_listSessions",
+        "parameters": [
+          {
+            "name": "appId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "List sessions for an app and user",
+        "tags": [
+          "ADK"
+        ]
+      }
+    },
+    "/api/v1/adk/apps/{appId}/users/{userId}/sessions/{sessionId}": {
+      "get": {
+        "operationId": "AdkController_getSession",
+        "parameters": [
+          {
+            "name": "appId",
+            "required": true,
+            "in": "path",
+            "description": "App ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "description": "User ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sessionId",
+            "required": true,
+            "in": "path",
+            "description": "Session ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Get a specific session",
+        "tags": [
+          "ADK"
+        ]
+      }
+    },
+    "/api/v1/adk/messages": {
+      "post": {
+        "operationId": "AdkController_sendMessage",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendMessageDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Send a message to an ADK agent (non-streaming)",
+        "tags": [
+          "ADK"
+        ]
+      }
+    },
+    "/api/v1/adk/messages/stream": {
+      "get": {
+        "operationId": "AdkController_sendMessageStream",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendMessageDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Send a message to an ADK agent with SSE streaming",
+        "tags": [
+          "ADK"
+        ]
+      }
+    },
     "/api/v1/chat/sessions": {
       "post": {
         "operationId": "ChatController_createSession",
@@ -4999,6 +5174,54 @@
             "example": 5
           }
         }
+      },
+      "CreateAdkSessionDto": {
+        "type": "object",
+        "properties": {
+          "appId": {
+            "type": "string",
+            "description": "App ID"
+          },
+          "userId": {
+            "type": "string",
+            "description": "User ID"
+          },
+          "sessionId": {
+            "type": "string",
+            "description": "Optional session ID"
+          }
+        },
+        "required": [
+          "appId",
+          "userId"
+        ]
+      },
+      "SendMessageDto": {
+        "type": "object",
+        "properties": {
+          "appId": {
+            "type": "string",
+            "description": "App ID (agent name)"
+          },
+          "userId": {
+            "type": "string",
+            "description": "User ID"
+          },
+          "sessionId": {
+            "type": "string",
+            "description": "Session ID"
+          },
+          "message": {
+            "type": "string",
+            "description": "Message content"
+          }
+        },
+        "required": [
+          "appId",
+          "userId",
+          "sessionId",
+          "message"
+        ]
       },
       "CreateSessionDto": {
         "type": "object",

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -817,6 +817,108 @@ export interface paths {
         patch: operations["AgentsController_updateAgent"];
         trace?: never;
     };
+    "/api/v1/adk/apps": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all available ADK apps */
+        get: operations["AdkController_listApps"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/adk/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a new ADK session */
+        post: operations["AdkController_createSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/adk/apps/{appId}/users/{userId}/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List sessions for an app and user */
+        get: operations["AdkController_listSessions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/adk/apps/{appId}/users/{userId}/sessions/{sessionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a specific session */
+        get: operations["AdkController_getSession"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/adk/messages": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send a message to an ADK agent (non-streaming) */
+        post: operations["AdkController_sendMessage"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/adk/messages/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Send a message to an ADK agent with SSE streaming */
+        get: operations["AdkController_sendMessageStream"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/chat/sessions": {
         parameters: {
             query?: never;
@@ -2332,6 +2434,24 @@ export interface components {
              * @example 5
              */
             concurrencyLimit?: number;
+        };
+        CreateAdkSessionDto: {
+            /** @description App ID */
+            appId: string;
+            /** @description User ID */
+            userId: string;
+            /** @description Optional session ID */
+            sessionId?: string;
+        };
+        SendMessageDto: {
+            /** @description App ID (agent name) */
+            appId: string;
+            /** @description User ID */
+            userId: string;
+            /** @description Session ID */
+            sessionId: string;
+            /** @description Message content */
+            message: string;
         };
         CreateSessionDto: {
             /**
@@ -4513,6 +4633,132 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["AgentResponseDto"];
                 };
+            };
+        };
+    };
+    AdkController_listApps: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
+                };
+            };
+        };
+    };
+    AdkController_createSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAdkSessionDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AdkController_listSessions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                appId: string;
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AdkController_getSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description App ID */
+                appId: string;
+                /** @description User ID */
+                userId: string;
+                /** @description Session ID */
+                sessionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AdkController_sendMessage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SendMessageDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AdkController_sendMessageStream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SendMessageDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/shared/src/client/index.ts
+++ b/packages/shared/src/client/index.ts
@@ -19,6 +19,7 @@ export { ClientRegistrationResponseDto } from './models/ClientRegistrationRespon
 export type { CommentResponseDto } from './models/CommentResponseDto';
 export type { ConnectionResponseDto } from './models/ConnectionResponseDto';
 export type { ConsentDecisionDto } from './models/ConsentDecisionDto';
+export type { CreateAdkSessionDto } from './models/CreateAdkSessionDto';
 export type { CreateAgentDto } from './models/CreateAgentDto';
 export type { CreateCommentDto } from './models/CreateCommentDto';
 export type { CreateConnectionDto } from './models/CreateConnectionDto';
@@ -49,6 +50,7 @@ export type { PageTreeResponseDto } from './models/PageTreeResponseDto';
 export { RegisterClientDto } from './models/RegisterClientDto';
 export type { ReorderPageDto } from './models/ReorderPageDto';
 export type { ScopeResponseDto } from './models/ScopeResponseDto';
+export type { SendMessageDto } from './models/SendMessageDto';
 export type { ServerListResponseDto } from './models/ServerListResponseDto';
 export type { ServerResponseDto } from './models/ServerResponseDto';
 export type { SessionListResponseDto } from './models/SessionListResponseDto';
@@ -66,6 +68,7 @@ export type { UpdateTaskDto } from './models/UpdateTaskDto';
 export type { UserDto } from './models/UserDto';
 export type { WikiTagResponseDto } from './models/WikiTagResponseDto';
 
+export { AdkService } from './services/AdkService';
 export { AgentService } from './services/AgentService';
 export { AppService } from './services/AppService';
 export { AuthorizationServerService } from './services/AuthorizationServerService';

--- a/packages/shared/src/client/models/CreateAdkSessionDto.ts
+++ b/packages/shared/src/client/models/CreateAdkSessionDto.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type CreateAdkSessionDto = {
+    /**
+     * App ID
+     */
+    appId: string;
+    /**
+     * User ID
+     */
+    userId: string;
+    /**
+     * Optional session ID
+     */
+    sessionId?: string;
+};
+

--- a/packages/shared/src/client/models/SendMessageDto.ts
+++ b/packages/shared/src/client/models/SendMessageDto.ts
@@ -1,0 +1,23 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type SendMessageDto = {
+    /**
+     * App ID (agent name)
+     */
+    appId: string;
+    /**
+     * User ID
+     */
+    userId: string;
+    /**
+     * Session ID
+     */
+    sessionId: string;
+    /**
+     * Message content
+     */
+    message: string;
+};
+

--- a/packages/shared/src/client/services/AdkService.ts
+++ b/packages/shared/src/client/services/AdkService.ts
@@ -1,0 +1,113 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CreateAdkSessionDto } from '../models/CreateAdkSessionDto';
+import type { SendMessageDto } from '../models/SendMessageDto';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class AdkService {
+    /**
+     * List all available ADK apps
+     * @returns string
+     * @throws ApiError
+     */
+    public static adkControllerListApps(): CancelablePromise<Array<string>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/adk/apps',
+        });
+    }
+    /**
+     * Create a new ADK session
+     * @param requestBody
+     * @returns any
+     * @throws ApiError
+     */
+    public static adkControllerCreateSession(
+        requestBody: CreateAdkSessionDto,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/adk/sessions',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * List sessions for an app and user
+     * @param appId
+     * @param userId
+     * @returns any
+     * @throws ApiError
+     */
+    public static adkControllerListSessions(
+        appId: string,
+        userId: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/adk/apps/{appId}/users/{userId}/sessions',
+            path: {
+                'appId': appId,
+                'userId': userId,
+            },
+        });
+    }
+    /**
+     * Get a specific session
+     * @param appId App ID
+     * @param userId User ID
+     * @param sessionId Session ID
+     * @returns any
+     * @throws ApiError
+     */
+    public static adkControllerGetSession(
+        appId: string,
+        userId: string,
+        sessionId: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/adk/apps/{appId}/users/{userId}/sessions/{sessionId}',
+            path: {
+                'appId': appId,
+                'userId': userId,
+                'sessionId': sessionId,
+            },
+        });
+    }
+    /**
+     * Send a message to an ADK agent (non-streaming)
+     * @param requestBody
+     * @returns any
+     * @throws ApiError
+     */
+    public static adkControllerSendMessage(
+        requestBody: SendMessageDto,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/adk/messages',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Send a message to an ADK agent with SSE streaming
+     * @param requestBody
+     * @returns any
+     * @throws ApiError
+     */
+    public static adkControllerSendMessageStream(
+        requestBody: SendMessageDto,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/adk/messages/stream',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+}


### PR DESCRIPTION
Implements ADK (Agent Development Kit) integration to enable backend communication with ADK agents.

## Summary
- Created ADK service client with session management
- Added REST endpoints for ADK operations
- Configurable ADK URL via environment variable (defaults to http://localhost:8000)
- TypeScript types matching ADK API specification
- Integrated with agents module

## Endpoints
All endpoints are available under `/adk`:
- `GET /adk/apps` - List available apps
- `POST /adk/sessions` - Create new session
- `GET /adk/apps/:appId/users/:userId/sessions` - List sessions
- `GET /adk/apps/:appId/users/:userId/sessions/:sessionId` - Get specific session
- `POST /adk/messages` - Send message (non-streaming)
- `SSE /adk/messages/stream` - Send message (streaming)

## Configuration
Set `ADK_URL` environment variable to configure the ADK API base URL (defaults to `http://localhost:8000`)

## Test Plan
- ✅ Build passes successfully
- ✅ TypeScript compilation successful
- ✅ OpenAPI spec generated without errors
- Manual testing pending (requires running ADK agent API)