### PR TITLE
Taskeroo: persist view mode, fix column sizing, mobile header, and theme login styles

### DIFF
--- a/apps/ui2/src/auth/LoginPage.css
+++ b/apps/ui2/src/auth/LoginPage.css
@@ -4,6 +4,7 @@
   align-items: center;
   justify-content: center;
   padding: var(--space-4);
+  background-color: var(--bg);
 }
 
 .login-container {
@@ -24,15 +25,15 @@
 }
 
 .login-card {
-  background-color: #ffffff;
+  background-color: var(--surface-2);
   border-radius: var(--r-4);
   padding: var(--space-6);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  color: #1a202c;
+  box-shadow: var(--shadow-3);
+  color: var(--text);
 }
 
 .login-card * {
-  color: #1a202c;
+  color: var(--text);
 }
 
 .login-label {
@@ -42,12 +43,12 @@
 .login-input {
   width: 100%;
   padding: var(--space-3) var(--space-4);
-  border: 2px solid #e2e8f0;
+  border: 2px solid var(--border);
   border-radius: var(--r-2);
   font-size: var(--fs-input-mobile-safe);
   font-family: var(--font-sans);
-  color: #1a202c !important;
-  background-color: #ffffff !important;
+  color: var(--text) !important;
+  background-color: var(--surface) !important;
   transition: all 0.2s ease;
 }
 

--- a/apps/ui2/src/features/taskeroo/BoardView.css
+++ b/apps/ui2/src/features/taskeroo/BoardView.css
@@ -1,6 +1,6 @@
 .board-view {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--space-4);
   width: 100%;
   align-items: start;
@@ -11,6 +11,7 @@
   flex-direction: column;
   gap: var(--space-3);
   min-height: 400px;
+  min-width: 0;
   background-color: var(--surface);
   border-radius: var(--radius-3);
   padding: var(--space-3);

--- a/apps/ui2/src/features/taskeroo/TaskerooDesktopView.tsx
+++ b/apps/ui2/src/features/taskeroo/TaskerooDesktopView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Stack, Text, Button } from '../../ui/primitives';
 import { useTaskerooCtx } from './TaskerooProvider';
 import { BoardView } from './BoardView';
@@ -7,6 +7,17 @@ import { ErrorText } from '../../ui/primitives/ErrorText';
 import './TaskerooDesktopView.css';
 
 type ViewMode = 'board' | 'list';
+
+const viewModeStorageKey = 'taskeroo.viewMode';
+
+const getInitialViewMode = (): ViewMode => {
+  if (typeof window === 'undefined') {
+    return 'board';
+  }
+
+  const stored = window.localStorage.getItem(viewModeStorageKey);
+  return stored === 'list' || stored === 'board' ? stored : 'board';
+};
 
 function LoadingState() {
   return (
@@ -33,8 +44,12 @@ function ConnectionHeader() {
 }
 
 export function TaskerooDesktopView() {
-  const [viewMode, setViewMode] = useState<ViewMode>('board');
+  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
   const { tasks, isLoading, error } = useTaskerooCtx();
+
+  useEffect(() => {
+    window.localStorage.setItem(viewModeStorageKey, viewMode);
+  }, [viewMode]);
 
   return (
     <Stack spacing="5">

--- a/apps/ui2/src/features/taskeroo/TaskerooLayout.tsx
+++ b/apps/ui2/src/features/taskeroo/TaskerooLayout.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import { useEffect, useMemo } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 import { Stack, Text } from '../../ui/primitives';
 import { useInAppNav } from '../../app/providers';
 import { taskerooNavigation } from './navigation';
+import { STATUS_CONFIG } from './const';
 import { TaskerooProvider, useTaskerooCtx } from './TaskerooProvider';
 import { TaskerooDesktopView } from './TaskerooDesktopView';
 import './TaskerooLayout.css';
@@ -15,6 +16,11 @@ function TaskerooConnectionHeader() {
 
 export function TaskerooLayout() {
   const { setInAppNav } = useInAppNav();
+  const location = useLocation();
+
+  const activeSection = useMemo(() => {
+    return STATUS_CONFIG.find((item) => location.pathname.startsWith(item.path));
+  }, [location.pathname]);
 
   useEffect(() => {
     // Register in-app navigation when this layout mounts
@@ -38,6 +44,11 @@ export function TaskerooLayout() {
         <Stack spacing="5">
           <Stack spacing="2">
             <Text size="6" weight="bold">Taskeroo</Text>
+            {activeSection && (
+              <Text size="4" weight="bold">
+                {activeSection.icon} {activeSection.label}
+              </Text>
+            )}
             <TaskerooConnectionHeader />
             <Text tone="muted">Manage your tasks and track progress</Text>
           </Stack>


### PR DESCRIPTION
### Motivation

- Board columns were resizing based on content causing uneven widths and poor layout stability.
- The Taskeroo view preference (board/list) should be persisted so users keep their chosen view across sessions.
- Mobile Taskeroo view needs a clear title indicating the currently selected section (Queued / Building / Review / Shipped).
- The login form used hard-coded colors that conflicted with theme tones and dark mode.

### Description

- Persist the board/list preference to `localStorage` by adding a `viewMode` storage key and loading/saving it in `TaskerooDesktopView.tsx`.
- Make board columns layout stable by changing the grid to `repeat(4, minmax(0, 1fr))` and adding `min-width: 0` to `.board-column` in `BoardView.css`.
- Show the active mobile section header by deriving the active `STATUS_CONFIG` entry from `useLocation()` and rendering its `icon` and `label` in `TaskerooLayout.tsx`.
- Align the login form with theme tokens by switching hard-coded colors to CSS variables like `--bg`, `--surface`, `--surface-2`, `--text`, and `--border` in `LoginPage.css`.

### Testing

- Attempted to run the UI dev server with `npm -w ui2 run dev -- --host 0.0.0.0 --port 4173`, but it failed because `vite` is not installed in the environment.
- No unit or e2e test suites were executed as part of this change due to the unavailable dev toolchain.
- Files modified: `apps/ui2/src/features/taskeroo/TaskerooDesktopView.tsx`, `apps/ui2/src/features/taskeroo/BoardView.css`, `apps/ui2/src/features/taskeroo/TaskerooLayout.tsx`, and `apps/ui2/src/auth/LoginPage.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dbd1eaa14832fb5f77dc16a2d94cb)