### PR TITLE
Support agent slug in URLs for better UX

### DIFF
--- a/apps/backend/src/agents/agents.controller.ts
+++ b/apps/backend/src/agents/agents.controller.ts
@@ -70,10 +70,10 @@ export class AgentsController {
   }
 
   @Get(':id')
-  @ApiOperation({ summary: 'Get an agent by ID' })
+  @ApiOperation({ summary: 'Get an agent by ID or slug' })
   @ApiOkResponse({ type: AgentResponseDto })
   async getAgent(@Param() params: AgentParamsDto): Promise<AgentResponseDto> {
-    const result = await this.agentsService.getAgentById(params.id);
+    const result = await this.agentsService.getAgentByIdOrSlug(params.id);
     return this.mapResultToResponse(result);
   }
 

--- a/apps/backend/src/agents/dto/agent-params.dto.ts
+++ b/apps/backend/src/agents/dto/agent-params.dto.ts
@@ -3,8 +3,17 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class AgentParamsDto {
   @ApiProperty({
-    description: 'Agent ID',
-    example: '123e4567-e89b-12d3-a456-426614174000',
+    description: 'Agent ID or slug',
+    examples: {
+      bySlug: {
+        summary: 'By slug',
+        value: 'alfred',
+      },
+      byId: {
+        summary: 'By ID',
+        value: '123e4567-e89b-12d3-a456-426614174000',
+      },
+    },
   })
   @IsString()
   @IsNotEmpty()

--- a/apps/backend/src/chat/chat.service.ts
+++ b/apps/backend/src/chat/chat.service.ts
@@ -49,10 +49,21 @@ export class ChatService {
       `Creating session for agent: ${input.agentId}, project: ${input.project}`,
     );
 
-    // Verify agent exists
-    const agent = await this.agentRepository.findOne({
-      where: { id: input.agentId },
+    // Verify agent exists - support both slug and UUID
+    const uuidPattern =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const isUuid = uuidPattern.test(input.agentId);
+
+    // Try by slug first, then by ID if it looks like a UUID
+    let agent = await this.agentRepository.findOne({
+      where: { slug: input.agentId },
     });
+
+    if (!agent && isUuid) {
+      agent = await this.agentRepository.findOne({
+        where: { id: input.agentId },
+      });
+    }
 
     if (!agent) {
       throw new Error(`Agent not found: ${input.agentId}`);


### PR DESCRIPTION
## Summary
- Added support for using agent slugs (like 'alfred') instead of UUIDs in URLs
- Updated backend to accept both slug and UUID in GET /agents/:id endpoint
- ChatService now validates agents by slug or UUID when creating sessions
- Maintains backward compatibility with existing UUID-based URLs

## Technical Changes
- Added `getAgentByIdOrSlug()` method to AgentsService that tries slug lookup first, then falls back to UUID
- Updated GET /agents/:id controller to use the new method
- Updated ChatService.createSession() to support slug or UUID for agent lookup
- Updated API documentation with examples for both slug and UUID

## Test Plan
- ✅ Backend build passes
- ✅ Production build passes
- Test manually: Navigate to /agents/alfred/session/new (should work now instead of AGENT_NOT_FOUND)
- Test backward compatibility: Existing UUID-based URLs should still work

## Fixes
Resolves the issue where `/agents/alfred/session/new` returned Internal Server Error with AGENT_NOT_FOUND. Now users can use friendly slugs like 'alfred' instead of UUIDs in URLs.