### PR TITLE
feat: add role field to User entity

### DIFF
--- a/apps/backend/src/identity-provider/user.entity.ts
+++ b/apps/backend/src/identity-provider/user.entity.ts
@@ -25,6 +25,9 @@ export class User {
   @Column({ default: true })
   isActive!: boolean;
 
+  @Column({ type: 'varchar', default: 'standard' })
+  role!: 'admin' | 'standard';
+
   @VersionColumn()
   rowVersion!: number;
 


### PR DESCRIPTION
## Summary
Adds a `role` field to the User entity to enable role-based authorization.

## Changes
- Added `role` column to User entity with type `'admin' | 'standard'`
- Defaults to `'standard'` for new users
- TypeORM auto-sync will create the column automatically

## Task
Phase 1.1: Add role field to User entity

## Testing
- ✅ Build passes (`npm run build:prod`)
- ✅ TypeORM entity validation successful