### PR TITLE
Fix chat bubble duplication during streaming

### DIFF
--- a/apps/ui/src/agents/AgentsChatSession.tsx
+++ b/apps/ui/src/agents/AgentsChatSession.tsx
@@ -76,6 +76,18 @@ const mergeStreamingParts = (
       continue;
     }
 
+    if (part.text) {
+      const lastTextIndex = mergedParts.findLastIndex(
+        (p) => p.text && !p.functionCall && !p.functionResponse
+      );
+      if (lastTextIndex >= 0) {
+        mergedParts[lastTextIndex] = part;
+      } else {
+        mergedParts.push(part);
+      }
+      continue;
+    }
+
     mergedParts.push(part);
   }
 


### PR DESCRIPTION
## Summary
- Fixed chat message bubbles being duplicated during streaming
- Updated `mergeStreamingParts` to replace the last text part instead of pushing new ones
- Text parts now behave consistently with functionCall and functionResponse parts

## Root Cause
The `mergeStreamingParts` function was always pushing new text parts to the array instead of updating the existing one. This caused multiple chat bubbles to be rendered for the same message as it streamed in.

## Solution
Added logic to find and replace the last text part when a new streaming text part arrives, matching the behavior of how functionCall and functionResponse parts are already handled.

## Test Plan
- [ ] Start a chat session with an agent
- [ ] Send a message that triggers a text response
- [ ] Verify that only one text bubble appears and updates as the response streams
- [ ] Verify that tool calls and tool responses still appear as separate bubbles
- [ ] Verify the final message appears correctly after streaming completes

Generated with [Claude Code](https://claude.com/claude-code)