### PR TITLE
Add Apple web app capable meta tag

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <link rel="icon" type="image/svg+xml" href="/roo-favicon.svg" />
     <title>AI Monorepo — Home</title>
   </head>


### PR DESCRIPTION
## Summary
- add apple mobile web app capable meta tag to allow fullscreen launch on iOS

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c32a83fd8832fa0d5a3b7fa0a56bb)