### PR TITLE
Rework agent chat sidebar UI

### DIFF
--- a/apps/ui/src/agents/Agents.css
+++ b/apps/ui/src/agents/Agents.css
@@ -48,25 +48,31 @@
   letter-spacing: 0.5px;
 }
 
-.agents-sidebar-button {
-  width: 100%;
-  padding: 10px 12px;
-  background: #3b82f6;
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 600;
+.agents-nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.agents-nav-item {
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #2c3e50;
   cursor: pointer;
-  transition: background 0.2s ease;
-  text-align: left;
+  transition: all 0.2s ease;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.agents-sidebar-button:hover {
+.agents-nav-item:hover {
+  background: #f8f9fa;
+}
+
+.agents-nav-item.active {
   background: #2563eb;
+  color: #ffffff;
 }
 
 .agents-history-list {
@@ -81,11 +87,16 @@
   font-size: 13px;
   color: #2c3e50;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: all 0.2s ease;
 }
 
 .agents-history-item:hover {
   background: #f8f9fa;
+}
+
+.agents-history-item.active {
+  background: #2563eb;
+  color: #ffffff;
 }
 
 /* Agents Right Sidebar (Resources) */

--- a/apps/ui/src/agents/AgentsWithSidebar.tsx
+++ b/apps/ui/src/agents/AgentsWithSidebar.tsx
@@ -45,6 +45,9 @@ export function AgentsWithSidebar() {
     setAgentsSidebarCollapsed(!agentsSidebarCollapsed);
   };
 
+  const isAdminActive = window.location.pathname.includes('/agents/admin');
+  const isAgentsHomeActive = window.location.pathname === '/agents' || window.location.pathname === '/agents/';
+
   return (
     <div className="agents-with-sidebar">
       <aside className={`sidebar-app-specific ${agentsSidebarCollapsed ? 'collapsed' : ''}`}>
@@ -55,16 +58,38 @@ export function AgentsWithSidebar() {
                 <h2 className="agents-sidebar-title">🤖 Agents</h2>
               </div>
 
-              {/* Admin Section */}
+              {/* Navigation Section */}
               <div className="agents-sidebar-section">
-                <button
-                  className="agents-sidebar-button"
-                  type="button"
-                  onClick={() => navigate('/agents/admin')}
-                  title="Admin"
-                >
-                  ⚙️ Admin
-                </button>
+                <div className="agents-nav-list">
+                  <div
+                    className={`agents-nav-item ${isAgentsHomeActive ? 'active' : ''}`}
+                    onClick={() => navigate('/agents')}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        navigate('/agents');
+                      }
+                    }}
+                    title="Agents"
+                  >
+                    🤖 Agents
+                  </div>
+                  <div
+                    className={`agents-nav-item ${isAdminActive ? 'active' : ''}`}
+                    onClick={() => navigate('/agents/admin')}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        navigate('/agents/admin');
+                      }
+                    }}
+                    title="Admin"
+                  >
+                    ⚙️ Admin
+                  </div>
+                </div>
               </div>
 
               {/* History Section */}


### PR DESCRIPTION
## Summary
- Unified styling for Agents and Admin nav items to match chat history rows
- Removed blue button styling from Admin button
- Added active state with blue background and white text for all clickable rows
- Grouped navigation items together without dividing borders

## Test plan
- [x] Build passes
- [ ] Visual verification: Agents and Admin rows look like chat history rows
- [ ] Visual verification: Active states show blue background
- [ ] Clicking each row navigates correctly