### PR TITLE
Align /agents and /agents/admin page layouts

### DIFF
--- a/apps/ui/src/agents/Agents.css
+++ b/apps/ui/src/agents/Agents.css
@@ -171,13 +171,13 @@
 
 /* Agents Home Page */
 .agents-home {
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
+  padding: 24px;
 }
 
 .agents-home-header {
   margin-bottom: 32px;
-  text-align: center;
 }
 
 .agents-home-header h2 {


### PR DESCRIPTION
## Summary
- Applied consistent left-aligned layout styling from `/agents/admin` to `/agents` home page
- Updated max-width from 1200px to 1400px for consistent spacing
- Added padding: 24px for left indentation matching admin page
- Removed centered text alignment from header

## Test plan
- [x] Verified build passes successfully
- [x] Confirmed CSS changes apply left-aligned layout to agents home page
- [ ] Visual verification: Check both `/agents` and `/agents/admin` pages have matching alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)