### PR TITLE
Add API documentation to authorization-server DTOs

### DIFF
--- a/apps/backend/src/authorization-server/dto/authorization-request.dto.ts
+++ b/apps/backend/src/authorization-server/dto/authorization-request.dto.ts
@@ -23,7 +23,8 @@ export class AuthorizationRequestDto {
   response_type!: ResponseType;
 
   @ApiPropertyOptional({
-    description: 'Comma separated list of scopes'
+    description: 'Space-delimited list of scopes being requested',
+    example: 'tasks:read tasks:write',
   })
   @IsString()
   scope?: string;

--- a/apps/backend/src/authorization-server/dto/callback-request.dto.ts
+++ b/apps/backend/src/authorization-server/dto/callback-request.dto.ts
@@ -27,7 +27,8 @@ export class CallbackRequestDto {
   error?: string;
 
   @ApiPropertyOptional({
-    description: 'Scopes that were granted'
+    description: 'Space-delimited list of scopes that were granted',
+    example: 'tasks:read tasks:write',
   })
   @IsString()
   @IsOptional()

--- a/apps/backend/src/authorization-server/dto/jwks-response.dto.ts
+++ b/apps/backend/src/authorization-server/dto/jwks-response.dto.ts
@@ -27,6 +27,7 @@ export class JwkResponseDto {
 
   @ApiPropertyOptional({
     description: 'RSA modulus encoded using base64url.',
+    example: 'xGOr-H7A...',
   })
   n?: string;
 
@@ -38,11 +39,13 @@ export class JwkResponseDto {
 
   @ApiPropertyOptional({
     description: 'Public coordinate X for EC keys encoded using base64url.',
+    example: 'WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis',
   })
   x?: string;
 
   @ApiPropertyOptional({
     description: 'Public coordinate Y for EC keys encoded using base64url.',
+    example: 'y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE',
   })
   y?: string;
 

--- a/apps/backend/src/authorization-server/dto/register-client.dto.ts
+++ b/apps/backend/src/authorization-server/dto/register-client.dto.ts
@@ -110,37 +110,58 @@ export class RegisterClientDto {
   @IsOptional()
   tos_uri?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'URL of the home page of the client',
+    example: 'https://example.com',
+  })
   @IsUrl()
   @IsOptional()
   client_uri?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'URL that references a logo for the client application',
+    example: 'https://example.com/logo.png',
+  })
   @IsUrl()
   @IsOptional()
   logo_uri?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'URL that the client provides to the end-user to read about how the profile data will be used',
+    example: 'https://example.com/privacy',
+  })
   @IsUrl()
   @IsOptional()
   policy_uri?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'URL for the client JSON Web Key Set document. If specified, must not include jwks parameter',
+    example: 'https://example.com/.well-known/jwks.json',
+  })
   @IsUrl()
   @IsOptional()
   jwks_uri?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Client JSON Web Key Set document value as a JSON string. If specified, must not include jwks_uri parameter',
+    example: '{"keys":[{"kty":"RSA","use":"sig","kid":"key-1","n":"...","e":"AQAB"}]}',
+  })
   @IsString()
   @IsOptional()
   jwks?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Unique identifier string assigned by the client developer or software publisher',
+    example: 'my-oauth-app-v1',
+  })
   @IsString()
   @IsOptional()
   software_id?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Version identifier string for the client software',
+    example: '1.0.0',
+  })
   @IsString()
   @IsOptional()
   software_version?: string;

--- a/apps/backend/src/authorization-server/dto/token-exchange-request.dto.ts
+++ b/apps/backend/src/authorization-server/dto/token-exchange-request.dto.ts
@@ -1,18 +1,45 @@
 import { IsString, IsEnum, IsOptional, Matches } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+/**
+ * OAuth 2.0 Token Exchange request DTO (RFC 8693).
+ * Used to exchange an existing access token for a new one with different scope or audience.
+ */
 export class TokenExchangeRequestDto {
+  @ApiProperty({
+    description: 'Grant type for token exchange as defined in RFC 8693',
+    enum: ['urn:ietf:params:oauth:grant-type:token-exchange'],
+    example: 'urn:ietf:params:oauth:grant-type:token-exchange',
+  })
   @IsEnum(['urn:ietf:params:oauth:grant-type:token-exchange'])
   grant_type!: 'urn:ietf:params:oauth:grant-type:token-exchange';
 
+  @ApiProperty({
+    description: 'The access token that represents the identity of the party on behalf of whom the request is being made',
+    example: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
   @IsString()
   subject_token!: string;
 
+  @ApiProperty({
+    description: 'Type identifier for the subject_token as defined in RFC 8693',
+    enum: ['urn:ietf:params:oauth:token-type:access_token'],
+    example: 'urn:ietf:params:oauth:token-type:access_token',
+  })
   @IsEnum(['urn:ietf:params:oauth:token-type:access_token'])
   subject_token_type!: 'urn:ietf:params:oauth:token-type:access_token';
 
+  @ApiProperty({
+    description: 'Resource server URL that the client wants to access with the exchanged token',
+    example: 'http://localhost:4001/',
+  })
   @IsString()
   resource!: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional space-delimited list of scopes for the exchanged token',
+    example: 'tasks:read tasks:write',
+  })
   @IsOptional()
   @IsString()
   @Matches(/^[\w\s\-\.:/]+$/, {

--- a/apps/backend/src/authorization-server/dto/token-exchange-response.dto.ts
+++ b/apps/backend/src/authorization-server/dto/token-exchange-response.dto.ts
@@ -1,8 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * OAuth 2.0 Token Exchange response DTO (RFC 8693).
+ * Contains the newly issued access token and its metadata.
+ */
 export class TokenExchangeResponseDto {
+  @ApiProperty({
+    description: 'The newly issued access token after successful exchange',
+    example: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
   access_token!: string;
+
+  @ApiProperty({
+    description: 'Type identifier for the issued token as defined in RFC 8693',
+    example: 'urn:ietf:params:oauth:token-type:access_token',
+  })
   issued_token_type!: string;
+
+  @ApiProperty({
+    description: 'Type of token issued, always Bearer for MCP clients',
+    example: 'Bearer',
+  })
   token_type!: string;
+
+  @ApiProperty({
+    description: 'Lifetime of the access token in seconds',
+    example: 3600,
+  })
   expires_in!: number;
+
+  @ApiProperty({
+    description: 'Space-delimited list of scopes granted for the exchanged token',
+    example: 'tasks:read tasks:write',
+  })
   scope!: string;
 
   constructor(

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -2051,8 +2051,9 @@
             "name": "scope",
             "required": false,
             "in": "query",
-            "description": "Comma separated list of scopes",
+            "description": "Space-delimited list of scopes being requested",
             "schema": {
+              "example": "tasks:read tasks:write",
               "type": "string"
             }
           },
@@ -2445,8 +2446,9 @@
             "name": "scope",
             "required": false,
             "in": "query",
-            "description": "Scopes that were granted",
+            "description": "Space-delimited list of scopes that were granted",
             "schema": {
+              "example": "tasks:read tasks:write",
               "type": "string"
             }
           },
@@ -4628,25 +4630,39 @@
             "example": "https://example.com/tos"
           },
           "client_uri": {
-            "type": "string"
+            "type": "string",
+            "description": "URL of the home page of the client",
+            "example": "https://example.com"
           },
           "logo_uri": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that references a logo for the client application",
+            "example": "https://example.com/logo.png"
           },
           "policy_uri": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that the client provides to the end-user to read about how the profile data will be used",
+            "example": "https://example.com/privacy"
           },
           "jwks_uri": {
-            "type": "string"
+            "type": "string",
+            "description": "URL for the client JSON Web Key Set document. If specified, must not include jwks parameter",
+            "example": "https://example.com/.well-known/jwks.json"
           },
           "jwks": {
-            "type": "string"
+            "type": "string",
+            "description": "Client JSON Web Key Set document value as a JSON string. If specified, must not include jwks_uri parameter",
+            "example": "{\"keys\":[{\"kty\":\"RSA\",\"use\":\"sig\",\"kid\":\"key-1\",\"n\":\"...\",\"e\":\"AQAB\"}]}"
           },
           "software_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique identifier string assigned by the client developer or software publisher",
+            "example": "my-oauth-app-v1"
           },
           "software_version": {
-            "type": "string"
+            "type": "string",
+            "description": "Version identifier string for the client software",
+            "example": "1.0.0"
           }
         },
         "required": [
@@ -4993,11 +5009,82 @@
       },
       "TokenExchangeRequestDto": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "grant_type": {
+            "type": "string",
+            "description": "Grant type for token exchange as defined in RFC 8693",
+            "enum": [
+              "urn:ietf:params:oauth:grant-type:token-exchange"
+            ],
+            "example": "urn:ietf:params:oauth:grant-type:token-exchange"
+          },
+          "subject_token": {
+            "type": "string",
+            "description": "The access token that represents the identity of the party on behalf of whom the request is being made",
+            "example": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+          },
+          "subject_token_type": {
+            "type": "string",
+            "description": "Type identifier for the subject_token as defined in RFC 8693",
+            "enum": [
+              "urn:ietf:params:oauth:token-type:access_token"
+            ],
+            "example": "urn:ietf:params:oauth:token-type:access_token"
+          },
+          "resource": {
+            "type": "string",
+            "description": "Resource server URL that the client wants to access with the exchanged token",
+            "example": "http://localhost:4001/"
+          },
+          "scope": {
+            "type": "string",
+            "description": "Optional space-delimited list of scopes for the exchanged token",
+            "example": "tasks:read tasks:write"
+          }
+        },
+        "required": [
+          "grant_type",
+          "subject_token",
+          "subject_token_type",
+          "resource"
+        ]
       },
       "TokenExchangeResponseDto": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "description": "The newly issued access token after successful exchange",
+            "example": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+          },
+          "issued_token_type": {
+            "type": "string",
+            "description": "Type identifier for the issued token as defined in RFC 8693",
+            "example": "urn:ietf:params:oauth:token-type:access_token"
+          },
+          "token_type": {
+            "type": "string",
+            "description": "Type of token issued, always Bearer for MCP clients",
+            "example": "Bearer"
+          },
+          "expires_in": {
+            "type": "number",
+            "description": "Lifetime of the access token in seconds",
+            "example": 3600
+          },
+          "scope": {
+            "type": "string",
+            "description": "Space-delimited list of scopes granted for the exchanged token",
+            "example": "tasks:read tasks:write"
+          }
+        },
+        "required": [
+          "access_token",
+          "issued_token_type",
+          "token_type",
+          "expires_in",
+          "scope"
+        ]
       },
       "JwkResponseDto": {
         "type": "object",
@@ -5024,7 +5111,8 @@
           },
           "n": {
             "type": "string",
-            "description": "RSA modulus encoded using base64url."
+            "description": "RSA modulus encoded using base64url.",
+            "example": "xGOr-H7A..."
           },
           "e": {
             "type": "string",
@@ -5033,11 +5121,13 @@
           },
           "x": {
             "type": "string",
-            "description": "Public coordinate X for EC keys encoded using base64url."
+            "description": "Public coordinate X for EC keys encoded using base64url.",
+            "example": "WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis"
           },
           "y": {
             "type": "string",
-            "description": "Public coordinate Y for EC keys encoded using base64url."
+            "description": "Public coordinate Y for EC keys encoded using base64url.",
+            "example": "y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE"
           },
           "crv": {
             "type": "string",

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -1984,12 +1984,40 @@ export interface components {
              * @example https://example.com/tos
              */
             tos_uri?: string;
+            /**
+             * @description URL of the home page of the client
+             * @example https://example.com
+             */
             client_uri?: string;
+            /**
+             * @description URL that references a logo for the client application
+             * @example https://example.com/logo.png
+             */
             logo_uri?: string;
+            /**
+             * @description URL that the client provides to the end-user to read about how the profile data will be used
+             * @example https://example.com/privacy
+             */
             policy_uri?: string;
+            /**
+             * @description URL for the client JSON Web Key Set document. If specified, must not include jwks parameter
+             * @example https://example.com/.well-known/jwks.json
+             */
             jwks_uri?: string;
+            /**
+             * @description Client JSON Web Key Set document value as a JSON string. If specified, must not include jwks_uri parameter
+             * @example {"keys":[{"kty":"RSA","use":"sig","kid":"key-1","n":"...","e":"AQAB"}]}
+             */
             jwks?: string;
+            /**
+             * @description Unique identifier string assigned by the client developer or software publisher
+             * @example my-oauth-app-v1
+             */
             software_id?: string;
+            /**
+             * @description Version identifier string for the client software
+             * @example 1.0.0
+             */
             software_version?: string;
         };
         ClientRegistrationResponseDto: {
@@ -2221,8 +2249,62 @@ export interface components {
              */
             version: Record<string, never>;
         };
-        TokenExchangeRequestDto: Record<string, never>;
-        TokenExchangeResponseDto: Record<string, never>;
+        TokenExchangeRequestDto: {
+            /**
+             * @description Grant type for token exchange as defined in RFC 8693
+             * @example urn:ietf:params:oauth:grant-type:token-exchange
+             * @enum {string}
+             */
+            grant_type: "urn:ietf:params:oauth:grant-type:token-exchange";
+            /**
+             * @description The access token that represents the identity of the party on behalf of whom the request is being made
+             * @example eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
+             */
+            subject_token: string;
+            /**
+             * @description Type identifier for the subject_token as defined in RFC 8693
+             * @example urn:ietf:params:oauth:token-type:access_token
+             * @enum {string}
+             */
+            subject_token_type: "urn:ietf:params:oauth:token-type:access_token";
+            /**
+             * @description Resource server URL that the client wants to access with the exchanged token
+             * @example http://localhost:4001/
+             */
+            resource: string;
+            /**
+             * @description Optional space-delimited list of scopes for the exchanged token
+             * @example tasks:read tasks:write
+             */
+            scope?: string;
+        };
+        TokenExchangeResponseDto: {
+            /**
+             * @description The newly issued access token after successful exchange
+             * @example eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
+             */
+            access_token: string;
+            /**
+             * @description Type identifier for the issued token as defined in RFC 8693
+             * @example urn:ietf:params:oauth:token-type:access_token
+             */
+            issued_token_type: string;
+            /**
+             * @description Type of token issued, always Bearer for MCP clients
+             * @example Bearer
+             */
+            token_type: string;
+            /**
+             * @description Lifetime of the access token in seconds
+             * @example 3600
+             */
+            expires_in: number;
+            /**
+             * @description Space-delimited list of scopes granted for the exchanged token
+             * @example tasks:read tasks:write
+             */
+            scope: string;
+        };
         JwkResponseDto: {
             /**
              * @description Key type, for example RSA or EC.
@@ -2244,16 +2326,25 @@ export interface components {
              * @example RS256
              */
             alg: string;
-            /** @description RSA modulus encoded using base64url. */
+            /**
+             * @description RSA modulus encoded using base64url.
+             * @example xGOr-H7A...
+             */
             n?: string;
             /**
              * @description RSA public exponent encoded using base64url.
              * @example AQAB
              */
             e?: string;
-            /** @description Public coordinate X for EC keys encoded using base64url. */
+            /**
+             * @description Public coordinate X for EC keys encoded using base64url.
+             * @example WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis
+             */
             x?: string;
-            /** @description Public coordinate Y for EC keys encoded using base64url. */
+            /**
+             * @description Public coordinate Y for EC keys encoded using base64url.
+             * @example y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE
+             */
             y?: string;
             /**
              * @description Curve name for EC keys.
@@ -4541,7 +4632,7 @@ export interface operations {
             query: {
                 /** @description OAuth 2.0 response type (must be "code" for authorization code flow) */
                 response_type: "code";
-                /** @description Comma separated list of scopes */
+                /** @description Space-delimited list of scopes being requested */
                 scope?: string;
                 /** @description Client identifier issued during registration */
                 client_id: string;
@@ -4802,7 +4893,7 @@ export interface operations {
                 state: string;
                 /** @description Error code if authorization failed */
                 error?: string;
-                /** @description Scopes that were granted */
+                /** @description Space-delimited list of scopes that were granted */
                 scope?: string;
                 /** @description Error description if authorization failed */
                 error_description?: string;

--- a/packages/shared/src/client/index.ts
+++ b/packages/shared/src/client/index.ts
@@ -71,7 +71,7 @@ export type { SessionResponseDto } from './models/SessionResponseDto';
 export type { TagResponseDto } from './models/TagResponseDto';
 export type { TaskListResponseDto } from './models/TaskListResponseDto';
 export { TaskResponseDto } from './models/TaskResponseDto';
-export type { TokenExchangeRequestDto } from './models/TokenExchangeRequestDto';
+export { TokenExchangeRequestDto } from './models/TokenExchangeRequestDto';
 export type { TokenExchangeResponseDto } from './models/TokenExchangeResponseDto';
 export { TokenRequestDto } from './models/TokenRequestDto';
 export { TokenResponseDto } from './models/TokenResponseDto';

--- a/packages/shared/src/client/models/RegisterClientDto.ts
+++ b/packages/shared/src/client/models/RegisterClientDto.ts
@@ -35,12 +35,33 @@ export type RegisterClientDto = {
      * Terms of service URI for the client registration
      */
     tos_uri?: string;
+    /**
+     * URL of the home page of the client
+     */
     client_uri?: string;
+    /**
+     * URL that references a logo for the client application
+     */
     logo_uri?: string;
+    /**
+     * URL that the client provides to the end-user to read about how the profile data will be used
+     */
     policy_uri?: string;
+    /**
+     * URL for the client JSON Web Key Set document. If specified, must not include jwks parameter
+     */
     jwks_uri?: string;
+    /**
+     * Client JSON Web Key Set document value as a JSON string. If specified, must not include jwks_uri parameter
+     */
     jwks?: string;
+    /**
+     * Unique identifier string assigned by the client developer or software publisher
+     */
     software_id?: string;
+    /**
+     * Version identifier string for the client software
+     */
     software_version?: string;
 };
 export namespace RegisterClientDto {

--- a/packages/shared/src/client/models/TokenExchangeRequestDto.ts
+++ b/packages/shared/src/client/models/TokenExchangeRequestDto.ts
@@ -3,5 +3,39 @@
 /* tslint:disable */
 /* eslint-disable */
 export type TokenExchangeRequestDto = {
+    /**
+     * Grant type for token exchange as defined in RFC 8693
+     */
+    grant_type: TokenExchangeRequestDto.grant_type;
+    /**
+     * The access token that represents the identity of the party on behalf of whom the request is being made
+     */
+    subject_token: string;
+    /**
+     * Type identifier for the subject_token as defined in RFC 8693
+     */
+    subject_token_type: TokenExchangeRequestDto.subject_token_type;
+    /**
+     * Resource server URL that the client wants to access with the exchanged token
+     */
+    resource: string;
+    /**
+     * Optional space-delimited list of scopes for the exchanged token
+     */
+    scope?: string;
 };
+export namespace TokenExchangeRequestDto {
+    /**
+     * Grant type for token exchange as defined in RFC 8693
+     */
+    export enum grant_type {
+        URN_IETF_PARAMS_OAUTH_GRANT_TYPE_TOKEN_EXCHANGE = 'urn:ietf:params:oauth:grant-type:token-exchange',
+    }
+    /**
+     * Type identifier for the subject_token as defined in RFC 8693
+     */
+    export enum subject_token_type {
+        URN_IETF_PARAMS_OAUTH_TOKEN_TYPE_ACCESS_TOKEN = 'urn:ietf:params:oauth:token-type:access_token',
+    }
+}
 

--- a/packages/shared/src/client/models/TokenExchangeResponseDto.ts
+++ b/packages/shared/src/client/models/TokenExchangeResponseDto.ts
@@ -3,5 +3,25 @@
 /* tslint:disable */
 /* eslint-disable */
 export type TokenExchangeResponseDto = {
+    /**
+     * The newly issued access token after successful exchange
+     */
+    access_token: string;
+    /**
+     * Type identifier for the issued token as defined in RFC 8693
+     */
+    issued_token_type: string;
+    /**
+     * Type of token issued, always Bearer for MCP clients
+     */
+    token_type: string;
+    /**
+     * Lifetime of the access token in seconds
+     */
+    expires_in: number;
+    /**
+     * Space-delimited list of scopes granted for the exchanged token
+     */
+    scope: string;
 };
 

--- a/packages/shared/src/client/services/AuthorizationServerService.ts
+++ b/packages/shared/src/client/services/AuthorizationServerService.ts
@@ -90,7 +90,7 @@ export class AuthorizationServerService {
      * @param resource Resource server URL that the client wants to access
      * @param serverIdentifier
      * @param version
-     * @param scope Comma separated list of scopes
+     * @param scope Space-delimited list of scopes being requested
      * @returns void
      * @throws ApiError
      */
@@ -276,7 +276,7 @@ export class AuthorizationServerService {
      * @param code Authorization code from downstream OAuth provider
      * @param state State parameter that identifies the connection flow
      * @param error Error code if authorization failed
-     * @param scope Scopes that were granted
+     * @param scope Space-delimited list of scopes that were granted
      * @param errorDescription Error description if authorization failed
      * @returns void
      * @throws ApiError


### PR DESCRIPTION
## Summary

Fixed violations in authorization-server DTOs where fields were missing @ApiProperty decorators or incomplete documentation according to DTO best practices guide.

### Changes Made

- **TokenExchangeRequestDto**: Added all @ApiProperty decorators with descriptions and examples
- **TokenExchangeResponseDto**: Added all @ApiProperty decorators with descriptions and examples  
- **RegisterClientDto**: Completed @ApiProperty documentation for 7 optional fields (client_uri, logo_uri, policy_uri, jwks_uri, jwks, software_id, software_version)
- **AuthorizationRequestDto**: Added example to scope field
- **CallbackRequestDto**: Added example to scope field
- **JwkResponseDto**: Added examples to n, x, y fields

All DTOs now comply with the DTO best practices guide requiring every field to have @ApiProperty with description and example for proper Swagger/OpenAPI documentation.

## Test Plan

- [x] Build passed: `npm run build:prod` completes successfully
- [x] All DTOs follow naming conventions
- [x] Every field has @ApiProperty/ApiPropertyOptional with description and example
- [x] API documentation will be properly generated in Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)