### PR TITLE
refactor: Replace custom auth API with generated WebAuthenticationService

### DIFF
--- a/apps/ui/src/auth/AuthContext.tsx
+++ b/apps/ui/src/auth/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { authApi, AuthUser } from './api';
+import { WebAuthenticationService, type AuthUser } from './api';
 
 /**
  * Authentication state interface
@@ -43,8 +43,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // Check auth status on mount
   useEffect(() => {
-    authApi
-      .getCurrentUser()
+    WebAuthenticationService.webAuthControllerMe()
       .then((userData) => {
         setUser(userData);
       })
@@ -65,8 +64,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const refreshInterval = setInterval(
       async () => {
         try {
-          const userData = await authApi.refresh();
-          setUser(userData);
+          const response = await WebAuthenticationService.webAuthControllerRefresh();
+          setUser(response.user);
         } catch (error) {
           // Refresh failed - user needs to re-authenticate
           console.error('Token refresh failed:', error);
@@ -84,8 +83,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
    * Sets httpOnly cookies and updates user state
    */
   const login = async (email: string, password: string): Promise<void> => {
-    const userData = await authApi.login(email, password);
-    setUser(userData);
+    const response = await WebAuthenticationService.webAuthControllerLogin({ email, password });
+    setUser(response.user);
   };
 
   /**
@@ -94,7 +93,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
    */
   const logout = async (): Promise<void> => {
     try {
-      await authApi.logout();
+      await WebAuthenticationService.webAuthControllerLogout();
     } finally {
       // Always clear user state, even if API call fails
       setUser(null);
@@ -106,8 +105,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
    * Useful for recovering from temporary network issues
    */
   const refreshAuth = async (): Promise<void> => {
-    const userData = await authApi.refresh();
-    setUser(userData);
+    const response = await WebAuthenticationService.webAuthControllerRefresh();
+    setUser(response.user);
   };
 
   const value: AuthState = {

--- a/apps/ui/src/auth/api.ts
+++ b/apps/ui/src/auth/api.ts
@@ -1,83 +1,12 @@
-/**
- * Frontend authentication API client
- * Uses httpOnly cookies for token storage (set by backend)
- */
+import { OpenAPI, WebAuthenticationService, type UserResponseDto } from 'shared';
+import { BFF_BASE_URL } from '../config/api';
 
-export interface AuthUser {
-  id: string;
-  email: string;
-  displayName: string;
-  role: 'admin' | 'standard';
-}
+// Use centralized API configuration
+OpenAPI.BASE = BFF_BASE_URL;
+
+export { WebAuthenticationService };
 
 /**
- * Authentication API methods
- * All requests include credentials: 'include' to send httpOnly cookies
+ * Re-export UserResponseDto as AuthUser for backward compatibility
  */
-export const authApi = {
-  /**
-   * Login with email and password
-   * Backend sets access_token and refresh_token httpOnly cookies
-   */
-  login: async (email: string, password: string): Promise<AuthUser> => {
-    const response = await fetch('/api/v1/auth/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include', // Send cookies
-      body: JSON.stringify({ email, password }),
-    });
-
-    if (!response.ok) {
-      throw new Error('Login failed');
-    }
-
-    const data = await response.json();
-    return data.user; // Extract user from LoginResponseDto
-  },
-
-  /**
-   * Logout current user
-   * Backend clears httpOnly cookies
-   */
-  logout: async (): Promise<void> => {
-    await fetch('/api/v1/auth/logout', {
-      method: 'POST',
-      credentials: 'include',
-    });
-  },
-
-  /**
-   * Get current authenticated user
-   * Uses access_token cookie automatically sent by browser
-   */
-  getCurrentUser: async (): Promise<AuthUser> => {
-    const response = await fetch('/api/v1/auth/me', {
-      credentials: 'include',
-    });
-
-    if (!response.ok) {
-      throw new Error('Not authenticated');
-    }
-
-    // /me endpoint returns UserResponseDto directly
-    return await response.json();
-  },
-
-  /**
-   * Refresh access token using refresh_token cookie
-   * Backend sets new access_token and refresh_token httpOnly cookies
-   */
-  refresh: async (): Promise<AuthUser> => {
-    const response = await fetch('/api/v1/auth/refresh', {
-      method: 'POST',
-      credentials: 'include',
-    });
-
-    if (!response.ok) {
-      throw new Error('Refresh failed');
-    }
-
-    const data = await response.json();
-    return data.user; // Extract user from LoginResponseDto
-  },
-};
+export type AuthUser = UserResponseDto;


### PR DESCRIPTION
## Summary
- Removed manual fetch calls from apps/ui/src/auth/api.ts
- Now uses auto-generated WebAuthenticationService from shared package
- Updated AuthContext to use generated client methods for all operations (login, logout, refresh, getCurrentUser)
- Re-exported UserResponseDto as AuthUser for backward compatibility
- Pattern now matches other modules like taskeroo and wikiroo

## Impact
- Eliminates code duplication - no more manual fetch calls
- Ensures consistency with OpenAPI spec
- Automatically inherits credentials: 'include' from centralized config
- 89 lines of code removed

## Test plan
- [x] Build passes
- [ ] Login flow works correctly
- [ ] Logout works correctly
- [ ] Auto-refresh works every 8 minutes
- [ ] getCurrentUser (/me) works correctly