### PR TITLE
Add read and upload file tools to test-mcp MCP server

### DIFF
--- a/apps/test-mcp/src/documents/documents.service.ts
+++ b/apps/test-mcp/src/documents/documents.service.ts
@@ -24,4 +24,31 @@ export class DocumentsService {
 
     return files;
   }
+
+  async readDocument(token: string, fileName: string): Promise<string> {
+    // Exchange the MCP token for a Google token
+    const tokenResponse = await this.tokenExchangeService.exchangeToken(token);
+
+    // Read the file using the exchanged token
+    const content = await this.gcsService.readFile(
+      tokenResponse.access_token,
+      fileName,
+      BUCKET_NAME,
+    );
+
+    return content;
+  }
+
+  async uploadDocument(token: string, fileName: string, content: string): Promise<void> {
+    // Exchange the MCP token for a Google token
+    const tokenResponse = await this.tokenExchangeService.exchangeToken(token);
+
+    // Upload the file using the exchanged token
+    await this.gcsService.uploadFile(
+      tokenResponse.access_token,
+      fileName,
+      content,
+      BUCKET_NAME,
+    );
+  }
 }

--- a/apps/test-mcp/src/documents/documents.ts
+++ b/apps/test-mcp/src/documents/documents.ts
@@ -57,6 +57,89 @@ export class Documents {
         }
       }
     );
+
+    server.registerTool(
+      'read_document',
+      {
+        title: 'Read document',
+        properties: {
+          fileName: {
+            type: 'string',
+            description: 'The name of the file to read',
+          },
+        },
+        required: ['fileName'],
+      },
+      async (args: { fileName: string }) => {
+        try {
+          const content = await this.documentsService.readDocument(auth.token, args.fileName);
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: content,
+              }
+            ]
+          };
+        } catch (error) {
+          this.logger.error('Error reading document:', error);
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Error: ${error.message}`,
+              }
+            ],
+            isError: true,
+          };
+        }
+      }
+    );
+
+    server.registerTool(
+      'upload_document',
+      {
+        title: 'Upload document',
+        properties: {
+          fileName: {
+            type: 'string',
+            description: 'The name of the file to upload',
+          },
+          content: {
+            type: 'string',
+            description: 'The text content to upload',
+          },
+        },
+        required: ['fileName', 'content'],
+      },
+      async (args: { fileName: string; content: string }) => {
+        try {
+          await this.documentsService.uploadDocument(auth.token, args.fileName, args.content);
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: `File ${args.fileName} uploaded successfully`,
+              }
+            ]
+          };
+        } catch (error) {
+          this.logger.error('Error uploading document:', error);
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Error: ${error.message}`,
+              }
+            ],
+            isError: true,
+          };
+        }
+      }
+    );
+
     return server;
   }
 

--- a/apps/test-mcp/src/documents/gcs.service.ts
+++ b/apps/test-mcp/src/documents/gcs.service.ts
@@ -48,4 +48,62 @@ export class GcsService {
       throw error;
     }
   }
+
+  async readFile(accessToken: string, fileName: string, bucketName?: string): Promise<string> {
+    const bucket = bucketName || GCS_BUCKET_NAME;
+
+    this.logger.debug(`Reading file ${fileName} from bucket: ${bucket}`);
+
+    try {
+      const response = await fetch(
+        `https://storage.googleapis.com/storage/v1/b/${bucket}/o/${encodeURIComponent(fileName)}?alt=media`,
+        {
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+          }
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to read file: ${response.status} ${response.statusText} - ${errorText}`);
+      }
+
+      const content = await response.text();
+      return content;
+    } catch (error) {
+      this.logger.error('Error reading file:', error);
+      throw error;
+    }
+  }
+
+  async uploadFile(accessToken: string, fileName: string, content: string, bucketName?: string): Promise<void> {
+    const bucket = bucketName || GCS_BUCKET_NAME;
+
+    this.logger.debug(`Uploading file ${fileName} to bucket: ${bucket}`);
+
+    try {
+      const response = await fetch(
+        `https://storage.googleapis.com/upload/storage/v1/b/${bucket}/o?uploadType=media&name=${encodeURIComponent(fileName)}`,
+        {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+            'Content-Type': 'text/plain',
+          },
+          body: content,
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to upload file: ${response.status} ${response.statusText} - ${errorText}`);
+      }
+
+      this.logger.debug(`File ${fileName} uploaded successfully`);
+    } catch (error) {
+      this.logger.error('Error uploading file:', error);
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Added `read_document` MCP tool to read file contents from GCS bucket by filename
- Added `upload_document` MCP tool to upload text content to GCS bucket
- Extended GcsService with `readFile()` and `uploadFile()` methods
- Extended DocumentsService with corresponding wrapper methods that handle token exchange

## Test plan
- [x] Build passes with `npm run build:prod`
- [ ] Test read_document tool with an existing file in GCS bucket
- [ ] Test upload_document tool to create a new file
- [ ] Verify error handling for non-existent files

🤖 Generated with [Claude Code](https://claude.com/claude-code)