### PR TITLE
feat: Add logout button to sidebar

### DIFF
--- a/apps/ui/src/components/AppNavSidebar.tsx
+++ b/apps/ui/src/components/AppNavSidebar.tsx
@@ -1,10 +1,14 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { useAuth } from '../auth/AuthContext';
 
 interface AppNavSidebarProps {
   collapsed: boolean;
 }
 
 export function AppNavSidebar({ collapsed }: AppNavSidebarProps) {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
   const menuItems = [
     {
       name: 'Home',
@@ -47,27 +51,59 @@ export function AppNavSidebar({ collapsed }: AppNavSidebarProps) {
     },
   ];
 
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
   return (
-    <nav>
-      {menuItems.map((item) => (
-        <NavLink
-          key={item.path}
-          to={item.path}
-          className={({ isActive }) =>
-            `sidebar-nav-link ${isActive ? 'active' : ''} ${collapsed ? 'collapsed' : ''}`
-          }
-          end={item.path === '/'}
+    <nav className="sidebar-nav-container">
+      <div className="sidebar-nav-main">
+        {menuItems.map((item) => (
+          <NavLink
+            key={item.path}
+            to={item.path}
+            className={({ isActive }) =>
+              `sidebar-nav-link ${isActive ? 'active' : ''} ${collapsed ? 'collapsed' : ''}`
+            }
+            end={item.path === '/'}
+          >
+            <div className="sidebar-nav-icon">
+              {typeof item.icon === 'string' ? (
+                <span>{item.icon}</span>
+              ) : (
+                item.icon
+              )}
+            </div>
+            <span className="nav-link-text">{item.name}</span>
+          </NavLink>
+        ))}
+      </div>
+      <div className="sidebar-nav-bottom">
+        <button
+          onClick={handleLogout}
+          className={`sidebar-nav-link logout-button ${collapsed ? 'collapsed' : ''}`}
+          aria-label="Logout"
         >
           <div className="sidebar-nav-icon">
-            {typeof item.icon === 'string' ? (
-              <span>{item.icon}</span>
-            ) : (
-              item.icon
-            )}
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+              <polyline points="16 17 21 12 16 7" />
+              <line x1="21" y1="12" x2="9" y2="12" />
+            </svg>
           </div>
-          <span className="nav-link-text">{item.name}</span>
-        </NavLink>
-      ))}
+          <span className="nav-link-text">Logout</span>
+        </button>
+      </div>
     </nav>
   );
 }

--- a/apps/ui/src/styles/sidebar.css
+++ b/apps/ui/src/styles/sidebar.css
@@ -129,6 +129,25 @@
 /* ===========================
    Navigation Links
    =========================== */
+.sidebar-nav-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.sidebar-nav-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sidebar-gap);
+}
+
+.sidebar-nav-bottom {
+  margin-top: auto;
+  padding-top: var(--sidebar-padding);
+  border-top: 1px solid var(--sidebar-border);
+}
+
 .sidebar-nav-link {
   display: flex;
   align-items: center;
@@ -140,6 +159,12 @@
   transition: var(--sidebar-transition-fast);
   white-space: nowrap;
   cursor: pointer;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+  font-size: inherit;
 }
 
 .sidebar-nav-link:hover {
@@ -150,6 +175,15 @@
 .sidebar-nav-link.active {
   background-color: var(--sidebar-active-bg);
   color: var(--sidebar-active-text);
+}
+
+.sidebar-nav-link.logout-button {
+  color: #ef4444;
+}
+
+.sidebar-nav-link.logout-button:hover {
+  background-color: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
 }
 
 /* Collapsed state - hide text, center icon */


### PR DESCRIPTION
## Summary
- Added logout button at bottom of sidebar navigation
- Implemented logout functionality using useAuth hook
- Added proper styling with red color theme for logout button
- Updated sidebar CSS to support new layout structure

## Changes
- Updated :
  - Added useAuth and useNavigate hooks
  - Created handleLogout function
  - Added logout button with icon at bottom of sidebar
  - Split navigation into main section and bottom section
- Updated :
  - Added sidebar-nav-container for flexbox layout
  - Added sidebar-nav-main for main navigation items
  - Added sidebar-nav-bottom for logout button section
  - Added logout-button styling with red color theme

## Layout
Sidebar now shows:
1. Home
2. Agents
3. Taskeroo
4. Wikiroo
5. MCP Registry
6. (empty space)
7. Logout (at bottom with red styling)
8. Collapse sidebar button (already exists in RootLayout)

## Test plan
- [x] Build passes
- [ ] Logout button appears at bottom of sidebar
- [ ] Clicking logout calls logout function and redirects to /login
- [ ] Button styling works in both collapsed and expanded states
- [ ] Red color theme indicates logout action