### PR TITLE
Skip downstream OAuth flows when no scopes requested

### DIFF
--- a/apps/backend/src/authorization-server/authorization.service.ts
+++ b/apps/backend/src/authorization-server/authorization.service.ts
@@ -186,6 +186,16 @@ export class AuthorizationService {
       return this.completeMcpAuthFlow(journeyId);
     }
 
+    // Check if any scopes were requested in the MCP auth flow
+    const mcpAuthFlow = connectionFlows[0]?.authJourney?.mcpAuthorizationFlow;
+    const hasRequestedScopes = mcpAuthFlow?.scope && mcpAuthFlow.scope.trim().length > 0;
+
+    // If no scopes were requested, skip downstream flows and complete MCP auth
+    if (!hasRequestedScopes) {
+      this.logger.log('No scopes requested, skipping downstream OAuth flows and completing MCP auth');
+      return this.completeMcpAuthFlow(journeyId);
+    }
+
     // Find the next pending connection flow
     const nextPendingFlow = connectionFlows.find(flow => flow.status === 'pending');
 


### PR DESCRIPTION
## Summary
- Fixed issue where downstream OAuth flows (like GCP) were triggered even when MCP client didn't request any scopes
- Added check in `processNextDownstreamFlow` to skip downstream flows when `scope` is empty/undefined
- This prevents the "Missing required parameter: scope" error from downstream OAuth providers

## Test plan
- [x] Build passes successfully (`npm run build:prod`)
- [ ] Manual testing: MCP authorization flow without scopes should complete without triggering GCP OAuth
- [ ] Manual testing: MCP authorization flow with scopes should still trigger GCP OAuth as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)