### PR TITLE
Refine agent chat UI layout

### DIFF
--- a/apps/ui/src/agents/AgentsHome.tsx
+++ b/apps/ui/src/agents/AgentsHome.tsx
@@ -20,11 +20,11 @@ export function AgentsHome() {
         <div className="agents-empty">No agents available. Create one in the admin panel.</div>
       )}
 
-      <div className="agents-grid">
+      <div className="agents-admin-grid">
         {agents.map((agent) => (
           <div
             key={agent.id}
-            className="agent-card"
+            className="agent-admin-card"
             onClick={() => navigate(`/agents/${agent.slug || agent.id}/session/new`)}
             role="button"
             tabIndex={0}
@@ -34,14 +34,22 @@ export function AgentsHome() {
               }
             }}
           >
-            <div className="agent-card-icon">🤖</div>
-            <h3 className="agent-card-title">{agent.name}</h3>
-            <p className="agent-card-description">
+            <div className="agent-admin-card-header">
+              <h3>{agent.name}</h3>
+              <span className={`agent-status ${agent.isActive ? 'active' : 'inactive'}`}>
+                {agent.isActive ? 'Active' : 'Inactive'}
+              </span>
+            </div>
+            <p className="agent-slug">@{agent.slug}</p>
+            <p className="agent-description">
               {typeof agent.description === 'string'
                 ? agent.description
                 : agent.description
                   ? JSON.stringify(agent.description)
                   : 'No description available'}
+            </p>
+            <p className="agent-tools">
+              Tools: {agent.allowedTools.length > 0 ? agent.allowedTools.join(', ') : 'None'}
             </p>
           </div>
         ))}

--- a/apps/ui/src/agents/AgentsWithSidebar.tsx
+++ b/apps/ui/src/agents/AgentsWithSidebar.tsx
@@ -111,23 +111,6 @@ export function AgentsWithSidebar() {
       <main className="agents-content">
         <Outlet />
       </main>
-
-      {/* Right sidebar for resources */}
-      <aside className="agents-resources-sidebar">
-        <div className="agents-resources-header">
-          <h3 className="agents-resources-title">Resources</h3>
-        </div>
-        <div className="agents-resources-content">
-          <div className="agents-resource-section">
-            <h4>Tasks</h4>
-            <div className="agents-resource-placeholder">No tasks yet</div>
-          </div>
-          <div className="agents-resource-section">
-            <h4>Referenced Content</h4>
-            <div className="agents-resource-placeholder">No content referenced</div>
-          </div>
-        </div>
-      </aside>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Removed resources sidebar from all agent routes (was showing placeholder Tasks and Referenced Content)
- Updated /agents home page to use consistent card styling with admin list (now shows agent status, slug, and tools)
- Left sidebar structure already matches requirements with Agents header, Admin link, and History section

## Test plan
- [ ] Visit /agents and verify cards show agent info with status, slug, and tools
- [ ] Verify no resources sidebar appears on any agent routes
- [ ] Check that left sidebar shows Agents, Admin, and History sections correctly
- [ ] Navigate to /agents/:agentSlug/session/new and verify layout
- [ ] Open an agent chat session and verify no resources sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)