### PR TITLE
Implement SSE streaming and message type rendering in chat UI

### DIFF
--- a/apps/backend/src/chat/chat.controller.ts
+++ b/apps/backend/src/chat/chat.controller.ts
@@ -122,10 +122,11 @@ export class ChatController {
     return await this.chatService.sendMessage(params.id, dto.message);
   }
 
-  @Sse(':id/messages/stream')
+  @Post(':id/messages/stream')
   @ApiOperation({
     summary: 'Send a message to the ADK agent with streaming response',
   })
+  @Sse()
   async sendMessageStream(
     @Param() params: SessionParamsDto,
     @Body() dto: ChatSendMessageDto,

--- a/apps/ui/src/agents/AgentsChatSession.tsx
+++ b/apps/ui/src/agents/AgentsChatSession.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import { ChatService } from './api';
-import type { ChatSessionResponseDto } from 'shared';
+import { ChatService, OpenAPI } from './api';
+import type { ChatSessionResponseDto, ChatMessageEventDto, ChatMessagePartDto } from 'shared';
 
 interface Message {
   role: 'user' | 'assistant';
   content: string;
   timestamp: Date;
+  parts?: ChatMessagePartDto[];
+  isStreaming?: boolean;
 }
 
 export function AgentsChatSession() {
@@ -62,40 +64,114 @@ export function AgentsChatSession() {
 
     // Add user message immediately
     setMessages((prev) => [...prev, userMessage]);
+    const messageContent = inputValue.trim();
     setInputValue('');
     setIsSending(true);
 
+    // Add placeholder for assistant response
+    const assistantMessageIndex = messages.length + 1;
+    setMessages((prev) => [
+      ...prev,
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: new Date(),
+        parts: [],
+        isStreaming: true,
+      },
+    ]);
+
     try {
-      const response = await ChatService.chatControllerSendMessage(sessionId, {
-        message: userMessage.content,
-      });
+      // Use fetch to establish SSE connection
+      const response = await fetch(
+        `${OpenAPI.BASE}/api/v1/chat/sessions/${sessionId}/messages/stream`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ message: messageContent }),
+        }
+      );
 
-      // Parse events from response
-      if (response.events && Array.isArray(response.events)) {
-        // Find assistant messages in events
-        const assistantContent = response.events
-          .filter((event: any) => event.type === 'message' || event.message)
-          .map((event: any) => event.message || event.content)
-          .join('\n');
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
 
-        if (assistantContent) {
-          const assistantMessage: Message = {
-            role: 'assistant',
-            content: assistantContent,
-            timestamp: new Date(),
-          };
-          setMessages((prev) => [...prev, assistantMessage]);
+      const reader = response.body?.getReader();
+      const decoder = new TextDecoder();
+
+      if (!reader) {
+        throw new Error('No response body');
+      }
+
+      let buffer = '';
+      const allEvents: ChatMessageEventDto[] = [];
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (line.startsWith('data:')) {
+            const data = line.slice(5).trim();
+            if (data === '[DONE]') continue;
+
+            try {
+              const event: ChatMessageEventDto = JSON.parse(data);
+              allEvents.push(event);
+
+              // Update the assistant message with accumulated content
+              setMessages((prev) => {
+                const newMessages = [...prev];
+                const assistantMsg = newMessages[assistantMessageIndex];
+                if (assistantMsg) {
+                  // Combine all text from all events
+                  const combinedParts = allEvents.flatMap((e) => e.content.parts);
+                  const text = combinedParts
+                    .filter((p) => p.text)
+                    .map((p) => p.text)
+                    .join('');
+
+                  assistantMsg.content = text;
+                  assistantMsg.parts = combinedParts;
+                  assistantMsg.isStreaming = event.partial !== false;
+                }
+                return newMessages;
+              });
+            } catch (error) {
+              console.warn('Failed to parse SSE event:', data, error);
+            }
+          }
         }
       }
+
+      // Mark streaming as complete
+      setMessages((prev) => {
+        const newMessages = [...prev];
+        const assistantMsg = newMessages[assistantMessageIndex];
+        if (assistantMsg) {
+          assistantMsg.isStreaming = false;
+        }
+        return newMessages;
+      });
     } catch (error) {
       console.error('Failed to send message:', error);
-      // Add error message
-      const errorMessage: Message = {
-        role: 'assistant',
-        content: 'Sorry, I encountered an error processing your message.',
-        timestamp: new Date(),
-      };
-      setMessages((prev) => [...prev, errorMessage]);
+      // Update the assistant message with error
+      setMessages((prev) => {
+        const newMessages = [...prev];
+        newMessages[assistantMessageIndex] = {
+          role: 'assistant',
+          content: 'Sorry, I encountered an error processing your message.',
+          timestamp: new Date(),
+          isStreaming: false,
+        };
+        return newMessages;
+      });
     } finally {
       setIsSending(false);
     }
@@ -135,8 +211,39 @@ export function AgentsChatSession() {
               >
                 <div className="agents-chat-message-role">
                   {message.role === 'user' ? 'You' : 'Assistant'}
+                  {message.isStreaming && <span className="agents-chat-streaming"> (streaming...)</span>}
                 </div>
-                <div className="agents-chat-message-content">{message.content}</div>
+                <div className="agents-chat-message-content">
+                  {message.parts && message.parts.length > 0 ? (
+                    <div className="agents-chat-message-parts">
+                      {message.parts.map((part, partIndex) => (
+                        <div key={partIndex} className="agents-chat-message-part">
+                          {part.text && <div className="agents-chat-text">{part.text}</div>}
+                          {part.functionCall && (
+                            <div className="agents-chat-function-call">
+                              <strong>🔧 Tool Call:</strong> {part.functionCall.name}
+                              <details>
+                                <summary>Arguments</summary>
+                                <pre>{JSON.stringify(part.functionCall.args, null, 2)}</pre>
+                              </details>
+                            </div>
+                          )}
+                          {part.functionResponse && (
+                            <div className="agents-chat-function-response">
+                              <strong>✅ Tool Response:</strong> {part.functionResponse.name}
+                              <details>
+                                <summary>Result</summary>
+                                <pre>{part.functionResponse.response.result}</pre>
+                              </details>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    message.content
+                  )}
+                </div>
               </div>
             ))}
             <div ref={messagesEndRef} />

--- a/apps/ui/src/agents/api.ts
+++ b/apps/ui/src/agents/api.ts
@@ -4,4 +4,4 @@ import { API_BASE_URL } from '../config/api';
 // Use centralized API configuration
 OpenAPI.BASE = API_BASE_URL;
 
-export { AgentService, ChatService };
+export { AgentService, ChatService, OpenAPI };

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -3125,7 +3125,7 @@
       }
     },
     "/api/v1/chat/sessions/{id}/messages/stream": {
-      "get": {
+      "post": {
         "operationId": "ChatController_sendMessageStream",
         "parameters": [
           {
@@ -3150,7 +3150,7 @@
           }
         },
         "responses": {
-          "200": {
+          "201": {
             "description": ""
           }
         },

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -980,10 +980,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Send a message to the ADK agent with streaming response */
-        get: operations["ChatController_sendMessageStream"];
+        get?: never;
         put?: never;
-        post?: never;
+        /** Send a message to the ADK agent with streaming response */
+        post: operations["ChatController_sendMessageStream"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5070,7 +5070,7 @@ export interface operations {
             };
         };
         responses: {
-            200: {
+            201: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/shared/src/client/services/ChatService.ts
+++ b/packages/shared/src/client/services/ChatService.ts
@@ -148,7 +148,7 @@ export class ChatService {
         requestBody: ChatSendMessageDto,
     ): CancelablePromise<any> {
         return __request(OpenAPI, {
-            method: 'GET',
+            method: 'POST',
             url: '/api/v1/chat/sessions/{id}/messages/stream',
             path: {
                 'id': id,


### PR DESCRIPTION
## Summary
- Modified chat UI to use /messages/stream endpoint with SSE
- Implemented real-time streaming updates
- Added proper rendering for different message types (text, tool calls, tool responses)

## Changes
### Backend
- **chat.controller.ts**: Changed endpoint from `@Sse(':id/messages/stream')` to `@Post(':id/messages/stream')` with `@Sse()` decorator for proper POST support

### Frontend
- **AgentsChatSession.tsx**: 
  - Implemented SSE streaming using fetch API
  - Added real-time message updates as events stream in
  - Added rendering for text, functionCall, and functionResponse message parts
  - Shows streaming indicator while receiving events
  - Displays tool calls and responses with expandable JSON details
- **api.ts**: Exported OpenAPI for base URL access

## Test plan
- [x] Build passes successfully (npm run build:prod)
- [ ] Test SSE streaming with an agent that sends messages
- [ ] Verify text messages render correctly
- [ ] Verify tool calls are displayed with expandable arguments
- [ ] Verify tool responses are displayed with expandable results
- [ ] Check streaming indicator appears and disappears correctly
- [ ] Test error handling when stream fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)