### PR TITLE
Phase 2A.6: Create custom decorators

### DIFF
--- a/apps/backend/src/authorization-server/decorators/current-user.decorator.ts
+++ b/apps/backend/src/authorization-server/decorators/current-user.decorator.ts
@@ -1,0 +1,22 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import type { WebAuthJwtPayload } from '../types/web-auth-jwt-payload.type';
+
+/**
+ * Parameter decorator that extracts the current authenticated user from the request.
+ * The user object is set by JwtAuthGuard after validating the access token.
+ *
+ * @example
+ * ```typescript
+ * @UseGuards(JwtAuthGuard)
+ * @Get('profile')
+ * async getProfile(@CurrentUser() user: WebAuthJwtPayload) {
+ *   return { userId: user.sub, email: user.email };
+ * }
+ * ```
+ */
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): WebAuthJwtPayload => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/apps/backend/src/authorization-server/decorators/roles.decorator.ts
+++ b/apps/backend/src/authorization-server/decorators/roles.decorator.ts
@@ -1,0 +1,19 @@
+import { SetMetadata } from '@nestjs/common';
+import { ROLES_KEY } from '../guards/roles.guard';
+
+/**
+ * Method decorator that sets role requirements for a route.
+ * Used in conjunction with RolesGuard to enforce role-based access control.
+ *
+ * @param roles - Array of role scopes required to access the route
+ * @example
+ * ```typescript
+ * @UseGuards(JwtAuthGuard, RolesGuard)
+ * @Roles('monolith:admin')
+ * @Get('admin-only')
+ * async adminRoute(@CurrentUser() user: WebAuthJwtPayload) {
+ *   // Only users with 'monolith:admin' scope can access this
+ * }
+ * ```
+ */
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/backend/src/authorization-server/types/web-auth-jwt-payload.type.ts
+++ b/apps/backend/src/authorization-server/types/web-auth-jwt-payload.type.ts
@@ -1,0 +1,52 @@
+/**
+ * Shape of the JWT payload we issue for web authentication access tokens.
+ * This is the payload structure returned by TokenService.validateWebToken()
+ * and attached to the request object by JwtAuthGuard.
+ */
+export interface WebAuthJwtPayload {
+  /**
+   * Issuer - authorization server identifier (URL)
+   */
+  iss: string;
+
+  /**
+   * Subject - user ID
+   */
+  sub: string;
+
+  /**
+   * User email address
+   */
+  email: string;
+
+  /**
+   * User display name
+   */
+  displayName: string;
+
+  /**
+   * Scopes granted to the user
+   * Examples: ['monolith:user'], ['monolith:user', 'monolith:admin']
+   */
+  scope: string[];
+
+  /**
+   * Issued-at time (seconds since Unix epoch)
+   */
+  iat: number;
+
+  /**
+   * Expiration time (seconds since Unix epoch)
+   */
+  exp: number;
+
+  /**
+   * Unique identifier for the token to support replay protection
+   */
+  jti: string;
+
+  /**
+   * Token type - always 'access' for access tokens
+   */
+  type: 'access';
+}


### PR DESCRIPTION
## Summary
- Created WebAuthJwtPayload type interface for web authentication tokens
- Created @CurrentUser() decorator to extract authenticated user from request
- Created @Roles() decorator for role-based access control

## Implementation Details

**WebAuthJwtPayload Type** (`apps/backend/src/authorization-server/types/web-auth-jwt-payload.type.ts`):
- Defines the structure of JWT payloads for web authentication
- Matches the payload created by TokenService.generateWebAccessToken()
- Used by JwtAuthGuard and CurrentUser decorator

**@CurrentUser() Decorator** (`apps/backend/src/authorization-server/decorators/current-user.decorator.ts`):
- Parameter decorator using createParamDecorator
- Extracts the user object from request (set by JwtAuthGuard)
- Returns WebAuthJwtPayload type

**@Roles() Decorator** (`apps/backend/src/authorization-server/decorators/roles.decorator.ts`):
- Method decorator using SetMetadata
- Imports ROLES_KEY from RolesGuard for consistency
- Sets required roles metadata for RolesGuard to enforce

## Usage Example
```typescript
@UseGuards(JwtAuthGuard, RolesGuard)
@Roles('monolith:admin')
@Get('admin-only')
async adminRoute(@CurrentUser() user: WebAuthJwtPayload) {
  // Only users with 'monolith:admin' scope can access
  return { userId: user.sub, email: user.email };
}
```

## Testing
- ✅ Production build passes
- All TypeScript types compile correctly
- Decorators integrate properly with guards from Phase 2A.5

## Related Tasks
- Completes Phase 2A.6
- Builds on Phase 2A.5 (JWT guards)
- Part of Phase 2A: Backend Web Authentication