### PR TITLE
Add streaming flag to ADK send message requests

### DIFF
--- a/apps/backend/src/adk/adk.controller.ts
+++ b/apps/backend/src/adk/adk.controller.ts
@@ -81,6 +81,7 @@ export class AdkController {
         role: 'user',
         parts: [{ text: dto.message }],
       },
+      streaming: false,
     });
   }
 
@@ -100,6 +101,7 @@ export class AdkController {
           role: 'user',
           parts: [{ text: dto.message }],
         },
+        streaming: true,
       });
 
       (async () => {

--- a/apps/backend/src/adk/adk.service.ts
+++ b/apps/backend/src/adk/adk.service.ts
@@ -144,11 +144,12 @@ export class AdkService {
     );
 
     const url = this.buildUrl('/run');
+    const requestPayload = { ...payload, streaming: false };
 
     const response = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(requestPayload),
     });
 
     if (!response.ok) {
@@ -171,6 +172,7 @@ export class AdkService {
     );
 
     const url = this.buildUrl('/run_sse');
+    const requestPayload = { ...payload, streaming: true };
 
     const response = await fetch(url, {
       method: 'POST',
@@ -178,7 +180,7 @@ export class AdkService {
         'Content-Type': 'application/json',
         Accept: 'text/event-stream',
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(requestPayload),
     });
 
     if (!response.ok) {

--- a/apps/backend/src/adk/dto/adk.types.ts
+++ b/apps/backend/src/adk/dto/adk.types.ts
@@ -62,6 +62,7 @@ export interface SendMessageRequest {
   user_id: string;
   session_id: string;
   new_message: NewMessage;
+  streaming: boolean;
 }
 
 export type ListAppsResponse = string[];

--- a/apps/backend/src/chat/chat.service.ts
+++ b/apps/backend/src/chat/chat.service.ts
@@ -419,6 +419,7 @@ export class ChatService {
           role: 'user',
           parts: [{ text: message }],
         },
+        streaming: false,
       });
 
       // Update lastMessageAt
@@ -464,6 +465,7 @@ export class ChatService {
           role: 'user',
           parts: [{ text: message }],
         },
+        streaming: true,
       });
 
       for await (const event of stream) {


### PR DESCRIPTION
## Summary
- add the `streaming` flag to `SendMessageRequest`
- send non-streaming requests with `streaming: false` and SSE requests with `streaming: true` across service and controller payloads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938cac354b4832f82cd08016d6f0a56)