### PR TITLE
Fix MCP authorization scope validation error

### DIFF
--- a/apps/backend/src/authorization-server/dto/authorization-request.dto.ts
+++ b/apps/backend/src/authorization-server/dto/authorization-request.dto.ts
@@ -5,6 +5,7 @@ import {
   IsUrl,
   Length,
   Matches,
+  IsOptional,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ResponseType } from '../enums';
@@ -26,6 +27,7 @@ export class AuthorizationRequestDto {
     description: 'Space-delimited list of scopes being requested',
     example: 'tasks:read tasks:write',
   })
+  @IsOptional()
   @IsString()
   scope?: string;
 


### PR DESCRIPTION
## Summary
- Fixed validation error "scope must be a string" during MCP authorization
- Added `@IsOptional()` decorator to the `scope` field in `AuthorizationRequestDto`
- The scope parameter is optional in OAuth 2.0, but the validator was requiring it to be a string even when not provided

## Test plan
- [x] Build passes successfully (`npm run build:prod`)
- [ ] Manual testing: MCP Server authentication flow works without scope parameter
- [ ] Verify authorization endpoint accepts requests with and without scope parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)