### PR TITLE
Fix TypeScript errors in auth flow UI

### DIFF
--- a/apps/backend/src/auth-journeys/dto/connection-flow-response.dto.ts
+++ b/apps/backend/src/auth-journeys/dto/connection-flow-response.dto.ts
@@ -23,6 +23,7 @@ export class ConnectionFlowResponseDto {
     description: 'Connection friendly name',
     example: 'GitHub OAuth Connection',
     nullable: true,
+    type: String,
   })
   connectionName?: string | null;
 
@@ -37,6 +38,7 @@ export class ConnectionFlowResponseDto {
     description: 'When the access token expires',
     example: '2025-12-15T10:00:00.000Z',
     nullable: true,
+    type: String,
   })
   tokenExpiresAt?: string | null;
 

--- a/apps/backend/src/auth-journeys/dto/mcp-flow-response.dto.ts
+++ b/apps/backend/src/auth-journeys/dto/mcp-flow-response.dto.ts
@@ -30,6 +30,7 @@ export class McpFlowResponseDto {
     description: 'Client name for display',
     example: 'My MCP Client',
     nullable: true,
+    type: String,
   })
   clientName?: string | null;
 
@@ -44,6 +45,7 @@ export class McpFlowResponseDto {
     description: 'Scopes requested by the client',
     example: 'tool:read tool:execute',
     nullable: true,
+    type: String,
   })
   scope?: string | null;
 
@@ -51,6 +53,7 @@ export class McpFlowResponseDto {
     description: 'When the authorization code expires',
     example: '2025-12-15T09:00:00.000Z',
     nullable: true,
+    type: String,
   })
   authorizationCodeExpiresAt?: string | null;
 

--- a/apps/mcp-portal/src/pages/ServerDetail.tsx
+++ b/apps/mcp-portal/src/pages/ServerDetail.tsx
@@ -599,14 +599,14 @@ export default function ServerDetailPage() {
                   <div className="flex items-start justify-between mb-3">
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-1">
-                        <h3 className="font-semibold">{journey.mcpAuthorizationFlow.clientName || 'Unknown Client'}</h3>
+                        <h3 className="font-semibold">{journey.mcpAuthorizationFlow.clientName ?? 'Unknown Client'}</h3>
                         <span className={`text-xs px-2 py-0.5 rounded ${
-                          journey.status === 'AUTHORIZATION_CODE_EXCHANGED' ? 'bg-green-500/20 text-green-300' :
-                          journey.status === 'MCP_AUTH_FLOW_STARTED' ? 'bg-blue-500/20 text-blue-300' :
-                          journey.status === 'CONNECTIONS_FLOW_STARTED' ? 'bg-yellow-500/20 text-yellow-300' :
+                          journey.status === 'authorization_code_exchanged' ? 'bg-green-500/20 text-green-300' :
+                          journey.status === 'mcp_auth_flow_started' ? 'bg-blue-500/20 text-blue-300' :
+                          journey.status === 'connections_flow_started' ? 'bg-yellow-500/20 text-yellow-300' :
                           'bg-gray-500/20 text-gray-300'
                         }`}>
-                          {journey.status.replace(/_/g, ' ')}
+                          {journey.status.replace(/_/g, ' ').toUpperCase()}
                         </span>
                       </div>
                       <div className="text-xs text-white/50 space-y-0.5">
@@ -642,7 +642,7 @@ export default function ServerDetailPage() {
                         {journey.connectionAuthorizationFlows.map((connFlow) => (
                           <div key={connFlow.id} className="bg-white/5 rounded px-3 py-2">
                             <div className="flex items-center justify-between mb-1">
-                              <span className="text-sm font-medium">{connFlow.connectionName || 'Unknown Connection'}</span>
+                              <span className="text-sm font-medium">{connFlow.connectionName ?? 'Unknown Connection'}</span>
                               <span className={`text-xs px-2 py-0.5 rounded ${
                                 connFlow.status === 'authorized' ? 'bg-green-500/20 text-green-300' :
                                 connFlow.status === 'pending' ? 'bg-yellow-500/20 text-yellow-300' :

--- a/packages/shared/contracts/openapi.json
+++ b/packages/shared/contracts/openapi.json
@@ -4712,7 +4712,7 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
           "clientName": {
-            "type": "object",
+            "type": "string",
             "description": "Client name for display",
             "example": "My MCP Client",
             "nullable": true
@@ -4733,13 +4733,13 @@
             ]
           },
           "scope": {
-            "type": "object",
+            "type": "string",
             "description": "Scopes requested by the client",
             "example": "tool:read tool:execute",
             "nullable": true
           },
           "authorizationCodeExpiresAt": {
-            "type": "object",
+            "type": "string",
             "description": "When the authorization code expires",
             "example": "2025-12-15T09:00:00.000Z",
             "nullable": true
@@ -4790,7 +4790,7 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
           "connectionName": {
-            "type": "object",
+            "type": "string",
             "description": "Connection friendly name",
             "example": "GitHub OAuth Connection",
             "nullable": true
@@ -4806,7 +4806,7 @@
             ]
           },
           "tokenExpiresAt": {
-            "type": "object",
+            "type": "string",
             "description": "When the access token expires",
             "example": "2025-12-15T10:00:00.000Z",
             "nullable": true

--- a/packages/shared/contracts/types.ts
+++ b/packages/shared/contracts/types.ts
@@ -2019,7 +2019,7 @@ export interface components {
              * @description Client name for display
              * @example My MCP Client
              */
-            clientName?: Record<string, never> | null;
+            clientName?: string | null;
             /**
              * @description Current status of the MCP authorization flow
              * @example CLIENT_REGISTERED
@@ -2030,12 +2030,12 @@ export interface components {
              * @description Scopes requested by the client
              * @example tool:read tool:execute
              */
-            scope?: Record<string, never> | null;
+            scope?: string | null;
             /**
              * @description When the authorization code expires
              * @example 2025-12-15T09:00:00.000Z
              */
-            authorizationCodeExpiresAt?: Record<string, never> | null;
+            authorizationCodeExpiresAt?: string | null;
             /**
              * @description Whether the authorization code has been used
              * @example false
@@ -2072,7 +2072,7 @@ export interface components {
              * @description Connection friendly name
              * @example GitHub OAuth Connection
              */
-            connectionName?: Record<string, never> | null;
+            connectionName?: string | null;
             /**
              * @description Current status of the connection flow
              * @example pending
@@ -2083,7 +2083,7 @@ export interface components {
              * @description When the access token expires
              * @example 2025-12-15T10:00:00.000Z
              */
-            tokenExpiresAt?: Record<string, never> | null;
+            tokenExpiresAt?: string | null;
             /**
              * @description Timestamp when the flow was created
              * @example 2025-12-15T08:00:00.000Z

--- a/packages/shared/src/client/models/ConnectionFlowResponseDto.ts
+++ b/packages/shared/src/client/models/ConnectionFlowResponseDto.ts
@@ -18,7 +18,7 @@ export type ConnectionFlowResponseDto = {
     /**
      * Connection friendly name
      */
-    connectionName?: Record<string, any> | null;
+    connectionName?: string | null;
     /**
      * Current status of the connection flow
      */
@@ -26,7 +26,7 @@ export type ConnectionFlowResponseDto = {
     /**
      * When the access token expires
      */
-    tokenExpiresAt?: Record<string, any> | null;
+    tokenExpiresAt?: string | null;
     /**
      * Timestamp when the flow was created
      */

--- a/packages/shared/src/client/models/McpFlowResponseDto.ts
+++ b/packages/shared/src/client/models/McpFlowResponseDto.ts
@@ -22,7 +22,7 @@ export type McpFlowResponseDto = {
     /**
      * Client name for display
      */
-    clientName?: Record<string, any> | null;
+    clientName?: string | null;
     /**
      * Current status of the MCP authorization flow
      */
@@ -30,11 +30,11 @@ export type McpFlowResponseDto = {
     /**
      * Scopes requested by the client
      */
-    scope?: Record<string, any> | null;
+    scope?: string | null;
     /**
      * When the authorization code expires
      */
-    authorizationCodeExpiresAt?: Record<string, any> | null;
+    authorizationCodeExpiresAt?: string | null;
     /**
      * Whether the authorization code has been used
      */


### PR DESCRIPTION
## Summary
Fixed TypeScript errors in the auth flow UI that were caused by incorrect type generation from OpenAPI.

## Changes
### Backend DTOs
- Added explicit `type: String` parameter to `@ApiPropertyOptional` decorators
- This ensures OpenAPI generates `string | null` instead of `Record<string, any>`

### Frontend UI
- Changed `||` to `??` for proper null coalescing
- Fixed status enum comparisons to use lowercase values (`authorization_code_exchanged` instead of `AUTHORIZATION_CODE_EXCHANGED`)
- Updated status display to uppercase for better readability

## Test plan
- [x] Backend builds successfully
- [x] OpenAPI types generated correctly (`string | null` instead of `Record<string, any>`)
- [x] Frontend builds with no TypeScript errors
- [x] Production build passes (`npm run build:prod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)