### PR TITLE
Move ADD buttons to table-bottom rows in MCP Server UI

### DIFF
--- a/apps/ui/src/mcp-registry/McpRegistry.css
+++ b/apps/ui/src/mcp-registry/McpRegistry.css
@@ -767,3 +767,24 @@
   font-size: 14px;
   line-height: 1.5;
 }
+
+/* Table Add Row */
+.table-add-row {
+  display: flex;
+  align-items: center;
+  padding: 14px 16px;
+  background: #f7fafc;
+  border-top: 1px solid #e2e8f0;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.table-add-row:hover {
+  background: #edf2f7;
+}
+
+.add-row-text {
+  color: #3b82f6;
+  font-size: 14px;
+  font-weight: 500;
+}

--- a/apps/ui/src/mcp-registry/McpServerDetail.tsx
+++ b/apps/ui/src/mcp-registry/McpServerDetail.tsx
@@ -375,15 +375,16 @@ export function McpServerDetail() {
         <div className="admin-subsection">
           <div className="subsection-header">
             <h3>Permissions</h3>
-            <button onClick={() => setActiveForm('scope')} className="btn-secondary btn-sm">
-              + Add
-            </button>
           </div>
           <p className="subsection-description">
             Define the scopes (permissions) that will be available for MCP clients to request when connecting to this server.
           </p>
           {scopes.length === 0 ? (
-            <p className="empty-text">No permissions defined</p>
+            <div className="proper-table">
+              <div className="table-add-row" onClick={() => setActiveForm('scope')}>
+                <span className="add-row-text">Add permission...</span>
+              </div>
+            </div>
           ) : (
             <div className="proper-table">
               <div className="table-header">
@@ -405,6 +406,9 @@ export function McpServerDetail() {
                   </div>
                 </div>
               ))}
+              <div className="table-add-row" onClick={() => setActiveForm('scope')}>
+                <span className="add-row-text">Add permission...</span>
+              </div>
             </div>
           )}
         </div>
@@ -415,15 +419,16 @@ export function McpServerDetail() {
         <div className="admin-subsection">
           <div className="subsection-header">
             <h3>Connections</h3>
-            <button onClick={() => setActiveForm('connection')} className="btn-secondary btn-sm">
-              + Add
-            </button>
           </div>
           <p className="subsection-description">
             Configure connections to downstream systems that support OAuth. The MCP server acts as a secure proxy, managing authentication and authorization on behalf of clients.
           </p>
           {connections.length === 0 ? (
-            <p className="empty-text">No connections configured</p>
+            <div className="proper-table">
+              <div className="table-add-row" onClick={() => setActiveForm('connection')}>
+                <span className="add-row-text">Add connection...</span>
+              </div>
+            </div>
           ) : (
             <div className="proper-table">
               <div className="table-header">
@@ -453,6 +458,9 @@ export function McpServerDetail() {
                   </div>
                 </div>
               ))}
+              <div className="table-add-row" onClick={() => setActiveForm('connection')}>
+                <span className="add-row-text">Add connection...</span>
+              </div>
             </div>
           )}
         </div>
@@ -464,19 +472,22 @@ export function McpServerDetail() {
             <div className="admin-subsection">
               <div className="subsection-header">
                 <h3>Scope Mappings</h3>
-                <button
-                  onClick={() => setActiveForm('mapping')}
-                  className="btn-secondary btn-sm"
-                  disabled={scopes.length === 0}
-                >
-                  + Add
-                </button>
               </div>
               <p className="subsection-description">
                 Map MCP server scopes to downstream connection scopes. When a client requests an MCP scope, the server will request the corresponding downstream scopes from the configured connections.
               </p>
               {mappings.length === 0 ? (
-                <p className="empty-text">No scope mappings configured</p>
+                <div className="mapping-group">
+                  <div
+                    className="table-add-row"
+                    onClick={() => scopes.length > 0 && setActiveForm('mapping')}
+                    style={{ opacity: scopes.length === 0 ? 0.5 : 1, cursor: scopes.length === 0 ? 'not-allowed' : 'pointer' }}
+                  >
+                    <span className="add-row-text">
+                      {scopes.length === 0 ? 'Add permissions first to create mappings...' : 'Add scope mapping...'}
+                    </span>
+                  </div>
+                </div>
               ) : (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
                   {Object.entries(groupedMappings).map(([scopeId, scopeGroup]) => (
@@ -507,6 +518,17 @@ export function McpServerDetail() {
                       </div>
                     </div>
                   ))}
+                  <div className="mapping-group">
+                    <div
+                      className="table-add-row"
+                      onClick={() => scopes.length > 0 && setActiveForm('mapping')}
+                      style={{ opacity: scopes.length === 0 ? 0.5 : 1, cursor: scopes.length === 0 ? 'not-allowed' : 'pointer' }}
+                    >
+                      <span className="add-row-text">
+                        {scopes.length === 0 ? 'Add permissions first to create mappings...' : 'Add scope mapping...'}
+                      </span>
+                    </div>
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
Improved UX in MCP Server UI by moving ADD buttons from section headers to intuitive table-bottom "Add [entity]..." rows.

**Changes:**
- **Permissions section**: Removed "+ Add" button from header → Added "Add permission..." row at bottom of table
- **Connections section**: Removed "+ Add" button from header → Added "Add connection..." row at bottom of table  
- **Scope Mappings section**: Removed "+ Add" button from header → Added "Add scope mapping..." row at bottom of table

**UX Improvements:**
- More discoverable: Add action is now part of the table itself
- Cleaner headers: Section titles stand alone without action buttons
- Better empty states: Tables show add row instead of separate empty text
- Smart disabled state: Scope Mappings shows helpful text when no permissions exist
- Consistent styling: All add rows use light blue background (#f7fafc) with hover effect

**Visual Design:**
- Add rows styled with subtle background and blue text (#3b82f6)
- Hover state changes background to slightly darker (#edf2f7)
- Cursor indicates clickability
- Maintains table border continuity

## Test plan
- [x] Build passes (`npm run build:prod`)
- [ ] Empty state shows "Add [entity]..." row for Permissions/Connections
- [ ] Clicking add row opens the appropriate modal
- [ ] Add rows appear at bottom of populated tables
- [ ] Scope Mappings shows disabled state when no permissions exist
- [ ] All hover effects work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)