### PR TITLE
Improve chat bubble streaming UI

### DIFF
--- a/apps/ui/src/agents/Agents.css
+++ b/apps/ui/src/agents/Agents.css
@@ -273,6 +273,134 @@
   padding: 24px 0;
 }
 
+.agents-chat-message {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.agents-chat-message.user {
+  align-items: flex-end;
+}
+
+.agents-chat-message.assistant {
+  align-items: flex-start;
+}
+
+.agents-chat-message-role {
+  font-size: 13px;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.agents-chat-streaming {
+  background: #e0f2fe;
+  color: #0369a1;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+}
+
+.agents-chat-bubbles {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 720px;
+}
+
+.agents-chat-message.user .agents-chat-bubbles {
+  align-items: flex-end;
+}
+
+.agents-chat-message.assistant .agents-chat-bubbles {
+  align-items: flex-start;
+}
+
+.chat-bubble {
+  border-radius: 14px;
+  padding: 12px 14px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  border: 1px solid transparent;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.bubble-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+.bubble-user {
+  background: #2563eb;
+  color: #ffffff;
+  border-color: #1d4ed8;
+}
+
+.bubble-assistant {
+  background: #f1f5f9;
+  color: #111827;
+  border-color: #e5e7eb;
+}
+
+.bubble-thinking {
+  background: #fff7ed;
+  color: #7c2d12;
+  border-color: #fdba74;
+}
+
+.bubble-tool-call {
+  background: #e0f2fe;
+  color: #0c4a6e;
+  border-color: #7dd3fc;
+}
+
+.bubble-tool-response {
+  background: #ecfdf3;
+  color: #166534;
+  border-color: #bbf7d0;
+}
+
+.agents-chat-message-part details {
+  width: 100%;
+}
+
+.agents-chat-message-part summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.agents-chat-message-part pre {
+  background: rgba(0, 0, 0, 0.04);
+  padding: 10px;
+  border-radius: 10px;
+  overflow: auto;
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.typing-indicator {
+  display: inline-block;
+  margin-left: 8px;
+  color: #0ea5e9;
+  animation: pulse 1.2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.2;
+  }
+}
+
 .agents-chat-placeholder {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- redesign chat message bubbles to distinguish user, assistant, thinking, tool calls, and tool responses
- accumulate streaming partials into a live-typing bubble and replace it with the final message payload once complete
- add styling for the new chat bubbles and expandable details for tool and thinking content

## Testing
- npm -w ui run test *(fails: vitest not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f5a39674832f961dc27709b161a7)