### PR TITLE
Adjust layout scrolling and full-height padding

### DIFF
--- a/apps/ui/src/consent/ConsentScreen.css
+++ b/apps/ui/src/consent/ConsentScreen.css
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: 0 20px;
 }
 
 .consent-container {

--- a/apps/ui/src/home/HomePage.css
+++ b/apps/ui/src/home/HomePage.css
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: 0 20px;
 }
 
 .home-container {

--- a/apps/ui/src/mcp-registry/McpRegistry.css
+++ b/apps/ui/src/mcp-registry/McpRegistry.css
@@ -3,7 +3,7 @@
 .mcp-registry {
   min-height: 100vh;
   background: #f8f9fa;
-  padding: 20px;
+  padding: 0 20px;
 }
 
 .mcp-registry-header {

--- a/apps/ui/src/styles/sidebar.css
+++ b/apps/ui/src/styles/sidebar.css
@@ -49,7 +49,8 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   transition: var(--sidebar-transition);
 }
 

--- a/apps/ui/src/taskeroo/TaskBoard.css
+++ b/apps/ui/src/taskeroo/TaskBoard.css
@@ -14,7 +14,7 @@ body {
 .task-board {
   min-height: 100vh;
   background: #f8f9fa;
-  padding: 20px;
+  padding: 0 20px;
 }
 
 .task-board-header {


### PR DESCRIPTION
## Summary
- allow the root layout main area to scroll vertically while preventing horizontal overflow
- remove vertical padding from several full-height pages to avoid overflowing 100vh sections

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a3a4edf30832faf491bcffd2a8ff3)