### PR TITLE
Refine MCP Server UI: Remove bubbles, compact layout, dividers

### DIFF
--- a/apps/ui/src/mcp-registry/McpRegistry.css
+++ b/apps/ui/src/mcp-registry/McpRegistry.css
@@ -184,87 +184,176 @@
   line-height: 1.5;
 }
 
-/* Detail Sections */
-.detail-sections {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+/* Info and Admin Sections */
+.info-section,
+.admin-section {
+  background: #f8f9fa;
   max-width: 1200px;
+  margin-bottom: 32px;
 }
 
-.detail-section {
-  background: white;
-  border-radius: 12px;
-  padding: 24px;
-  border: 1px solid #e8eef3;
-}
-
-.section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 20px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid #e8eef3;
-}
-
-.section-header h2 {
-  margin: 0;
+.section-title {
+  margin: 0 0 12px 0;
   color: #1a202c;
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 600;
   letter-spacing: -0.02em;
 }
 
-.items-list {
+.section-divider {
+  height: 1px;
+  background: #e2e8f0;
+  margin: 16px 0;
+}
+
+/* Info Grid */
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.info-item {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 4px;
 }
 
-.item-card {
+.info-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #718096;
+  letter-spacing: 0.02em;
+}
+
+.info-value {
+  font-size: 14px;
+  color: #1a202c;
+  line-height: 1.5;
+}
+
+.mono {
+  font-family: 'SF Mono', 'Monaco', 'Courier New', monospace;
+}
+
+/* Authorization Server Metadata */
+.metadata-section {
+  margin-top: 16px;
+}
+
+.metadata-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
-  padding: 14px 0;
-  border-bottom: 1px solid #e8eef3;
-  gap: 16px;
-  transition: all 0.2s ease;
+  align-items: center;
+  margin-bottom: 12px;
 }
 
-.item-card:last-child {
-  border-bottom: none;
+.metadata-status {
+  color: #10b981;
+  font-size: 14px;
+  font-weight: 500;
 }
 
-.item-card:hover {
-  padding-left: 8px;
+.metadata-content {
+  margin-top: 12px;
 }
 
-.item-content {
+.metadata-url {
+  font-size: 12px;
+  color: #718096;
+  margin: 0 0 8px 0;
+  word-break: break-all;
+}
+
+.btn-link {
+  background: transparent;
+  color: #3b82f6;
+  border: none;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.btn-link:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+/* Admin Subsections */
+.admin-subsection {
+  margin: 16px 0;
+}
+
+.subsection-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.subsection-header h3 {
+  margin: 0;
+  color: #1a202c;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.btn-sm {
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+/* Compact Table */
+.compact-table {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: #e2e8f0;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.table-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  background: white;
+  gap: 12px;
+  transition: background 0.15s ease;
+}
+
+.table-row:hover {
+  background: #f7fafc;
+}
+
+.table-cell {
   flex: 1;
   min-width: 0;
 }
 
-.item-actions {
+.cell-main {
+  color: #1a202c;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.cell-sub {
+  color: #718096;
+  font-size: 13px;
+  line-height: 1.4;
+  margin-top: 2px;
+}
+
+.table-actions {
   display: flex;
   gap: 8px;
-  align-items: flex-start;
+  align-items: center;
   flex-shrink: 0;
-}
-
-.item-content h3 {
-  margin: 0 0 8px 0;
-  color: #1a202c;
-  font-size: 16px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-
-.item-content p {
-  margin: 4px 0;
-  color: #4a5568;
-  font-size: 14px;
-  line-height: 1.5;
 }
 
 .small-text {
@@ -275,9 +364,9 @@
 
 .empty-text {
   color: #a0aec0;
-  font-size: 15px;
+  font-size: 14px;
   text-align: center;
-  padding: 40px 20px;
+  padding: 24px 20px;
   font-style: italic;
 }
 
@@ -534,88 +623,60 @@
   color: #2d3748;
 }
 
-/* Grouped Mappings */
-.grouped-mappings {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+/* Mapping Groups */
+.mapping-group {
+  margin-top: 12px;
 }
 
-.scope-group {
-  border-left: 3px solid #3b82f6;
-  padding-left: 16px;
+.mapping-group:first-child {
+  margin-top: 0;
 }
 
-.scope-group-title {
-  margin: 0 0 12px 0;
-  color: #1a202c;
-  font-size: 18px;
+.mapping-group-header {
+  background: #3b82f6;
+  color: white;
+  padding: 8px 14px;
+  font-size: 13px;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  border-radius: 6px 6px 0 0;
 }
 
-.connection-groups {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.connection-group {
-  padding-left: 16px;
-  border-left: 2px solid #e2e8f0;
-}
-
-.connection-group-title {
-  margin: 0 0 8px 0;
-  color: #4a5568;
-  font-size: 15px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-
-.mapping-items {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.mapping-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 14px;
+.mapping-subgroup {
   background: #f7fafc;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  transition: all 0.2s ease;
+  border-left: 3px solid #3b82f6;
+  margin-bottom: 1px;
 }
 
-.mapping-item:hover {
+.mapping-subgroup-header {
   background: #edf2f7;
-  border-color: #cbd5e0;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #4a5568;
 }
 
-.mapping-scope {
-  color: #2d3748;
-  font-size: 14px;
-  font-family: 'SF Mono', 'Monaco', 'Courier New', monospace;
+.mapping-subgroup .table-row {
+  background: white;
+  padding-left: 24px;
+}
+
+.mapping-subgroup .table-row:hover {
+  background: #f7fafc;
 }
 
 .btn-delete-small {
   background: transparent;
   color: #ef4444;
   border: 1px solid #ef4444;
-  padding: 6px 12px;
-  border-radius: 6px;
+  padding: 5px 10px;
+  border-radius: 4px;
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all 0.15s ease;
 }
 
 .btn-delete-small:hover {
   background: #ef4444;
   color: white;
-  transform: translateY(-1px);
-  box-shadow: 0 2px 6px rgba(239, 68, 68, 0.25);
 }

--- a/apps/ui/src/mcp-registry/McpServerDetail.tsx
+++ b/apps/ui/src/mcp-registry/McpServerDetail.tsx
@@ -311,129 +311,171 @@ export function McpServerDetail() {
 
       {error && <div className="error-message">{error}</div>}
 
+      {/* Info Section */}
+      <div className="info-section">
+        <h2 className="section-title">Information</h2>
+        <div className="section-divider"></div>
 
-      <div className="detail-sections">
-        {/* Authorization Server Metadata Section */}
-        {authorizationServerMetadata && (
-          <div className="detail-section">
-            <div className="section-header">
-              <h2>Authorization Server Metadata</h2>
-              <button
-                onClick={() => setIsMetadataExpanded(!isMetadataExpanded)}
-                className="btn-secondary"
-              >
-                {isMetadataExpanded ? 'Collapse' : 'Expand'}
-              </button>
+        <div className="info-grid">
+          <div className="info-item">
+            <span className="info-label">Name</span>
+            <span className="info-value">{selectedServer.name}</span>
+          </div>
+          <div className="info-item">
+            <span className="info-label">ID</span>
+            <span className="info-value mono">{selectedServer.providedId}</span>
+          </div>
+          {connections.length > 0 && (
+            <div className="info-item">
+              <span className="info-label">Connections</span>
+              <span className="info-value">{connections.map(c => c.friendlyName).join(', ')}</span>
             </div>
-            {isMetadataExpanded && (
-              <div>
-                <p className="small-text">{authorizationServerMetadataUrl?.toString()}</p>
-                <pre className="metadata-json">
-                  {JSON.stringify(authorizationServerMetadata, null, 2)}
-                </pre>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Scopes Section */}
-        <div className="detail-section">
-          <div className="section-header">
-            <h2>Scopes</h2>
-            <button onClick={() => setActiveForm('scope')} className="btn-secondary">
-              + Add Scope
-            </button>
-          </div>
-          <div className="items-list">
-            {scopes.length === 0 ? (
-              <p className="empty-text">No scopes defined</p>
-            ) : (
-              scopes.map((scope) => (
-                <div key={scope.id} className="item-card">
-                  <div className="item-content">
-                    <h3>{scope.scopeId}</h3>
-                    <p>{scope.description}</p>
-                  </div>
-                  <button
-                    onClick={() => handleDeleteScope(scope.scopeId)}
-                    className="btn-delete"
-                  >
-                    Delete
-                  </button>
-                </div>
-              ))
-            )}
-          </div>
+          )}
+          {scopes.length > 0 && (
+            <div className="info-item">
+              <span className="info-label">Scopes</span>
+              <span className="info-value">{scopes.map(s => s.scopeId).join(', ')}</span>
+            </div>
+          )}
         </div>
 
-        {/* Connections Section */}
-        <div className="detail-section">
-          <div className="section-header">
-            <h2>OAuth Connections</h2>
-            <button onClick={() => setActiveForm('connection')} className="btn-secondary">
-              + Add Connection
+        {/* Authorization Server Metadata */}
+        {authorizationServerMetadata ? (
+          <>
+            <div className="section-divider"></div>
+            <div className="metadata-section">
+              <div className="metadata-header">
+                <span className="metadata-status">✓ Authorization Server Metadata found</span>
+                <button
+                  onClick={() => setIsMetadataExpanded(!isMetadataExpanded)}
+                  className="btn-link"
+                >
+                  {isMetadataExpanded ? 'Hide' : 'Show'}
+                </button>
+              </div>
+              {isMetadataExpanded && (
+                <div className="metadata-content">
+                  <p className="metadata-url">{authorizationServerMetadataUrl?.toString()}</p>
+                  <pre className="metadata-json">
+                    {JSON.stringify(authorizationServerMetadata, null, 2)}
+                  </pre>
+                </div>
+              )}
+            </div>
+          </>
+        ) : null}
+      </div>
+
+      {/* Admin Section */}
+      <div className="admin-section">
+        <h2 className="section-title">Administration</h2>
+        <div className="section-divider"></div>
+
+        {/* Scopes */}
+        <div className="admin-subsection">
+          <div className="subsection-header">
+            <h3>Scopes</h3>
+            <button onClick={() => setActiveForm('scope')} className="btn-secondary btn-sm">
+              + Add
             </button>
           </div>
-          <div className="items-list">
-            {connections.length === 0 ? (
-              <p className="empty-text">No connections configured</p>
-            ) : (
-              connections.map((connection) => (
-                <div key={connection.id} className="item-card">
-                  <div className="item-content">
-                    <h3>{connection.friendlyName}</h3>
-                    <p>Client ID: {connection.clientId}</p>
-                    <p className="small-text">Authorize: {connection.authorizeUrl}</p>
-                    <p className="small-text">Token: {connection.tokenUrl}</p>
+          {scopes.length === 0 ? (
+            <p className="empty-text">No scopes defined</p>
+          ) : (
+            <div className="compact-table">
+              {scopes.map((scope) => (
+                <div key={scope.id} className="table-row">
+                  <div className="table-cell">
+                    <div className="cell-main">{scope.scopeId}</div>
+                    <div className="cell-sub">{scope.description}</div>
                   </div>
-                  <div className="item-actions">
+                  <div className="table-actions">
                     <button
-                      onClick={() => handleEditConnection(connection.id)}
-                      className="btn-secondary"
-                    >
-                      Edit
-                    </button>
-                    <button
-                      onClick={() => handleDeleteConnection(connection.id)}
-                      className="btn-delete"
+                      onClick={() => handleDeleteScope(scope.scopeId)}
+                      className="btn-delete-small"
                     >
                       Delete
                     </button>
                   </div>
                 </div>
-              ))
-            )}
-          </div>
+              ))}
+            </div>
+          )}
         </div>
 
-        {/* Mappings Section - Only show if there are connections */}
-        {connections.length > 0 && (
-          <div className="detail-section">
-            <div className="section-header">
-              <h2>Scope Mappings</h2>
-              <button
-                onClick={() => setActiveForm('mapping')}
-                className="btn-secondary"
-                disabled={scopes.length === 0}
-              >
-                + Add Mapping
-              </button>
+        <div className="section-divider"></div>
+
+        {/* Connections */}
+        <div className="admin-subsection">
+          <div className="subsection-header">
+            <h3>OAuth Connections</h3>
+            <button onClick={() => setActiveForm('connection')} className="btn-secondary btn-sm">
+              + Add
+            </button>
+          </div>
+          {connections.length === 0 ? (
+            <p className="empty-text">No connections configured</p>
+          ) : (
+            <div className="compact-table">
+              {connections.map((connection) => (
+                <div key={connection.id} className="table-row">
+                  <div className="table-cell">
+                    <div className="cell-main">{connection.friendlyName}</div>
+                    <div className="cell-sub">Client ID: {connection.clientId}</div>
+                    <div className="cell-sub">Authorize: {connection.authorizeUrl}</div>
+                    <div className="cell-sub">Token: {connection.tokenUrl}</div>
+                  </div>
+                  <div className="table-actions">
+                    <button
+                      onClick={() => handleEditConnection(connection.id)}
+                      className="btn-secondary btn-sm"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleDeleteConnection(connection.id)}
+                      className="btn-delete-small"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              ))}
             </div>
-            {mappings.length === 0 ? (
-              <p className="empty-text">No mappings configured</p>
-            ) : (
-              <div className="grouped-mappings">
-                {Object.entries(groupedMappings).map(([scopeId, scopeGroup]) => (
-                  <div key={scopeId} className="scope-group">
-                    <h3 className="scope-group-title">{scopeGroup.scope.scopeId}</h3>
-                    <div className="connection-groups">
+          )}
+        </div>
+
+        {/* Mappings - Only show if there are connections */}
+        {connections.length > 0 && (
+          <>
+            <div className="section-divider"></div>
+            <div className="admin-subsection">
+              <div className="subsection-header">
+                <h3>Scope Mappings</h3>
+                <button
+                  onClick={() => setActiveForm('mapping')}
+                  className="btn-secondary btn-sm"
+                  disabled={scopes.length === 0}
+                >
+                  + Add
+                </button>
+              </div>
+              {mappings.length === 0 ? (
+                <p className="empty-text">No mappings configured</p>
+              ) : (
+                <div className="compact-table">
+                  {Object.entries(groupedMappings).map(([scopeId, scopeGroup]) => (
+                    <div key={scopeId} className="mapping-group">
+                      <div className="mapping-group-header">{scopeGroup.scope.scopeId}</div>
                       {Object.entries(scopeGroup.connections).map(([connectionId, connectionGroup]) => (
-                        <div key={connectionId} className="connection-group">
-                          <h4 className="connection-group-title">{connectionGroup.connection.friendlyName}</h4>
-                          <div className="mapping-items">
-                            {connectionGroup.mappings.map((mapping) => (
-                              <div key={mapping.id} className="mapping-item">
-                                <span className="mapping-scope">{mapping.downstreamScope}</span>
+                        <div key={connectionId} className="mapping-subgroup">
+                          <div className="mapping-subgroup-header">{connectionGroup.connection.friendlyName}</div>
+                          {connectionGroup.mappings.map((mapping) => (
+                            <div key={mapping.id} className="table-row">
+                              <div className="table-cell">
+                                <span className="mono">{mapping.downstreamScope}</span>
+                              </div>
+                              <div className="table-actions">
                                 <button
                                   onClick={() => handleDeleteMapping(mapping.id)}
                                   className="btn-delete-small"
@@ -442,16 +484,16 @@ export function McpServerDetail() {
                                   Delete
                                 </button>
                               </div>
-                            ))}
-                          </div>
+                            </div>
+                          ))}
                         </div>
                       ))}
                     </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Removed detail-section padding and bubble effects for a cleaner look
- Reorganized UI into Info and Admin sections as requested
- Replaced padded cards with compact table-style rows
- Improved authorization server metadata display with status indicator
- Removed all uppercase text transformations
- Used dividers instead of nested containers with padding
- Made scopes, connections, and mappings more space-efficient and consistent

## Test plan
- [ ] Verify Info section displays server name, ID, connections, and scopes
- [ ] Verify Auth Server Metadata shows status with collapsible content
- [ ] Verify Admin section has Scopes, Connections, and Mappings subsections
- [ ] Verify all tables are compact with no excessive padding
- [ ] Verify no text is transformed to uppercase
- [ ] Verify dividers separate sections cleanly
- [ ] Test add/edit/delete operations for scopes, connections, and mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)