### PR TITLE
feat: add admin user creation script

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,7 +20,8 @@
     "dev": "npm run start:dev",
     "typecheck": "tsc --noEmit",
     "does-it-start": "(nest start & ) && sleep 10 && kill $! || true",
-    "init-test-user": "ts-node -r tsconfig-paths/register src/scripts/init-test-user.ts"
+    "init-test-user": "ts-node -r tsconfig-paths/register src/scripts/init-test-user.ts",
+    "create-admin": "ts-node -r tsconfig-paths/register src/scripts/create-admin-user.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.21.1",

--- a/apps/backend/src/scripts/create-admin-user.ts
+++ b/apps/backend/src/scripts/create-admin-user.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Script to create an admin user for MCP Portal
+ *
+ * Usage:
+ *   npm run create-admin
+ *   npm run create-admin <email> <displayName> <password>
+ *
+ * If arguments are not provided, the script will prompt for input.
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from '../app.module';
+import { IdentityProviderService } from '../identity-provider/identity-provider.service';
+import * as readline from 'readline';
+
+async function promptInput(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const identityService = app.get(IdentityProviderService);
+
+  // Get parameters from CLI args or prompt
+  let email = process.argv[2];
+  let displayName = process.argv[3];
+  let password = process.argv[4];
+
+  if (!email) {
+    email = await promptInput('Enter email: ');
+  }
+
+  if (!displayName) {
+    displayName = await promptInput('Enter display name: ');
+  }
+
+  if (!password) {
+    password = await promptInput('Enter password: ');
+  }
+
+  // Validate inputs
+  if (!email || !displayName || !password) {
+    console.error('❌ Error: All fields are required (email, displayName, password)');
+    process.exit(1);
+  }
+
+  try {
+    console.log('Creating admin user...');
+
+    // Create user with standard role first
+    const user = await identityService.createUser(
+      email,
+      displayName,
+      password,
+    );
+
+    // Update role to admin
+    await identityService.updateUserRole(user.id, 'admin');
+
+    console.log('✅ Admin user created successfully!');
+    console.log('');
+    console.log('Login credentials:');
+    console.log('  Email:', email);
+    console.log('  Password:', password);
+    console.log('  User ID:', user.id);
+    console.log('  Role: admin');
+    console.log('');
+  } catch (error: any) {
+    if (error.code === '23505' || error.code === 'SQLITE_CONSTRAINT') {
+      // Unique constraint violation - user already exists
+      console.log('ℹ️  User with this email already exists');
+      console.log('');
+      console.log('To update an existing user to admin role, use:');
+      console.log('  User lookup and role update functionality (coming soon)');
+      console.log('');
+    } else {
+      console.error('❌ Error creating admin user:', error.message);
+      process.exit(1);
+    }
+  }
+
+  await app.close();
+}
+
+bootstrap();

--- a/apps/backend/src/scripts/init-test-user.ts
+++ b/apps/backend/src/scripts/init-test-user.ts
@@ -4,10 +4,12 @@
  *
  * This script creates a test user with credentials:
  * - Email: test@example.com
- * - Password: password123
+ * - Password: testpassword
  * - Display Name: Test User
  *
- * Run with: npm run init-test-user
+ * Usage:
+ *   npm run init-test-user           # Creates standard user
+ *   npm run init-test-user admin     # Creates admin user
  */
 
 import { NestFactory } from '@nestjs/core';
@@ -21,20 +23,28 @@ async function bootstrap() {
   const testEmail = 'test@example.com';
   const testPassword = 'testpassword';
   const testDisplayName = 'Test User';
+  const role = process.argv[2] === 'admin' ? 'admin' : 'standard';
 
   try {
-    console.log('Creating test user...');
+    console.log(`Creating test user (${role})...`);
     const user = await identityService.createUser(
       testEmail,
       testDisplayName,
       testPassword,
     );
+
+    // Update role if admin
+    if (role === 'admin') {
+      await identityService.updateUserRole(user.id, 'admin');
+    }
+
     console.log('✅ Test user created successfully!');
     console.log('');
     console.log('Login credentials:');
     console.log('  Email:', testEmail);
     console.log('  Password:', testPassword);
     console.log('  User ID:', user.id);
+    console.log('  Role:', role);
     console.log('');
   } catch (error: any) {
     if (error.code === '23505') {


### PR DESCRIPTION
## Summary
Adds CLI script for manual admin user creation with interactive prompts and CLI args support.

## Changes

### New Script: create-admin-user.ts
- ✅ Accepts email, displayName, password via CLI args
- ✅ Falls back to interactive prompts if args not provided
- ✅ Creates user and sets role to 'admin'
- ✅ Gracefully handles duplicate email errors
- ✅ Added npm script: `npm run create-admin`

### Updated: init-test-user.ts
- ✅ Now supports optional 'admin' parameter
- ✅ Usage: `npm run init-test-user [admin]`
- ✅ Defaults to 'standard' role if no parameter
- ✅ Displays role in output

## Usage

**Create custom admin user:**
```bash
npm run create-admin
# Or with args
npm run create-admin admin@example.com "Admin User" password123
```

**Create test admin user:**
```bash
npm run init-test-user admin
```

## Task
Phase 1.4: Create admin user creation script

## Testing
- ✅ Build passes (`npm run build:prod`)
- ✅ Scripts compile successfully
- ✅ Follows existing init-test-user.ts pattern