### PR TITLE
Add LLM helper service with automatic title generation

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -36,6 +36,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "cookie-parser": "^1.4.7",
+    "ollama": "^0.6.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { AgentsModule } from './agents/agents.module';
 import { ChatModule } from './chat/chat.module';
 import { IdentityProviderModule } from './identity-provider/identity-provider.module';
 import { AdkModule } from './adk/adk.module';
+import { LlmHelperModule } from './llm-helper/llm-helper.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { AdkModule } from './adk/adk.module';
     ChatModule,
     IdentityProviderModule,
     AdkModule,
+    LlmHelperModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/chat/chat.module.ts
+++ b/apps/backend/src/chat/chat.module.ts
@@ -7,11 +7,13 @@ import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
 import { ChatGateway } from './chat.gateway';
 import { AdkModule } from '../adk/adk.module';
+import { LlmHelperModule } from '../llm-helper/llm-helper.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([SessionEntity, TaskEntity, AgentEntity]),
     AdkModule,
+    LlmHelperModule,
   ],
   controllers: [ChatController],
   providers: [ChatService, ChatGateway],

--- a/apps/backend/src/llm-helper/llm-helper.module.ts
+++ b/apps/backend/src/llm-helper/llm-helper.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { LlmHelperService } from './llm-helper.service';
+
+@Module({
+  providers: [LlmHelperService],
+  exports: [LlmHelperService],
+})
+export class LlmHelperModule {}

--- a/apps/backend/src/llm-helper/llm-helper.service.ts
+++ b/apps/backend/src/llm-helper/llm-helper.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import ollama from 'ollama';
+
+@Injectable()
+export class LlmHelperService {
+  private readonly logger = new Logger(LlmHelperService.name);
+  private readonly model = 'qwen2.5:0.5b';
+
+  /**
+   * Generates a concise title for a chat message
+   * @param message The first message of a chat session
+   * @returns A generated title for the conversation
+   */
+  async generateTitle(message: string): Promise<string> {
+    try {
+      this.logger.debug(`Generating title for message: ${message.substring(0, 50)}...`);
+
+      const response = await ollama.chat({
+        model: this.model,
+        messages: [
+          {
+            role: 'user',
+            content: `Create a concise title for this message, without any formatting: ${message}`,
+          },
+        ],
+      });
+
+      const title = response.message.content.trim();
+      this.logger.debug(`Generated title: ${title}`);
+
+      return title;
+    } catch (error) {
+      this.logger.error('Failed to generate title', error);
+      // Fallback: return a truncated version of the message
+      return message.substring(0, 50) + (message.length > 50 ? '...' : '');
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "cookie-parser": "^1.4.7",
+        "ollama": "^0.6.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "socket.io": "^4.8.1",
@@ -15354,6 +15355,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ollama": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.6.3.tgz",
+      "integrity": "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-fetch": "^3.6.20"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -20542,6 +20552,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",


### PR DESCRIPTION
## Summary
- Implemented LLM helper service using Ollama (qwen2.5:0.5b model)
- Added automatic title generation for chat sessions based on first message
- Integrated with ChatService for both streaming and non-streaming message flows
- Real-time UI updates via WebSocket events

## Implementation Details

### New Components
- **LlmHelperService**: Core service using Ollama to generate titles
  - Uses `qwen2.5:0.5b` model for fast, local inference
  - Prompt: "Create a concise title for this message, without any formatting"
  - Includes fallback to truncated message if generation fails

- **LlmHelperModule**: NestJS module exporting the service

### Integration with ChatService
- Added `llmHelperService` dependency injection
- Detects first message by checking if title starts with "Chat with"
- Generates title and updates session after message is sent
- Emits `session.updated` event for WebSocket broadcast
- Non-blocking: title generation failures don't break message sending

### Files Changed
- `apps/backend/src/llm-helper/llm-helper.service.ts` - New service
- `apps/backend/src/llm-helper/llm-helper.module.ts` - New module
- `apps/backend/src/app.module.ts` - Register LlmHelperModule
- `apps/backend/src/chat/chat.module.ts` - Import LlmHelperModule
- `apps/backend/src/chat/chat.service.ts` - Integrate title generation
- `apps/backend/package.json` - Add ollama dependency

## Test Plan
- [ ] Start a new chat session
- [ ] Verify default title is "Chat with {Agent Name} - {Date}"
- [ ] Send first message
- [ ] Verify title is automatically updated with AI-generated title
- [ ] Verify WebSocket event updates the UI in real-time
- [ ] Verify subsequent messages don't regenerate the title
- [ ] Test with both streaming and non-streaming message endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)