### PR TITLE
feat: Configure OpenAPI client to send cookies with requests

### DIFF
--- a/apps/ui/src/config/api.ts
+++ b/apps/ui/src/config/api.ts
@@ -9,6 +9,8 @@
  * served from the same origin as the backend.
  */
 
+import { OpenAPI } from 'shared';
+
 /**
  * Get the base URL for API requests
  *
@@ -37,3 +39,10 @@ export const getUIWebSocketUrl = (path: string): string => {
  * Pre-configured base URL for OpenAPI clients
  */
 export const BFF_BASE_URL = getBFFBaseUrl();
+
+/**
+ * Configure OpenAPI client to send cookies with all requests
+ * This ensures authentication tokens stored in httpOnly cookies are sent automatically
+ */
+OpenAPI.BASE = BFF_BASE_URL;
+OpenAPI.CREDENTIALS = 'include';


### PR DESCRIPTION
## Summary
- Updated apps/ui/src/config/api.ts to configure OpenAPI client with credentials: 'include'
- Ensures all auto-generated API clients (TaskService, WikirooService, etc.) send httpOnly cookies with requests
- Critical for backend JWT guards to receive and validate tokens

## Impact
All API calls will now include authentication cookies automatically.

## Test plan
- [x] Build passes
- [ ] Verify cookies are sent with API requests in browser dev tools
- [ ] Verify authentication works end-to-end