### PR TITLE
Add multi-architecture Docker build support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -90,6 +96,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Added QEMU setup for ARM emulation using docker/setup-qemu-action@v3
- Added Docker Buildx for multi-platform builds using docker/setup-buildx-action@v3
- Configured Docker build to target both linux/amd64 and linux/arm64 platforms

## Changes
Modified `.github/workflows/test.yml`:
- Added QEMU setup step before Docker login
- Added Buildx setup step for multi-platform support
- Added `platforms: linux/amd64,linux/arm64` to the build-push-action configuration

## Testing
- ✅ Build validation passed: `npm run build:prod` completed successfully
- CI will verify the Docker build process works for both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)