### PR TITLE
Simplify frontend API configuration using Vite proxy

### DIFF
--- a/apps/ui/src/config/api.ts
+++ b/apps/ui/src/config/api.ts
@@ -1,34 +1,29 @@
 /**
  * Centralized API configuration for the frontend application.
  *
- * This module provides a single source of truth for backend URL configuration,
- * handling both production and development environments.
+ * This module provides a single source of truth for backend URL configuration.
  *
- * - In production: Uses relative paths ("/")
- * - In development: Uses http://localhost:{BACKEND_PORT}
+ * With Vite proxy configured in development mode, the frontend always uses
+ * relative paths for API requests. The proxy handles forwarding requests to
+ * the backend server in development, while in production the frontend is
+ * served from the same origin as the backend.
  */
-
-/**
- * Get the backend port from environment variables
- */
-const getBackendPort = (): number => {
-  return import.meta.env.VITE_BACKEND_PORT || 3000;
-};
 
 /**
  * Get the base URL for API requests
  *
- * @returns "/" in production, "http://localhost:{port}" in development
+ * @returns Empty string (relative paths) in all environments
  */
 export const getBFFBaseUrl = (): string => {
-  if (import.meta.env.PROD) {
-    return '';
-  }
-  return `http://localhost:${getBackendPort()}`;
+  // Always use relative paths - Vite proxy handles dev mode routing
+  return '';
 };
 
 /**
  * Get the WebSocket URL for real-time connections
+ *
+ * WebSockets cannot be proxied by Vite in the same way as HTTP requests,
+ * so in development mode we need to construct the full URL to the backend.
  *
  * @param path - The WebSocket path (e.g., "/taskeroo")
  * @returns WebSocket-compatible URL
@@ -37,7 +32,9 @@ export const getUIWebSocketUrl = (path: string): string => {
   if (import.meta.env.PROD) {
     return path;
   }
-  return `http://localhost:${getBackendPort()}${path}`;
+  // In dev mode, construct full URL since WebSockets can't use Vite proxy
+  const backendPort = import.meta.env.VITE_BACKEND_PORT || 3000;
+  return `http://localhost:${backendPort}${path}`;
 };
 
 /**

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -7,13 +7,18 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: Number(process.env.VITE_PORT) || 5173,
-    // proxy: {
-    //   "/api": {
-    //     target: "http://localhost:3000",
-    //     changeOrigin: true,
-    //     secure: false,
-    //   },
-    // },
+    proxy: {
+      "/api": {
+        target: `http://localhost:${process.env.VITE_BACKEND_PORT || 3000}`,
+        changeOrigin: true,
+        secure: false,
+      },
+      "/.well-known": {
+        target: `http://localhost:${process.env.VITE_BACKEND_PORT || 3000}`,
+        changeOrigin: true,
+        secure: false,
+      },
+    },
   },
   build: {
     outDir: './dist',


### PR DESCRIPTION
## Summary
- Enabled Vite proxy for /api and /.well-known routes in development mode
- Removed environment-based URL switching in api.ts
- Frontend now always uses relative paths for API requests
- WebSocket URLs still construct full URLs in dev mode (cannot be proxied)

## Changes
- **vite.config.ts**: Enabled proxy configuration for /api and /.well-known routes
- **api.ts**: Simplified getBFFBaseUrl() to always return empty string
- **api.ts**: Updated WebSocket URL configuration with explanation

## Benefits
- Simpler configuration - no more conditional logic for prod vs dev
- Consistent URL patterns across all environments
- Easier to understand and maintain
- Better separation of concerns (Vite handles routing in dev, NestJS in prod)

## Test Plan
- ✅ Build validation passed (npm run build:prod)
- Manual testing needed: Verify API requests work correctly in dev mode with Vite proxy
- Manual testing needed: Verify WebSocket connections work in dev mode