### PR TITLE
refactor: Centralize cookie keys and export shared types

### DIFF
--- a/apps/backend/src/authorization-server/constants/cookie-keys.constant.ts
+++ b/apps/backend/src/authorization-server/constants/cookie-keys.constant.ts
@@ -1,0 +1,8 @@
+/**
+ * Cookie key constants for web authentication
+ * Centralized to ensure consistency across the application
+ */
+export const COOKIE_KEYS = {
+  ACCESS_TOKEN: 'access_token',
+  REFRESH_TOKEN: 'refresh_token',
+} as const;

--- a/apps/backend/src/authorization-server/constants/index.ts
+++ b/apps/backend/src/authorization-server/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './cookie-keys.constant';

--- a/apps/backend/src/authorization-server/guards/jwt-auth.guard.ts
+++ b/apps/backend/src/authorization-server/guards/jwt-auth.guard.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import type { Request } from 'express';
 import { TokenService } from '../token.service';
+import { COOKIE_KEYS } from '../constants/cookie-keys.constant';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
@@ -13,7 +14,7 @@ export class JwtAuthGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
-    const token = request.cookies?.['access_token'];
+    const token = request.cookies?.[COOKIE_KEYS.ACCESS_TOKEN];
 
     if (!token) {
       throw new UnauthorizedException('No access token provided');

--- a/apps/backend/src/authorization-server/types/index.ts
+++ b/apps/backend/src/authorization-server/types/index.ts
@@ -1,1 +1,2 @@
 export * from './mcp-jwt-payload.type';
+export * from './web-auth-jwt-payload.type';

--- a/apps/backend/src/authorization-server/web-auth.controller.ts
+++ b/apps/backend/src/authorization-server/web-auth.controller.ts
@@ -17,6 +17,7 @@ import { LoginRequestDto } from './dto/login-request.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { getConfig } from '../config/env.config';
+import { COOKIE_KEYS } from './constants/cookie-keys.constant';
 
 @ApiTags('Web Authentication')
 @Controller('api/v1/auth')
@@ -68,12 +69,12 @@ export class WebAuthController {
       path: '/',
     };
 
-    response.cookie('access_token', accessToken, {
+    response.cookie(COOKIE_KEYS.ACCESS_TOKEN, accessToken, {
       ...cookieOptions,
       maxAge: expiresIn * 1000, // 10 minutes in milliseconds
     });
 
-    response.cookie('refresh_token', refreshToken, {
+    response.cookie(COOKIE_KEYS.REFRESH_TOKEN, refreshToken, {
       ...cookieOptions,
       maxAge: 24 * 60 * 60 * 1000, // 1 day in milliseconds
     });
@@ -107,7 +108,7 @@ export class WebAuthController {
     @Res({ passthrough: true }) response: Response,
   ): Promise<LoginResponseDto> {
     // Get refresh token from cookie
-    const refreshTokenFromCookie = request.cookies?.['refresh_token'];
+    const refreshTokenFromCookie = request.cookies?.[COOKIE_KEYS.REFRESH_TOKEN];
 
     if (!refreshTokenFromCookie) {
       throw new UnauthorizedException('Refresh token not found');
@@ -139,12 +140,12 @@ export class WebAuthController {
       path: '/',
     };
 
-    response.cookie('access_token', accessToken, {
+    response.cookie(COOKIE_KEYS.ACCESS_TOKEN, accessToken, {
       ...cookieOptions,
       maxAge: expiresIn * 1000,
     });
 
-    response.cookie('refresh_token', refreshToken, {
+    response.cookie(COOKIE_KEYS.REFRESH_TOKEN, refreshToken, {
       ...cookieOptions,
       maxAge: 24 * 60 * 60 * 1000,
     });
@@ -179,7 +180,7 @@ export class WebAuthController {
     @Res({ passthrough: true }) response: Response,
   ): Promise<{ ok: boolean }> {
     // Get refresh token from cookie
-    const refreshTokenFromCookie = request.cookies?.['refresh_token'];
+    const refreshTokenFromCookie = request.cookies?.[COOKIE_KEYS.REFRESH_TOKEN];
 
     // If refresh token exists, revoke it in the database
     // Note: We silently handle the case where token doesn't exist
@@ -197,8 +198,8 @@ export class WebAuthController {
     }
 
     // Clear cookies
-    response.clearCookie('access_token', { path: '/' });
-    response.clearCookie('refresh_token', { path: '/' });
+    response.clearCookie(COOKIE_KEYS.ACCESS_TOKEN, { path: '/' });
+    response.clearCookie(COOKIE_KEYS.REFRESH_TOKEN, { path: '/' });
 
     return { ok: true };
   }
@@ -216,7 +217,7 @@ export class WebAuthController {
   })
   async me(@Req() request: Request): Promise<UserResponseDto> {
     // Get access token from cookie
-    const accessToken = request.cookies?.['access_token'];
+    const accessToken = request.cookies?.[COOKIE_KEYS.ACCESS_TOKEN];
 
     if (!accessToken) {
       throw new UnauthorizedException('Not authenticated');


### PR DESCRIPTION
## Summary
- Created  constant to replace all hardcoded 'access_token' and 'refresh_token' strings
- Updated  to use  constant for all cookie operations
- Updated  to use  
- Exported  type from authorization-server/types
- Created constants/index.ts for organized exports

## Impact
- Eliminates magic strings throughout the authentication codebase
- Ensures consistency across all cookie operations
- Makes cookie key changes easier to manage (single source of truth)
- Shared types are now properly exported for use across modules

## Test plan
- [x] Build passes
- [ ] Login flow works correctly
- [ ] Refresh token flow works correctly
- [ ] Logout clears cookies properly
- [ ] JWT guard validates access token correctly