### PR TITLE
Add BaseAgent class for simplified agent creation

### DIFF
--- a/apps/agent-api/src/alfred/__init__.py
+++ b/apps/agent-api/src/alfred/__init__.py
@@ -1,1 +1,4 @@
 from . import agent
+from .base_agent import BaseAgent
+
+__all__ = ["agent", "BaseAgent"]

--- a/apps/agent-api/src/alfred/agent.py
+++ b/apps/agent-api/src/alfred/agent.py
@@ -1,6 +1,7 @@
 from google.adk.agents import Agent
 from google.adk.models.lite_llm import LiteLlm
 from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
+from .base_agent import BaseAgent
 
 model = LiteLlm(
     model=f"openai/gpt-oss:20b",
@@ -9,16 +10,22 @@ model = LiteLlm(
 def get_weather(city: str) -> str:
     """
     Get the weather for a city.
-    
+
     Args:
         city: The city to get the weather for
-        
+
     Returns:
         The weather for the city
     """
     return f"The weather in {city} is sunny."
-    
-# Agent
+
+# Example using BaseAgent (simplified)
+alfred_base = BaseAgent(
+    name="alfred",
+    instructions="You are a helpful assistant.",
+)
+
+# Original Agent (for reference)
 root_agent = Agent(
     name="alfred",
     model=model,

--- a/apps/agent-api/src/alfred/base_agent.py
+++ b/apps/agent-api/src/alfred/base_agent.py
@@ -1,0 +1,56 @@
+from google.adk.agents import Agent
+from google.adk.models.lite_llm import LiteLlm
+from typing import Optional, List, Callable
+
+
+class BaseAgent:
+    """
+    A simplified base class for creating ADK agents.
+
+    This class wraps google.adk.agents.Agent with a simpler interface
+    that only requires name and instructions, making it easy to create
+    agents on the fly.
+
+    Example:
+        agent = BaseAgent(
+            name="my-agent",
+            instructions="You are a helpful assistant."
+        )
+    """
+
+    def __init__(
+        self,
+        name: str,
+        instructions: str,
+        model: Optional[LiteLlm] = None,
+        tools: Optional[List[Callable]] = None
+    ):
+        """
+        Initialize a BaseAgent.
+
+        Args:
+            name: The name/slug of the agent
+            instructions: The instruction prompt for the agent
+            model: Optional LiteLlm model. Defaults to gpt-oss:20b if not provided
+            tools: Optional list of tool functions to provide to the agent
+        """
+        # Use default model if none provided
+        if model is None:
+            model = LiteLlm(model="openai/gpt-oss:20b")
+
+        # Initialize with empty tools list if none provided
+        if tools is None:
+            tools = []
+
+        # Create the underlying Agent
+        self._agent = Agent(
+            name=name,
+            model=model,
+            instruction=instructions,
+            tools=tools,
+        )
+
+    @property
+    def agent(self) -> Agent:
+        """Get the underlying google.adk.agents.Agent instance."""
+        return self._agent


### PR DESCRIPTION
## Summary
- Created a new `BaseAgent` class in `apps/agent-api/src/alfred/base_agent.py`
- Provides a simplified interface for creating ADK agents with just name and instructions
- Defaults model to `gpt-oss:20b` and tools to empty list if not provided
- Exported from `__init__.py` for easy import
- Updated `agent.py` with example usage

## Implementation Details
The `BaseAgent` class wraps `google.adk.agents.Agent` with a constructor that requires only:
- `name`: The agent slug/identifier
- `instructions`: The instruction prompt

Optional parameters:
- `model`: Custom LiteLlm model (defaults to gpt-oss:20b)
- `tools`: List of tool functions (defaults to empty list)

This makes it easy to create agents on the fly without repetitive configuration.

## Test plan
- [x] Created BaseAgent class with proper type hints
- [x] Added example usage in agent.py
- [x] Exported from __init__.py
- [x] Production build passes successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)