### PR TITLE
Prevent duplicate threads for parent tasks

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { AgentRunsModule } from './agent-runs/agent-runs.module';
 import { getConfig } from './config/env.config';
 import { AppInitModule } from './app-init/app-init.module';
 import { BaselineSchema1700000000000 } from './migrations/1700000000000-BaselineSchema';
+import { AddUniqueIndexThreadsParentTask2026021100001 } from './migrations/2026021100001-AddUniqueIndexThreadsParentTask';
 
 @Module({
   imports: [
@@ -28,7 +29,10 @@ import { BaselineSchema1700000000000 } from './migrations/1700000000000-Baseline
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: false,
       migrationsRun: true,
-      migrations: [BaselineSchema1700000000000],
+      migrations: [
+        BaselineSchema1700000000000,
+        AddUniqueIndexThreadsParentTask2026021100001,
+      ],
     }),
     EventEmitterModule.forRoot(),
     ScheduleModule.forRoot(),

--- a/apps/backend/src/migrations/2026021100001-AddUniqueIndexThreadsParentTask.ts
+++ b/apps/backend/src/migrations/2026021100001-AddUniqueIndexThreadsParentTask.ts
@@ -1,0 +1,102 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUniqueIndexThreadsParentTask2026021100001
+  implements MigrationInterface
+{
+  name = 'AddUniqueIndexThreadsParentTask2026021100001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const duplicates: Array<{ parentTaskId?: string; parent_task_id?: string }> =
+      await queryRunner.query(`
+        SELECT parent_task_id as parentTaskId
+        FROM threads
+        GROUP BY parent_task_id
+        HAVING COUNT(*) > 1
+      `);
+
+    for (const duplicate of duplicates) {
+      const parentTaskId = duplicate.parentTaskId ?? duplicate.parent_task_id;
+      if (!parentTaskId) {
+        continue;
+      }
+
+      const threadRows: Array<{ id: string }> = await queryRunner.query(
+        `
+          SELECT id
+          FROM threads
+          WHERE parent_task_id = ?
+          ORDER BY created_at ASC
+        `,
+        [parentTaskId],
+      );
+
+      const [canonicalThread] = threadRows;
+      if (!canonicalThread) {
+        continue;
+      }
+
+      const duplicateIds = threadRows.slice(1).map((row) => row.id);
+
+      for (const duplicateId of duplicateIds) {
+        await queryRunner.query(
+          `
+            INSERT OR IGNORE INTO thread_tasks (thread_id, task_id)
+            SELECT ?, task_id FROM thread_tasks WHERE thread_id = ?
+          `,
+          [canonicalThread.id, duplicateId],
+        );
+        await queryRunner.query(
+          `DELETE FROM thread_tasks WHERE thread_id = ?`,
+          [duplicateId],
+        );
+
+        await queryRunner.query(
+          `
+            INSERT OR IGNORE INTO thread_context_blocks (thread_id, context_block_id)
+            SELECT ?, context_block_id FROM thread_context_blocks WHERE thread_id = ?
+          `,
+          [canonicalThread.id, duplicateId],
+        );
+        await queryRunner.query(
+          `DELETE FROM thread_context_blocks WHERE thread_id = ?`,
+          [duplicateId],
+        );
+
+        await queryRunner.query(
+          `
+            INSERT OR IGNORE INTO thread_tags (thread_id, tag_id)
+            SELECT ?, tag_id FROM thread_tags WHERE thread_id = ?
+          `,
+          [canonicalThread.id, duplicateId],
+        );
+        await queryRunner.query(`DELETE FROM thread_tags WHERE thread_id = ?`, [
+          duplicateId,
+        ]);
+
+        await queryRunner.query(
+          `
+            INSERT OR IGNORE INTO thread_participants (thread_id, actor_id)
+            SELECT ?, actor_id FROM thread_participants WHERE thread_id = ?
+          `,
+          [canonicalThread.id, duplicateId],
+        );
+        await queryRunner.query(
+          `DELETE FROM thread_participants WHERE thread_id = ?`,
+          [duplicateId],
+        );
+
+        await queryRunner.query(`DELETE FROM threads WHERE id = ?`, [duplicateId]);
+      }
+    }
+
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_threads_parent_task_id_unique ON threads(parent_task_id)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS idx_threads_parent_task_id_unique`,
+    );
+  }
+}

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -209,7 +209,7 @@ export class TasksService {
     });
 
     // Try to find a thread where the parent task is
-    let thread = await this.threadsService.findThreadByTaskId(parentTaskId);
+    let thread = await this.threadsService.findThreadByParentTaskId(parentTaskId);
 
     if (thread) {
       // Thread exists, attach the task to it
@@ -234,7 +234,9 @@ export class TasksService {
         });
       } catch (error) {
         if (this.isThreadParentUniqueConstraintError(error)) {
-          thread = await this.threadsService.findThreadByTaskId(parentTaskId);
+          thread = await this.threadsService.findThreadByParentTaskId(
+            parentTaskId,
+          );
           if (!thread) {
             throw error;
           }

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { Repository, In } from 'typeorm';
+import { Repository, In, QueryFailedError } from 'typeorm';
 import { TaskEntity } from './task.entity';
 import { TaskStatus } from './enums';
 import { CommentEntity } from './comment.entity';
@@ -226,11 +226,23 @@ export class TasksService {
         parentTaskId,
         newTaskId: task.id,
       });
-      thread = await this.threadsService.createThread({
-        createdByActorId: input.createdByActorId,
-        parentTaskId: parentTaskId,
-        taskIds: [task.id],
-      });
+      try {
+        thread = await this.threadsService.createThread({
+          createdByActorId: input.createdByActorId,
+          parentTaskId: parentTaskId,
+          taskIds: [task.id],
+        });
+      } catch (error) {
+        if (this.isThreadParentUniqueConstraintError(error)) {
+          thread = await this.threadsService.findThreadByTaskId(parentTaskId);
+          if (!thread) {
+            throw error;
+          }
+          await this.threadsService.attachTask(thread.id, task.id);
+        } else {
+          throw error;
+        }
+      }
     }
 
     this.logger.log({
@@ -349,6 +361,17 @@ export class TasksService {
       new TaskUpdatedEvent({ id: actorId }, taskWithRelations),
     );
     return this.mapTaskToResult(taskWithRelations);
+  }
+
+  private isThreadParentUniqueConstraintError(error: unknown): boolean {
+    if (!(error instanceof QueryFailedError)) {
+      return false;
+    }
+    const driverError = (error as any).driverError;
+    if (driverError?.code !== 'SQLITE_CONSTRAINT') {
+      return false;
+    }
+    return driverError?.message?.includes('threads.parent_task_id') === true;
   }
 
   async assignTask(

--- a/apps/backend/src/threads/thread.entity.ts
+++ b/apps/backend/src/threads/thread.entity.ts
@@ -10,6 +10,7 @@ import {
   ManyToOne,
   JoinTable,
   JoinColumn,
+  Index,
 } from 'typeorm';
 import { ActorEntity } from '../identity-provider/actor.entity';
 import { TaskEntity } from '../tasks/task.entity';
@@ -17,6 +18,7 @@ import { ContextBlockEntity } from '../context/block.entity';
 import { TagEntity } from '../meta/tag.entity';
 
 @Entity({ name: 'threads' })
+@Index(['parentTaskId'], { unique: true })
 export class ThreadEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;

--- a/apps/backend/src/threads/threads.service.ts
+++ b/apps/backend/src/threads/threads.service.ts
@@ -426,6 +426,37 @@ export class ThreadsService {
     return await this.buildThreadResult(thread);
   }
 
+  async findThreadByParentTaskId(
+    parentTaskId: string,
+  ): Promise<ThreadResult | null> {
+    this.logger.log({
+      message: 'Finding thread by parent task ID',
+      parentTaskId,
+    });
+
+    const thread = await this.threadRepository.findOne({
+      where: { parentTaskId },
+      relations: [
+        'createdByActor',
+        'tasks',
+        'tasks.assigneeActor',
+        'tasks.createdByActor',
+        'tasks.tags',
+        'tasks.comments',
+        'tasks.inputRequests',
+        'referencedContextBlocks',
+        'tags',
+        'participants',
+      ],
+    });
+
+    if (!thread) {
+      return null;
+    }
+
+    return this.mapThreadToResult(thread);
+  }
+
   async findThreadsByParentTaskId(parentTaskId: string): Promise<ThreadResult[]> {
     this.logger.log({
       message: 'Finding threads by parent task ID',


### PR DESCRIPTION
## Summary
- enforce a unique parent task constraint on threads to avoid duplicate thread creation
- retry thread attachment when concurrent subtask creation hits the unique constraint

## Testing
- npm run zero-to-prod
- npm run dev

## Tech Debt
- none