### PR TITLE
Add WebSocket support for chat sessions

### DIFF
--- a/apps/backend/src/chat/chat.gateway.ts
+++ b/apps/backend/src/chat/chat.gateway.ts
@@ -1,0 +1,116 @@
+import { Logger } from '@nestjs/common';
+import {
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Server, Socket } from 'socket.io';
+import {
+  SessionCreatedEvent,
+  SessionUpdatedEvent,
+  SessionDeletedEvent,
+  TaskReferencedEvent,
+  TaskSubscribedEvent,
+  TaskUnsubscribedEvent,
+} from './events/chat.events';
+import { ChatService } from './chat.service';
+
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+  },
+  namespace: '/chat',
+})
+export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server!: Server;
+
+  private readonly logger = new Logger(ChatGateway.name);
+
+  constructor(private readonly chatService: ChatService) {}
+
+  handleConnection(client: Socket) {
+    this.logger.log(`Client connected to chat gateway: ${client.id}`);
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.log(`Client disconnected from chat gateway: ${client.id}`);
+  }
+
+  /**
+   * Broadcasts session created event to all connected clients
+   */
+  @OnEvent('session.created')
+  async handleSessionCreated(event: SessionCreatedEvent) {
+    this.logger.log(`Broadcasting session.created: ${event.session.id}`);
+    const sessionResult = await this.chatService.getSessionById(
+      event.session.id,
+    );
+    this.server.emit('session.created', sessionResult);
+  }
+
+  /**
+   * Broadcasts session updated event to all connected clients
+   */
+  @OnEvent('session.updated')
+  async handleSessionUpdated(event: SessionUpdatedEvent) {
+    this.logger.log(`Broadcasting session.updated: ${event.session.id}`);
+    const sessionResult = await this.chatService.getSessionById(
+      event.session.id,
+    );
+    this.server.emit('session.updated', sessionResult);
+  }
+
+  /**
+   * Broadcasts session deleted event to all connected clients
+   */
+  @OnEvent('session.deleted')
+  handleSessionDeleted(event: SessionDeletedEvent) {
+    this.logger.log(`Broadcasting session.deleted: ${event.sessionId}`);
+    this.server.emit('session.deleted', { sessionId: event.sessionId });
+  }
+
+  /**
+   * Broadcasts task referenced event to all connected clients
+   */
+  @OnEvent('task.referenced')
+  handleTaskReferenced(event: TaskReferencedEvent) {
+    this.logger.log(
+      `Broadcasting task.referenced: session=${event.sessionId}, task=${event.taskId}`,
+    );
+    this.server.emit('task.referenced', {
+      sessionId: event.sessionId,
+      taskId: event.taskId,
+    });
+  }
+
+  /**
+   * Broadcasts task subscribed event to all connected clients
+   */
+  @OnEvent('task.subscribed')
+  handleTaskSubscribed(event: TaskSubscribedEvent) {
+    this.logger.log(
+      `Broadcasting task.subscribed: session=${event.sessionId}, task=${event.taskId}`,
+    );
+    this.server.emit('task.subscribed', {
+      sessionId: event.sessionId,
+      taskId: event.taskId,
+    });
+  }
+
+  /**
+   * Broadcasts task unsubscribed event to all connected clients
+   */
+  @OnEvent('task.unsubscribed')
+  handleTaskUnsubscribed(event: TaskUnsubscribedEvent) {
+    this.logger.log(
+      `Broadcasting task.unsubscribed: session=${event.sessionId}, task=${event.taskId}`,
+    );
+    this.server.emit('task.unsubscribed', {
+      sessionId: event.sessionId,
+      taskId: event.taskId,
+    });
+  }
+}

--- a/apps/backend/src/chat/chat.module.ts
+++ b/apps/backend/src/chat/chat.module.ts
@@ -5,6 +5,7 @@ import { TaskEntity } from '../taskeroo/task.entity';
 import { AgentEntity } from '../agents/agent.entity';
 import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
+import { ChatGateway } from './chat.gateway';
 import { AdkModule } from '../adk/adk.module';
 
 @Module({
@@ -13,7 +14,7 @@ import { AdkModule } from '../adk/adk.module';
     AdkModule,
   ],
   controllers: [ChatController],
-  providers: [ChatService],
+  providers: [ChatService, ChatGateway],
   exports: [ChatService],
 })
 export class ChatModule {}

--- a/apps/ui/src/agents/Agents.css
+++ b/apps/ui/src/agents/Agents.css
@@ -32,6 +32,28 @@
   color: #2c3e50;
   white-space: nowrap;
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.agents-status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: auto;
+  transition: background-color 0.3s ease;
+}
+
+.agents-status-dot.connected {
+  background-color: #10b981;
+  box-shadow: 0 0 8px rgba(16, 185, 129, 0.4);
+}
+
+.agents-status-dot.disconnected {
+  background-color: #ef4444;
+  box-shadow: 0 0 8px rgba(239, 68, 68, 0.4);
 }
 
 .agents-sidebar-section {

--- a/apps/ui/src/agents/AgentsWithSidebar.tsx
+++ b/apps/ui/src/agents/AgentsWithSidebar.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, Outlet } from 'react-router-dom';
-import { ChatService } from './api';
-import type { ChatSessionResponseDto } from 'shared';
+import { useChatSessions } from './useChatSessions';
 
 const STORAGE_KEY = 'agents-sidebar-collapsed';
 
@@ -15,26 +14,8 @@ export function AgentsWithSidebar() {
     return stored === 'true';
   });
 
-  // Sessions state
-  const [sessions, setSessions] = useState<ChatSessionResponseDto[]>([]);
-  const [sessionsLoading, setSessionsLoading] = useState(false);
-
-  // Load sessions on mount
-  useEffect(() => {
-    loadSessions();
-  }, []);
-
-  const loadSessions = async () => {
-    setSessionsLoading(true);
-    try {
-      const response = await ChatService.chatControllerListSessions();
-      setSessions(response.items || []);
-    } catch (error) {
-      console.error('Failed to load sessions:', error);
-    } finally {
-      setSessionsLoading(false);
-    }
-  };
+  // Use WebSocket hook for real-time session updates
+  const { sessions, loading: sessionsLoading, isConnected } = useChatSessions();
 
   // Save to localStorage on change
   useEffect(() => {
@@ -55,7 +36,13 @@ export function AgentsWithSidebar() {
           {!agentsSidebarCollapsed && (
             <div>
               <div className="agents-sidebar-header">
-                <h2 className="agents-sidebar-title">🤖 Agents</h2>
+                <h2 className="agents-sidebar-title">
+                  🤖 Agents
+                  <span
+                    className={`agents-status-dot ${isConnected ? 'connected' : 'disconnected'}`}
+                    title={isConnected ? 'WebSocket connected' : 'WebSocket disconnected'}
+                  />
+                </h2>
               </div>
 
               {/* Navigation Section */}

--- a/apps/ui/src/agents/useChatSessions.ts
+++ b/apps/ui/src/agents/useChatSessions.ts
@@ -1,0 +1,150 @@
+import { useState, useEffect } from 'react';
+import { io, Socket } from 'socket.io-client';
+import { getWebSocketUrl } from '../config/api';
+import { ChatService } from './api';
+import type { ChatSessionResponseDto } from 'shared';
+
+const SOCKET_URL = getWebSocketUrl('/chat');
+
+export const useChatSessions = () => {
+  const [socket, setSocket] = useState<Socket | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [sessions, setSessions] = useState<ChatSessionResponseDto[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // Load sessions from API
+  const loadSessions = async () => {
+    setLoading(true);
+    try {
+      const response = await ChatService.chatControllerListSessions();
+      setSessions(response.items || []);
+    } catch (error) {
+      console.error('Failed to load sessions:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Initialize WebSocket connection
+  useEffect(() => {
+    const newSocket = io(SOCKET_URL, {
+      transports: ['websocket', 'polling'],
+    });
+
+    newSocket.on('connect', () => {
+      console.log('[Chat WebSocket] Connected');
+      setIsConnected(true);
+      loadSessions(); // Refresh on connect
+    });
+
+    newSocket.on('disconnect', () => {
+      console.log('[Chat WebSocket] Disconnected');
+      setIsConnected(false);
+    });
+
+    // Listen for session events
+    newSocket.on('session.created', (session: ChatSessionResponseDto) => {
+      console.log('[Chat WebSocket] Session created:', session.id);
+      setSessions((prev) => {
+        // Avoid duplicates
+        if (prev.some((s) => s.id === session.id)) {
+          return prev;
+        }
+        // Add to beginning, sorted by lastMessageAt
+        const updated = [session, ...prev];
+        return updated.sort(
+          (a, b) =>
+            new Date(b.lastMessageAt).getTime() -
+            new Date(a.lastMessageAt).getTime(),
+        );
+      });
+    });
+
+    newSocket.on('session.updated', (session: ChatSessionResponseDto) => {
+      console.log('[Chat WebSocket] Session updated:', session.id);
+      setSessions((prev) => {
+        const updated = prev.map((s) => (s.id === session.id ? session : s));
+        // Re-sort by lastMessageAt
+        return updated.sort(
+          (a, b) =>
+            new Date(b.lastMessageAt).getTime() -
+            new Date(a.lastMessageAt).getTime(),
+        );
+      });
+    });
+
+    newSocket.on(
+      'session.deleted',
+      ({ sessionId }: { sessionId: string }) => {
+        console.log('[Chat WebSocket] Session deleted:', sessionId);
+        setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+      },
+    );
+
+    newSocket.on(
+      'task.referenced',
+      ({
+        sessionId,
+        taskId,
+      }: {
+        sessionId: string;
+        taskId: string;
+      }) => {
+        console.log(
+          '[Chat WebSocket] Task referenced:',
+          sessionId,
+          taskId,
+        );
+        // Optionally refresh the specific session to get updated task references
+      },
+    );
+
+    newSocket.on(
+      'task.subscribed',
+      ({
+        sessionId,
+        taskId,
+      }: {
+        sessionId: string;
+        taskId: string;
+      }) => {
+        console.log(
+          '[Chat WebSocket] Task subscribed:',
+          sessionId,
+          taskId,
+        );
+        // Optionally refresh the specific session to get updated subscribed tasks
+      },
+    );
+
+    newSocket.on(
+      'task.unsubscribed',
+      ({
+        sessionId,
+        taskId,
+      }: {
+        sessionId: string;
+        taskId: string;
+      }) => {
+        console.log(
+          '[Chat WebSocket] Task unsubscribed:',
+          sessionId,
+          taskId,
+        );
+        // Optionally refresh the specific session to get updated subscribed tasks
+      },
+    );
+
+    setSocket(newSocket);
+
+    // Load initial data
+    loadSessions();
+
+    // Cleanup on unmount
+    return () => {
+      newSocket.disconnect();
+    };
+  }, []);
+
+  return { socket, isConnected, sessions, loading, loadSessions };
+};


### PR DESCRIPTION
## Summary
- Implemented real-time session updates for Agents UI sidebar using WebSockets
- Followed Taskeroo/Wikiroo pattern for consistency
- Added connection status indicator in sidebar

## Backend Implementation
**File: `apps/backend/src/chat/chat.gateway.ts`**
- Created WebSocket gateway on `/chat` namespace
- Listens to domain events via EventEmitter2:
  - `session.created` → broadcasts to clients
  - `session.updated` → broadcasts to clients
  - `session.deleted` → broadcasts to clients
  - `task.referenced`, `task.subscribed`, `task.unsubscribed` → broadcasts to clients
- Added to ChatModule providers

## Frontend Implementation
**File: `apps/ui/src/agents/useChatSessions.ts`**
- Custom hook connecting to `/chat` WebSocket namespace
- Manages session list state with real-time updates
- Features:
  - Auto-connects on mount, refreshes data on connect
  - Handles all session/task events
  - Auto-sorts sessions by `lastMessageAt`
  - Prevents duplicate sessions
  - Returns `{ socket, isConnected, sessions, loading, loadSessions }`

**File: `apps/ui/src/agents/AgentsWithSidebar.tsx`**
- Replaced manual session loading with `useChatSessions` hook
- Added connection status indicator (green/red dot in header)
- Sessions update automatically without page refresh

**File: `apps/ui/src/agents/Agents.css`**
- Added styles for `.agents-status-dot` with connected/disconnected states
- Green dot with glow effect when connected
- Red dot with glow effect when disconnected

## User Experience
✅ Sessions appear instantly when created
✅ Sessions update in sidebar when modified
✅ Sessions disappear when deleted
✅ Visual feedback with connection status indicator
✅ No manual refresh needed

## Technical Details
- Uses socket.io for WebSocket communication
- Follows existing patterns from Taskeroo and Wikiroo
- Service layer already emits domain events (no changes needed)
- Gateway listens and broadcasts to all connected clients

## Testing
✅ Build validation passed (`npm run build:prod`)
✅ TypeScript compilation successful
✅ No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)