### PR TITLE
Add project selector and project-scoped task stream behavior

### DIFF
--- a/apps/ui2/src/app/shells/DesktopShell.css
+++ b/apps/ui2/src/app/shells/DesktopShell.css
@@ -8,6 +8,10 @@
 .desktop-shell__header {
   flex-shrink: 0;
   padding-bottom: var(--space-4);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
 }
 
 .desktop-shell__title {
@@ -28,4 +32,8 @@
 .desktop-shell__content > * {
   flex: 1;
   min-height: 0;
+}
+
+.desktop-shell__header-right {
+  flex-shrink: 0;
 }

--- a/apps/ui2/src/app/shells/DesktopShell.tsx
+++ b/apps/ui2/src/app/shells/DesktopShell.tsx
@@ -3,15 +3,17 @@ import "./DesktopShell.css";
 
 export interface DesktopShellProps {
   sectionTitle?: string;
+  headerRight?: ReactNode;
   children: ReactNode;
 }
 
-export function DesktopShell({ sectionTitle, children }: DesktopShellProps): JSX.Element {
+export function DesktopShell({ sectionTitle, headerRight, children }: DesktopShellProps): JSX.Element {
   return (
     <div className="desktop-shell">
-      {sectionTitle && (
+      {(sectionTitle || headerRight) && (
         <div className="desktop-shell__header">
-          <h1 className="desktop-shell__title">{sectionTitle}</h1>
+          {sectionTitle ? <h1 className="desktop-shell__title">{sectionTitle}</h1> : <div />}
+          {headerRight ? <div className="desktop-shell__header-right">{headerRight}</div> : null}
         </div>
       )}
       <div className="desktop-shell__content">

--- a/apps/ui2/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui2/src/features/tasks/TaskDetailPage.tsx
@@ -1,8 +1,10 @@
-import { useState, useEffect, useRef } from 'react';
+import { useCallback, useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { io } from 'socket.io-client';
 import { useTasksCtx } from './TasksProvider';
 import { TasksService } from './api';
 import { TaskStatus, TASKS_STATUS } from './const';
+import type { Task } from './types';
 import { Text, Stack, Button, Avatar, DataRow, ErrorText, DataRowTag, DataRowContainer } from '../../ui/primitives';
 import { DeleteWithConfirmation } from '../../ui/components';
 import { elapsedTime } from "../../shared/helpers/elapsedTime";
@@ -12,10 +14,22 @@ import { TagSearchPop } from './TagSearchPop';
 import { ActorSearchPop, Actor, useActorsCtx } from '../actors';
 import { useAuth } from '../../auth/AuthContext';
 import { InputRequestResponseDto, MetaTagResponseDto } from "@taico/client";
-import { TaskActivityWireEvent } from '@taico/events';
+import {
+  InputRequestAnsweredWireEvent,
+  TaskActivityWireEvent,
+  TaskAssignedWireEvent,
+  TaskCommentedWireEvent,
+  TaskDeletedWireEvent,
+  TaskStatusChangedWireEvent,
+  TaskUpdatedWireEvent,
+  TaskWireEvents,
+} from '@taico/events';
 import { useDocumentTitle } from '../../shared/hooks/useDocumentTitle';
 import { useToast } from '../../shared/context/ToastContext';
+import { getUIWebSocketUrl } from '../../config/api';
 import './TaskDetailPage.css';
+
+const SOCKET_URL = getUIWebSocketUrl('/tasks');
 
 export function TaskDetailPage() {
   const { d: taskId } = useParams<{ d: string }>();
@@ -38,9 +52,33 @@ export function TaskDetailPage() {
   const ACTIVITY_VISIBLE_MS = 3500;
   const ACTIVITY_EXIT_MS = 220;
 
+  const showLiveActivity = useCallback((activityEvent: TaskActivityWireEvent) => {
+    if (!activityEvent.message) {
+      return;
+    }
+
+    if (activityHideTimerRef.current) {
+      window.clearTimeout(activityHideTimerRef.current);
+    }
+    if (activityExitTimerRef.current) {
+      window.clearTimeout(activityExitTimerRef.current);
+    }
+
+    setLiveActivity(activityEvent);
+    setActivityPhase('enter');
+
+    activityHideTimerRef.current = window.setTimeout(() => {
+      setActivityPhase('exit');
+      activityExitTimerRef.current = window.setTimeout(() => {
+        setLiveActivity(null);
+        setActivityPhase('idle');
+      }, ACTIVITY_EXIT_MS);
+    }, ACTIVITY_VISIBLE_MS);
+  }, [ACTIVITY_EXIT_MS, ACTIVITY_VISIBLE_MS]);
+
   // Find task from context (real-time updates)
   const taskFromContext = tasks.find(t => t.id === taskId);
-  const [hydratedTask, setHydratedTask] = useState<typeof taskFromContext>(undefined);
+  const [hydratedTask, setHydratedTask] = useState<Task | undefined>(undefined);
   const [isHydratingTask, setIsHydratingTask] = useState(false);
   const task = taskFromContext ?? hydratedTask;
 
@@ -68,9 +106,28 @@ export function TaskDetailPage() {
     };
   }, []);
 
-  useEffect(() => {
-    let isCurrent = true;
+  const refreshHydratedTask = useCallback(async (options?: { showLoading?: boolean }) => {
+    if (!taskId) {
+      setHydratedTask(undefined);
+      setIsHydratingTask(false);
+      return;
+    }
 
+    if (options?.showLoading) {
+      setIsHydratingTask(true);
+    }
+
+    try {
+      const fetchedTask = await TasksService.tasksControllerGetTask(taskId);
+      setHydratedTask(fetchedTask);
+    } catch {
+      setHydratedTask(undefined);
+    } finally {
+      setIsHydratingTask(false);
+    }
+  }, [taskId]);
+
+  useEffect(() => {
     if (!taskId) {
       setHydratedTask(undefined);
       setIsHydratingTask(false);
@@ -83,28 +140,71 @@ export function TaskDetailPage() {
       return;
     }
 
-    setIsHydratingTask(true);
-    TasksService.tasksControllerGetTask(taskId)
-      .then((fetchedTask) => {
-        if (isCurrent) {
-          setHydratedTask(fetchedTask);
-        }
-      })
-      .catch(() => {
-        if (isCurrent) {
-          setHydratedTask(undefined);
-        }
-      })
-      .finally(() => {
-        if (isCurrent) {
-          setIsHydratingTask(false);
-        }
-      });
+    void refreshHydratedTask({ showLoading: true });
+  }, [taskId, taskFromContext, refreshHydratedTask]);
+
+  useEffect(() => {
+    if (!taskId) {
+      return;
+    }
+
+    const socket = io(SOCKET_URL, {
+      transports: ['websocket', 'polling'],
+      withCredentials: true,
+    });
+
+    const upsertIfCurrentTask = (updatedTask: Task) => {
+      if (updatedTask.id === taskId) {
+        setHydratedTask(updatedTask);
+      }
+    };
+
+    const refreshIfCurrentTask = (updatedTaskId: string) => {
+      if (updatedTaskId === taskId) {
+        void refreshHydratedTask();
+      }
+    };
+
+    socket.on('connect', () => {
+      socket.emit('tasks.subscribe', {}, () => undefined);
+    });
+
+    socket.on(TaskWireEvents.TASK_UPDATED, (event: TaskUpdatedWireEvent) => {
+      upsertIfCurrentTask(event.payload as Task);
+    });
+
+    socket.on(TaskWireEvents.TASK_ASSIGNED, (event: TaskAssignedWireEvent) => {
+      upsertIfCurrentTask(event.payload as Task);
+    });
+
+    socket.on(TaskWireEvents.TASK_STATUS_CHANGED, (event: TaskStatusChangedWireEvent) => {
+      upsertIfCurrentTask(event.payload as Task);
+    });
+
+    socket.on(TaskWireEvents.TASK_COMMENTED, (event: TaskCommentedWireEvent) => {
+      refreshIfCurrentTask(event.payload.taskId);
+    });
+
+    socket.on(TaskWireEvents.INPUT_REQUEST_ANSWERED, (event: InputRequestAnsweredWireEvent) => {
+      refreshIfCurrentTask(event.payload.taskId);
+    });
+
+    socket.on(TaskWireEvents.TASK_DELETED, (event: TaskDeletedWireEvent) => {
+      if (event.payload.taskId === taskId) {
+        setHydratedTask(undefined);
+      }
+    });
+
+    socket.on(TaskWireEvents.TASK_ACTIVITY, (event: TaskActivityWireEvent) => {
+      if (event.taskId === taskId) {
+        showLiveActivity(event);
+      }
+    });
 
     return () => {
-      isCurrent = false;
+      socket.close();
     };
-  }, [taskId, taskFromContext]);
+  }, [taskId, refreshHydratedTask, showLiveActivity]);
 
   // Loading / error state
   const [error, setError] = useState<string | null>(null);
@@ -125,6 +225,7 @@ export function TaskDetailPage() {
         taskId: task.id,
         comment: content,
       });
+      await refreshHydratedTask();
       return true;
     } catch (err: unknown) {
       showError(err);
@@ -144,6 +245,7 @@ export function TaskDetailPage() {
         taskId: task.id,
         assigneeActorId: actor.id,
       });
+      await refreshHydratedTask();
       return true;
     } catch (err: unknown) {
       showError(err);
@@ -164,6 +266,7 @@ export function TaskDetailPage() {
         inputRequestId: respondingToInputRequest.id,
         answer,
       });
+      await refreshHydratedTask();
       return true;
     } catch (err: unknown) {
       showError(err);
@@ -182,6 +285,7 @@ export function TaskDetailPage() {
       await TasksService.tasksControllerAddTagToTask(task.id, {
         name: tag.name,
       });
+      await refreshHydratedTask();
       return true;
     } catch (err: unknown) {
       showError(err);
@@ -198,6 +302,7 @@ export function TaskDetailPage() {
     }
     try {
       await TasksService.tasksControllerRemoveTagFromTask(task.id, tagId);
+      await refreshHydratedTask();
     } catch (err: unknown) {
       showError(err);
     }
@@ -211,24 +316,8 @@ export function TaskDetailPage() {
       return;
     }
 
-    if (activityHideTimerRef.current) {
-      window.clearTimeout(activityHideTimerRef.current);
-    }
-    if (activityExitTimerRef.current) {
-      window.clearTimeout(activityExitTimerRef.current);
-    }
-
-    setLiveActivity(activity);
-    setActivityPhase('enter');
-
-    activityHideTimerRef.current = window.setTimeout(() => {
-      setActivityPhase('exit');
-      activityExitTimerRef.current = window.setTimeout(() => {
-        setLiveActivity(null);
-        setActivityPhase('idle');
-      }, ACTIVITY_EXIT_MS);
-    }, ACTIVITY_VISIBLE_MS);
-  }, [activity, task, ACTIVITY_EXIT_MS, ACTIVITY_VISIBLE_MS]);
+    showLiveActivity(activity);
+  }, [activity, task, showLiveActivity]);
 
   // If task not found in context, could be loading or invalid
   if (!task) {
@@ -248,6 +337,7 @@ export function TaskDetailPage() {
     setIsLoading(true);
     try {
       await TasksService.tasksControllerChangeStatus(task.id, { status: newStatus });
+      await refreshHydratedTask();
       setError(null);
     } catch (err: unknown) {
       showError(err);
@@ -587,6 +677,7 @@ export function TaskDetailPage() {
             variant='primary'
             onClick={async () => {
               await assignTaskToMe({ taskId: task.id });
+              await refreshHydratedTask();
             }}
           >
             Assign to Me

--- a/apps/ui2/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui2/src/features/tasks/TaskDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useTasksCtx } from './TasksProvider';
 import { TasksService } from './api';
 import { TaskStatus, TASKS_STATUS } from './const';
@@ -20,10 +20,15 @@ import './TaskDetailPage.css';
 export function TaskDetailPage() {
   const { d: taskId } = useParams<{ d: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const { tasks, setSectionTitle, addComment, deleteTask, assignTask, assignTaskToMe, answerInputRequest, activityByTaskId } = useTasksCtx();
   const { actors } = useActorsCtx();
   const { user } = useAuth();
   const { showError } = useToast();
+
+  const navigateToTasksList = () => {
+    navigate({ pathname: '/tasks', search: location.search });
+  };
 
   const [liveActivity, setLiveActivity] = useState<TaskActivityWireEvent | null>(null);
   const [activityPhase, setActivityPhase] = useState<'idle' | 'enter' | 'exit'>('idle');
@@ -190,7 +195,7 @@ export function TaskDetailPage() {
       <div className="task-detail-page">
         <Stack spacing="4" align="center">
           <Text size="3" tone="muted">Task not found</Text>
-          <Button variant="secondary" onClick={() => navigate('/tasks')}>
+          <Button variant="secondary" onClick={navigateToTasksList}>
             Back to tasks
           </Button>
         </Stack>
@@ -554,7 +559,7 @@ export function TaskDetailPage() {
         onDelete={async () => {
           try {
             await deleteTask({ taskId: task.id });
-            navigate('/tasks');
+            navigateToTasksList();
           } catch (err: unknown) {
             showError(err);
           }
@@ -566,7 +571,7 @@ export function TaskDetailPage() {
         <Button
           size='lg'
           variant='secondary'
-          onClick={() => navigate('/tasks')}
+          onClick={navigateToTasksList}
         >
           Back to Tasks
         </Button>

--- a/apps/ui2/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui2/src/features/tasks/TaskDetailPage.tsx
@@ -39,7 +39,10 @@ export function TaskDetailPage() {
   const ACTIVITY_EXIT_MS = 220;
 
   // Find task from context (real-time updates)
-  const task = tasks.find(t => t.id === taskId);
+  const taskFromContext = tasks.find(t => t.id === taskId);
+  const [hydratedTask, setHydratedTask] = useState<typeof taskFromContext>(undefined);
+  const [isHydratingTask, setIsHydratingTask] = useState(false);
+  const task = taskFromContext ?? hydratedTask;
 
   // Set document title (browser tab)
   useDocumentTitle({ task: { name: task?.name } });
@@ -64,6 +67,44 @@ export function TaskDetailPage() {
       }
     };
   }, []);
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    if (!taskId) {
+      setHydratedTask(undefined);
+      setIsHydratingTask(false);
+      return;
+    }
+
+    if (taskFromContext) {
+      setHydratedTask(taskFromContext);
+      setIsHydratingTask(false);
+      return;
+    }
+
+    setIsHydratingTask(true);
+    TasksService.tasksControllerGetTask(taskId)
+      .then((fetchedTask) => {
+        if (isCurrent) {
+          setHydratedTask(fetchedTask);
+        }
+      })
+      .catch(() => {
+        if (isCurrent) {
+          setHydratedTask(undefined);
+        }
+      })
+      .finally(() => {
+        if (isCurrent) {
+          setIsHydratingTask(false);
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [taskId, taskFromContext]);
 
   // Loading / error state
   const [error, setError] = useState<string | null>(null);
@@ -194,7 +235,7 @@ export function TaskDetailPage() {
     return (
       <div className="task-detail-page">
         <Stack spacing="4" align="center">
-          <Text size="3" tone="muted">Task not found</Text>
+          <Text size="3" tone="muted">{isHydratingTask ? 'Loading task...' : 'Task not found'}</Text>
           <Button variant="secondary" onClick={navigateToTasksList}>
             Back to tasks
           </Button>

--- a/apps/ui2/src/features/tasks/TaskDetailPageWithEdits.tsx
+++ b/apps/ui2/src/features/tasks/TaskDetailPageWithEdits.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useTasksCtx } from './TasksProvider';
 import { ActorsService, TasksService } from './api';
 import { TaskStatus, TASKS_STATUS } from './const';
@@ -15,6 +15,7 @@ type EditingField = 'title' | 'description' | 'assignee' | null;
 export function TaskDetailPage() {
   const { d: taskId } = useParams<{ d: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const { tasks, setSectionTitle } = useTasksCtx();
 
   // Find task from context (real-time updates)
@@ -71,7 +72,7 @@ export function TaskDetailPage() {
       <div className="task-detail-page">
         <Stack spacing="4" align="center">
           <Text size="3" tone="muted">Task not found</Text>
-          <Button variant="secondary" onClick={() => navigate('/tasks')}>
+          <Button variant="secondary" onClick={() => navigate({ pathname: '/tasks', search: location.search })}>
             Back to tasks
           </Button>
         </Stack>

--- a/apps/ui2/src/features/tasks/TasksLayout.tsx
+++ b/apps/ui2/src/features/tasks/TasksLayout.tsx
@@ -1,16 +1,21 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { useIsDesktop } from "../../app/hooks/useIsDesktop";
 import { DesktopShell } from "../../app/shells/DesktopShell";
 import { IosShell } from "../../app/shells/IosShell";
 import { useTasksCtx } from "./TasksProvider";
 import { TASKS_STATUS_NAV } from "./const";
 import { ShippedCelebration } from "./ShippedCelebration";
+import { TasksProjectSelector } from "./TasksProjectSelector";
 
 export function TasksLayout(): JSX.Element {
   const isDesktop = useIsDesktop();
   const { sectionTitle, shippedCelebrationTrigger } = useTasksCtx();
+  const location = useLocation();
 
-  console.log('Tasks layout mounting');
+  const navItems = TASKS_STATUS_NAV.map((item) => ({
+    ...item,
+    path: `${item.path}${location.search}`,
+  }));
 
   return (
     <div style={{ minHeight: 0 }}>
@@ -18,6 +23,7 @@ export function TasksLayout(): JSX.Element {
       {isDesktop ?
         <DesktopShell
           sectionTitle={sectionTitle}
+          headerRight={<TasksProjectSelector compact />}
         >
           <Outlet />
         </DesktopShell>
@@ -25,7 +31,7 @@ export function TasksLayout(): JSX.Element {
         <IosShell
           appTitle="Tasks"
           sectionTitle={sectionTitle}
-          navItems={TASKS_STATUS_NAV}
+          navItems={navItems}
         >
           <Outlet />
         </IosShell>}

--- a/apps/ui2/src/features/tasks/TasksLayout.tsx
+++ b/apps/ui2/src/features/tasks/TasksLayout.tsx
@@ -16,6 +16,7 @@ export function TasksLayout(): JSX.Element {
     ...item,
     path: `${item.path}${location.search}`,
   }));
+  const showProjectSelector = !location.pathname.startsWith("/tasks/task/");
 
   return (
     <div style={{ minHeight: 0 }}>
@@ -23,7 +24,7 @@ export function TasksLayout(): JSX.Element {
       {isDesktop ?
         <DesktopShell
           sectionTitle={sectionTitle}
-          headerRight={<TasksProjectSelector compact />}
+          headerRight={showProjectSelector ? <TasksProjectSelector compact /> : null}
         >
           <Outlet />
         </DesktopShell>

--- a/apps/ui2/src/features/tasks/TasksPage.css
+++ b/apps/ui2/src/features/tasks/TasksPage.css
@@ -7,6 +7,10 @@
   display: flex;
 }
 
+.tasks-mobile-project-filter {
+  padding: 0 var(--space-3) var(--space-2);
+}
+
 .tasks-board-view {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -157,5 +161,4 @@
   font-weight: 600;
   white-space: nowrap;
 }
-
 

--- a/apps/ui2/src/features/tasks/TasksPage.tsx
+++ b/apps/ui2/src/features/tasks/TasksPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Text } from "../../ui/primitives";
 import { useTasksCtx, AnimationState } from "./TasksProvider"
 import { TaskStatus } from "./const";
@@ -12,6 +12,7 @@ import './TasksPage.css';
 import { NewTaskPop } from "./NewTaskPop";
 import { TasksToRows } from "./TasksToRows";
 import { TasksToCards } from "./TasksToCards";
+import { TasksProjectSelector } from "./TasksProjectSelector";
 
 export function TasksPage({ status }: { status?: TaskStatus }) {
 
@@ -21,6 +22,7 @@ export function TasksPage({ status }: { status?: TaskStatus }) {
   const { showError } = useToast();
 
   const navigate = useNavigate();
+  const location = useLocation();
 
   // Set document title (browser tab)
   useDocumentTitle();
@@ -74,7 +76,7 @@ export function TasksPage({ status }: { status?: TaskStatus }) {
       });
       if (task) {
         setNewTask(task);
-        navigate(`/tasks/task/${task.id}`);
+        navigate({ pathname: `/tasks/task/${task.id}`, search: location.search });
         return true;
       } else {
         return false;
@@ -91,6 +93,9 @@ export function TasksPage({ status }: { status?: TaskStatus }) {
     <div className={`${isDesktop ? 'full-height' : ''}`}>
       {!isDesktop ?
         <>
+          <div className="tasks-mobile-project-filter">
+            <TasksProjectSelector />
+          </div>
           <TasksToRows
             tasks={filteredTasks}
             enteringIds={mobileAnimationState.enteringIds}

--- a/apps/ui2/src/features/tasks/TasksProjectSelector.css
+++ b/apps/ui2/src/features/tasks/TasksProjectSelector.css
@@ -1,4 +1,5 @@
 .tasks-project-selector {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
@@ -10,15 +11,100 @@
   white-space: nowrap;
 }
 
-.tasks-project-selector__select {
+.tasks-project-selector__trigger {
   min-width: 140px;
   max-width: 180px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
   border: 1px solid var(--border);
   border-radius: var(--r-2);
   background: var(--surface);
   color: var(--text);
   font-size: var(--fs-2);
   padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+}
+
+.tasks-project-selector__trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.tasks-project-selector__trigger:focus-visible,
+.tasks-project-selector__search:focus-visible,
+.tasks-project-selector__option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.tasks-project-selector__icon,
+.tasks-project-selector__chevron {
+  color: var(--text-muted);
+  flex: 0 0 auto;
+}
+
+.tasks-project-selector__value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tasks-project-selector__popover {
+  position: absolute;
+  right: 0;
+  top: calc(100% + var(--space-1));
+  z-index: 20;
+  width: min(280px, calc(100vw - var(--space-4)));
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+  background: var(--surface);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 16%);
+  padding: var(--space-2);
+}
+
+.tasks-project-selector__search {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--fs-2);
+  padding: var(--space-2);
+}
+
+.tasks-project-selector__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  max-height: 240px;
+  overflow-y: auto;
+  padding-top: var(--space-2);
+}
+
+.tasks-project-selector__option {
+  width: 100%;
+  border: 0;
+  border-radius: var(--r-2);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font-size: var(--fs-2);
+  padding: var(--space-2);
+  text-align: left;
+}
+
+.tasks-project-selector__option:hover,
+.tasks-project-selector__option--selected {
+  background: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.tasks-project-selector__empty {
+  color: var(--text-muted);
+  font-size: var(--fs-2);
+  padding: var(--space-2);
 }
 
 .tasks-project-selector--compact .tasks-project-selector__label {
@@ -30,8 +116,14 @@
     width: 100%;
   }
 
-  .tasks-project-selector__select {
+  .tasks-project-selector__trigger {
     width: 100%;
     max-width: none;
+  }
+
+  .tasks-project-selector__popover {
+    left: 0;
+    right: auto;
+    width: 100%;
   }
 }

--- a/apps/ui2/src/features/tasks/TasksProjectSelector.css
+++ b/apps/ui2/src/features/tasks/TasksProjectSelector.css
@@ -1,0 +1,37 @@
+.tasks-project-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.tasks-project-selector__label {
+  font-size: var(--fs-2);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.tasks-project-selector__select {
+  min-width: 140px;
+  max-width: 180px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  background: var(--surface);
+  color: var(--text);
+  font-size: var(--fs-2);
+  padding: var(--space-1) var(--space-2);
+}
+
+.tasks-project-selector--compact .tasks-project-selector__label {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .tasks-project-selector {
+    width: 100%;
+  }
+
+  .tasks-project-selector__select {
+    width: 100%;
+    max-width: none;
+  }
+}

--- a/apps/ui2/src/features/tasks/TasksProjectSelector.tsx
+++ b/apps/ui2/src/features/tasks/TasksProjectSelector.tsx
@@ -30,7 +30,7 @@ export function TasksProjectSelector({ compact = false }: TasksProjectSelectorPr
       >
         <option value="">All projects</option>
         {sortedProjects.map((project) => (
-          <option key={project.id} value={project.id}>
+          <option key={project.id} value={project.slug}>
             {project.slug}
           </option>
         ))}

--- a/apps/ui2/src/features/tasks/TasksProjectSelector.tsx
+++ b/apps/ui2/src/features/tasks/TasksProjectSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useTasksCtx } from './TasksProvider';
 import './TasksProjectSelector.css';
 
@@ -13,28 +13,121 @@ export function TasksProjectSelector({ compact = false }: TasksProjectSelectorPr
     setSelectedProjectId,
     isLoadingProjects,
   } = useTasksCtx();
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const labelId = useId();
+  const valueId = useId();
 
   const sortedProjects = useMemo(
     () => [...projects].sort((a, b) => a.slug.localeCompare(b.slug)),
     [projects],
   );
 
+  const selectedProject = sortedProjects.find((project) => project.slug === selectedProjectId) ?? null;
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredProjects = normalizedQuery
+    ? sortedProjects.filter((project) => project.slug.toLowerCase().includes(normalizedQuery))
+    : sortedProjects;
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+        setQuery('');
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+        setQuery('');
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  const selectProject = (projectId: string | null) => {
+    setSelectedProjectId(projectId);
+    setIsOpen(false);
+    setQuery('');
+  };
+
   return (
-    <label className={`tasks-project-selector ${compact ? 'tasks-project-selector--compact' : ''}`}>
-      <span className="tasks-project-selector__label">Project</span>
-      <select
-        className="tasks-project-selector__select"
-        value={selectedProjectId ?? ''}
-        onChange={(event) => setSelectedProjectId(event.target.value || null)}
+    <div
+      className={`tasks-project-selector ${compact ? 'tasks-project-selector--compact' : ''}`}
+      ref={containerRef}
+    >
+      <span className="tasks-project-selector__label" id={labelId}>Project</span>
+      <button
+        type="button"
+        className="tasks-project-selector__trigger"
+        onClick={() => setIsOpen((open) => !open)}
         disabled={isLoadingProjects}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-labelledby={`${labelId} ${valueId}`}
       >
-        <option value="">All projects</option>
-        {sortedProjects.map((project) => (
-          <option key={project.id} value={project.slug}>
-            {project.slug}
-          </option>
-        ))}
-      </select>
-    </label>
+        <span className="tasks-project-selector__icon" aria-hidden="true">P</span>
+        <span className="tasks-project-selector__value" id={valueId}>
+          {selectedProject?.slug ?? 'All projects'}
+        </span>
+        <span className="tasks-project-selector__chevron" aria-hidden="true">v</span>
+      </button>
+      {isOpen ? (
+        <div className="tasks-project-selector__popover">
+          <input
+            ref={inputRef}
+            className="tasks-project-selector__search"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search projects"
+            aria-label="Search projects"
+          />
+          <div className="tasks-project-selector__list" role="listbox" aria-label="Task project">
+            <button
+              type="button"
+              className={`tasks-project-selector__option ${selectedProjectId === null ? 'tasks-project-selector__option--selected' : ''}`}
+              onClick={() => selectProject(null)}
+              role="option"
+              aria-selected={selectedProjectId === null}
+            >
+              All projects
+            </button>
+            {filteredProjects.map((project) => (
+              <button
+                key={project.id}
+                type="button"
+                className={`tasks-project-selector__option ${selectedProjectId === project.slug ? 'tasks-project-selector__option--selected' : ''}`}
+                onClick={() => selectProject(project.slug)}
+                role="option"
+                aria-selected={selectedProjectId === project.slug}
+              >
+                {project.slug}
+              </button>
+            ))}
+            {filteredProjects.length === 0 ? (
+              <div className="tasks-project-selector__empty">No projects found</div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/ui2/src/features/tasks/TasksProjectSelector.tsx
+++ b/apps/ui2/src/features/tasks/TasksProjectSelector.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import { useTasksCtx } from './TasksProvider';
+import './TasksProjectSelector.css';
+
+type TasksProjectSelectorProps = {
+  compact?: boolean;
+};
+
+export function TasksProjectSelector({ compact = false }: TasksProjectSelectorProps): JSX.Element {
+  const {
+    projects,
+    selectedProjectId,
+    setSelectedProjectId,
+    isLoadingProjects,
+  } = useTasksCtx();
+
+  const sortedProjects = useMemo(
+    () => [...projects].sort((a, b) => a.slug.localeCompare(b.slug)),
+    [projects],
+  );
+
+  return (
+    <label className={`tasks-project-selector ${compact ? 'tasks-project-selector--compact' : ''}`}>
+      <span className="tasks-project-selector__label">Project</span>
+      <select
+        className="tasks-project-selector__select"
+        value={selectedProjectId ?? ''}
+        onChange={(event) => setSelectedProjectId(event.target.value || null)}
+        disabled={isLoadingProjects}
+      >
+        <option value="">All projects</option>
+        {sortedProjects.map((project) => (
+          <option key={project.id} value={project.id}>
+            {project.slug}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/ui2/src/features/tasks/TasksProvider.tsx
+++ b/apps/ui2/src/features/tasks/TasksProvider.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useMemo, useRef, useState 
 import { useTasks } from "./useTasks"; // your abstraction hook
 import type { Task } from "./types";
 import { TaskStatus } from "./const";
-import { CommentResponseDto, CreateTaskDto, TaskResponseDto, InputRequestResponseDto } from "@taico/client";
+import { CommentResponseDto, CreateTaskDto, TaskResponseDto, InputRequestResponseDto, ProjectResponseDto } from "@taico/client";
 import { TaskActivityWireEvent } from "@taico/events";
 
 // Animation state tracked per status (for column-based animations)
@@ -50,6 +50,12 @@ export type TasksContextValue = {
   globalExitingTasks: Task[];
   activityByTaskId: Record<string, TaskActivityWireEvent>;
   shippedCelebrationTrigger: number;
+  projects: ProjectResponseDto[];
+  selectedProjectId: string | null;
+  selectedProject: ProjectResponseDto | null;
+  setSelectedProjectId: (projectId: string | null) => void;
+  isLoadingProjects: boolean;
+  projectsError: string | null;
 };
 
 const TasksContext = createContext<TasksContextValue | null>(null);
@@ -68,7 +74,25 @@ type ActiveAnimation = {
 
 export function TasksProvider({ children }: { children: React.ReactNode }) {
   // IMPORTANT: this is where the one websocket connection should be created
-  const { tasks, isLoading, error, isConnected, createTask, deleteTask, addComment, assignTask, assignTaskToMe, answerInputRequest, activityByTaskId } = useTasks();
+  const {
+    tasks,
+    isLoading,
+    error,
+    isConnected,
+    createTask,
+    deleteTask,
+    addComment,
+    assignTask,
+    assignTaskToMe,
+    answerInputRequest,
+    activityByTaskId,
+    projects,
+    selectedProjectId,
+    selectedProject,
+    setSelectedProjectId,
+    isLoadingProjects,
+    projectsError,
+  } = useTasks();
   const [sectionTitle, setSectionTitle] = useState("");
   const [shippedCelebrationTrigger, setShippedCelebrationTrigger] = useState(0);
 
@@ -237,6 +261,12 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
       globalExitingTasks,
       activityByTaskId,
       shippedCelebrationTrigger,
+      projects,
+      selectedProjectId,
+      selectedProject,
+      setSelectedProjectId,
+      isLoadingProjects,
+      projectsError,
     };
   }, [
     tasks,
@@ -256,6 +286,12 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
     globalExitingTasks,
     activityByTaskId,
     shippedCelebrationTrigger,
+    projects,
+    selectedProjectId,
+    selectedProject,
+    setSelectedProjectId,
+    isLoadingProjects,
+    projectsError,
   ]);
 
   return <TasksContext.Provider value={value}>{children}</TasksContext.Provider>;

--- a/apps/ui2/src/features/tasks/TasksRoutes.tsx
+++ b/apps/ui2/src/features/tasks/TasksRoutes.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { TasksPage } from "./TasksPage";
 import { TasksLayout } from "./TasksLayout";
 import { TasksProvider } from "./TasksProvider";
@@ -10,7 +10,7 @@ export function TasksRoutes() {
     <TasksProvider>
       <Routes>
         <Route element={<TasksLayout />}>
-          <Route index element={<Navigate to="/tasks/not-started" replace />} />
+          <Route index element={<TasksIndexRedirect />} />
           {/* <Route path="/" element={<TasksPage />} /> */}
           <Route path="/not-started" element={<TasksPage status={TaskStatus.NOT_STARTED} />} />
           <Route path="/in-progress" element={<TasksPage status={TaskStatus.IN_PROGRESS} />} />
@@ -21,4 +21,9 @@ export function TasksRoutes() {
       </Routes>
     </TasksProvider>
   );
+}
+
+function TasksIndexRedirect(): JSX.Element {
+  const location = useLocation();
+  return <Navigate to={{ pathname: "/tasks/not-started", search: location.search }} replace />;
 }

--- a/apps/ui2/src/features/tasks/TasksToCards.tsx
+++ b/apps/ui2/src/features/tasks/TasksToCards.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { BoardCardAnimation } from "../../ui/primitives";
 import { useTasksCtx } from "./TasksProvider"
 import { Task } from "./types";
@@ -9,8 +9,13 @@ import { groupTasksByDay } from "./taskGrouping";
 
 export function TasksToCards({ tasks, enteringIds, exitingTasks, groupByDay = false }: { tasks: Task[], enteringIds: Set<string>, exitingTasks: Task[], groupByDay?: boolean }): JSX.Element {
   const navigate = useNavigate();
+  const location = useLocation();
   const { activityByTaskId } = useTasksCtx();
   const [expandedDays, setExpandedDays] = useState<Set<string>>(new Set());
+
+  const navigateToTask = (taskId: string) => {
+    navigate({ pathname: `/tasks/task/${taskId}`, search: location.search });
+  };
 
   // Merge tasks and exitingTasks, sorted by updatedAt (descending) to maintain original order
   const exitingIdSet = new Set(exitingTasks.map(t => t.id));
@@ -38,7 +43,7 @@ export function TasksToCards({ tasks, enteringIds, exitingTasks, groupByDay = fa
               key={isExiting ? `exiting-${task.id}` : task.id}
               task={task}
               animation={animation}
-              onClick={() => navigate(`/tasks/task/${task.id}`)}
+              onClick={() => navigateToTask(task.id)}
               pulseKey={activity?.ts}
             />
           );
@@ -81,7 +86,7 @@ export function TasksToCards({ tasks, enteringIds, exitingTasks, groupByDay = fa
             key={isExiting ? `exiting-${task.id}` : task.id}
             task={task}
             animation={animation}
-            onClick={() => navigate(`/tasks/task/${task.id}`)}
+            onClick={() => navigateToTask(task.id)}
             pulseKey={activity?.ts}
           />
         );
@@ -120,7 +125,7 @@ export function TasksToCards({ tasks, enteringIds, exitingTasks, groupByDay = fa
             key={isExiting ? `exiting-${task.id}` : task.id}
             task={task}
             animation={animation}
-            onClick={() => navigate(`/tasks/task/${task.id}`)}
+            onClick={() => navigateToTask(task.id)}
             pulseKey={activity?.ts}
           />
         );
@@ -133,4 +138,3 @@ export function TasksToCards({ tasks, enteringIds, exitingTasks, groupByDay = fa
     {elements}
   </>
 }
-

--- a/apps/ui2/src/features/tasks/TasksToRows.tsx
+++ b/apps/ui2/src/features/tasks/TasksToRows.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { DataRowAnimation, DataRowContainer } from "../../ui/primitives";
 import { useTasksCtx } from "./TasksProvider"
 import { Task } from "./types";
@@ -9,8 +9,13 @@ import { groupTasksByDay } from "./taskGrouping";
 
 export function TasksToRows({ tasks, enteringIds, exitingTasks, groupByDay = false }: { tasks: Task[], enteringIds: Set<string>, exitingTasks: Task[], groupByDay?: boolean }): JSX.Element {
   const navigate = useNavigate();
+  const location = useLocation();
   const { activityByTaskId } = useTasksCtx();
   const [expandedDays, setExpandedDays] = useState<Set<string>>(new Set());
+
+  const navigateToTask = (taskId: string) => {
+    navigate({ pathname: `/tasks/task/${taskId}`, search: location.search });
+  };
 
   // Merge tasks and exitingTasks, sorted by updatedAt (descending) to maintain original order
   const exitingIdSet = new Set(exitingTasks.map(t => t.id));
@@ -38,7 +43,7 @@ export function TasksToRows({ tasks, enteringIds, exitingTasks, groupByDay = fal
               task={task}
               animation={animation}
               pulseKey={activity?.ts}
-              onClick={() => navigate(`/tasks/task/${task.id}`)}
+              onClick={() => navigateToTask(task.id)}
             />
           );
         })}
@@ -82,7 +87,7 @@ export function TasksToRows({ tasks, enteringIds, exitingTasks, groupByDay = fal
                 task={task}
                 animation={animation}
                 pulseKey={activity?.ts}
-                onClick={() => navigate(`/tasks/task/${task.id}`)}
+                onClick={() => navigateToTask(task.id)}
               />
             );
           });
@@ -115,7 +120,7 @@ export function TasksToRows({ tasks, enteringIds, exitingTasks, groupByDay = fal
                   task={task}
                   animation={animation}
                   pulseKey={activity?.ts}
-                  onClick={() => navigate(`/tasks/task/${task.id}`)}
+                  onClick={() => navigateToTask(task.id)}
                 />
               );
             })}

--- a/apps/ui2/src/features/tasks/useTasks.ts
+++ b/apps/ui2/src/features/tasks/useTasks.ts
@@ -1,12 +1,16 @@
-import { useEffect, useState } from 'react';
-import { io, Socket } from 'socket.io-client';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useSearchParams } from 'react-router-dom';
+import { io } from 'socket.io-client';
+import type { Socket } from 'socket.io-client';
 import { TasksService } from './api';
+import { ProjectsService } from '../projects/api';
 import type { Task } from './types';
 import { getUIWebSocketUrl } from '../../config/api';
 import type {
   CreateTaskDto,
   AssignTaskDto,
-} from "@taico/client"
+  ProjectResponseDto,
+} from '@taico/client';
 import {
   TaskWireEvents,
   TaskCreatedWireEvent,
@@ -17,233 +21,295 @@ import {
   TaskCommentedWireEvent,
   InputRequestAnsweredWireEvent,
   TaskActivityWireEvent,
-} from "@taico/events";
+} from '@taico/events';
 
-// Use centralized API configuration
 const SOCKET_URL = getUIWebSocketUrl('/tasks');
 const TASKS_PAGE_SIZE = 100;
-
+const PROJECT_QUERY_PARAM = 'project';
+const PROJECT_STORAGE_KEY = 'tasks:selected-project-id';
 
 export const useTasks = () => {
-  // UI feedback
+  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Data store
   const [tasks, setTasks] = useState<Task[]>([]);
-
-  // Transport
-  const [socket, setSocket] = useState<Socket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
-
-  // Ephemeral UI state: last activity per task
   const [activityByTaskId, setActivityByTaskId] = useState<Record<string, TaskActivityWireEvent>>({});
+  const [projects, setProjects] = useState<ProjectResponseDto[]>([]);
+  const [isLoadingProjects, setIsLoadingProjects] = useState(false);
+  const [projectsError, setProjectsError] = useState<string | null>(null);
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
+
+  const selectedProjectIdFromUrl = searchParams.get(PROJECT_QUERY_PARAM);
+
+  const selectedProject = useMemo(
+    () => projects.find((project) => project.id === selectedProjectIdFromUrl) ?? null,
+    [projects, selectedProjectIdFromUrl],
+  );
+
+  const selectedProjectTagName = selectedProject?.tagName;
+  const tasksRef = useRef<Task[]>([]);
+
+  const sortTasks = (items: Task[]): Task[] => {
+    return [...items].sort((a, b) => {
+      const dateA = new Date(a.updatedAt).getTime();
+      const dateB = new Date(b.updatedAt).getTime();
+      return dateB - dateA;
+    });
+  };
+
+  const taskMatchesSelectedProject = useCallback(
+    (task: { tags?: { name: string }[] }) => {
+      if (!selectedProjectTagName) {
+        return true;
+      }
+      return task.tags?.some((tag) => tag.name === selectedProjectTagName) ?? false;
+    },
+    [selectedProjectTagName],
+  );
+
+  const setSelectedProjectId = useCallback(
+    (projectId: string | null, options?: { replace?: boolean }) => {
+      const next = new URLSearchParams(location.search);
+      if (projectId) {
+        next.set(PROJECT_QUERY_PARAM, projectId);
+        window.localStorage.setItem(PROJECT_STORAGE_KEY, projectId);
+      } else {
+        next.delete(PROJECT_QUERY_PARAM);
+        window.localStorage.removeItem(PROJECT_STORAGE_KEY);
+      }
+      setSearchParams(next, { replace: options?.replace ?? false });
+    },
+    [location.search, setSearchParams],
+  );
 
   const upsertActivity = (evt: TaskActivityWireEvent) => {
-    // Only store activity if it has a message to display
     if (!evt.message) {
-      console.warn('Received task activity event without message, skipping', evt);
       return;
     }
-    setActivityByTaskId(prev => ({
+    setActivityByTaskId((prev) => ({
       ...prev,
-      [evt.taskId]: evt
+      [evt.taskId]: evt,
     }));
   };
 
-  // Optional: clear activity when task changes / gets refreshed
-  const clearActivity = (taskId: string) => {
-    setActivityByTaskId(prev => {
-      const { [taskId]: _, ...rest } = prev;
-      return rest;
-    });
-  };
-
-  // Boot
-  useEffect(() => {
-    loadTasks();
-    const cleanup = setupWebsocket();
-    return cleanup;
-  }, []);
-
-  // Sort tasks by updatedAt (newest first)
-  const sortTasks = (tasks: Task[]): Task[] => {
-    return [...tasks].sort((a, b) => {
-      const dateA = new Date(a.updatedAt).getTime();
-      const dateB = new Date(b.updatedAt).getTime();
-      return dateB - dateA; // Descending order (newest first)
-    });
-  };
-
-  // Create task
   const createTask = async (task: CreateTaskDto) => {
-    return await TasksService.tasksControllerCreateTask(task);
-  }
+    const tagNames = new Set(task.tagNames ?? []);
+    if (selectedProjectTagName) {
+      tagNames.add(selectedProjectTagName);
+    }
 
-  // Delete tasl
+    return await TasksService.tasksControllerCreateTask({
+      ...task,
+      tagNames: tagNames.size > 0 ? Array.from(tagNames) : undefined,
+    });
+  };
+
   const deleteTask = async ({ taskId }: { taskId: string }) => {
     return await TasksService.tasksControllerDeleteTask(taskId);
-  }
+  };
 
-  // Add comment
-  const addComment = async ({ taskId, comment }: { taskId: string, comment: string }) => {
+  const addComment = async ({ taskId, comment }: { taskId: string; comment: string }) => {
     return await TasksService.tasksControllerAddComment(taskId, { content: comment });
-  }
+  };
 
-  // Assign task
-  const assignTask = async ({ taskId, assigneeActorId }: { taskId: string, assigneeActorId: string }) => {
+  const assignTask = async ({ taskId, assigneeActorId }: { taskId: string; assigneeActorId: string }) => {
     const dto: AssignTaskDto = { assigneeActorId };
     return await TasksService.tasksControllerAssignTask(taskId, dto);
-  }
+  };
 
-  // Assign task to me
   const assignTaskToMe = async ({ taskId }: { taskId: string }) => {
     return await TasksService.tasksControllerAssignTaskToMe(taskId);
-  }
+  };
 
-  // Answer input request
-  const answerInputRequest = async ({ taskId, inputRequestId, answer }: { taskId: string, inputRequestId: string, answer: string }) => {
+  const answerInputRequest = async ({
+    taskId,
+    inputRequestId,
+    answer,
+  }: {
+    taskId: string;
+    inputRequestId: string;
+    answer: string;
+  }) => {
     return await TasksService.tasksControllerAnswerInputRequest(taskId, inputRequestId, { answer });
-  }
+  };
 
-  // Load tasks
-  const loadTasks = async () => {
+  const loadTasks = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await TasksService.tasksControllerListTasks(undefined, undefined, undefined, 1, TASKS_PAGE_SIZE);
+      const response = await TasksService.tasksControllerListTasks(
+        undefined,
+        undefined,
+        selectedProjectTagName,
+        1,
+        TASKS_PAGE_SIZE,
+      );
       setTasks(sortTasks(response.items));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load tasks');
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [selectedProjectTagName]);
 
-  // Setup websocket
-  const setupWebsocket = () => {
-    const newSocket = io(SOCKET_URL, {
+  const loadProjects = useCallback(async () => {
+    setIsLoadingProjects(true);
+    setProjectsError(null);
+    try {
+      const allProjects = await ProjectsService.projectsControllerGetAllProjects();
+      setProjects(allProjects);
+    } catch (err: any) {
+      setProjectsError(err?.body?.detail ?? 'Failed to load projects');
+    } finally {
+      setProjectsLoaded(true);
+      setIsLoadingProjects(false);
+    }
+  }, []);
+
+  const setupWebsocket = useCallback(() => {
+    const newSocket: Socket = io(SOCKET_URL, {
       transports: ['websocket', 'polling'],
       withCredentials: true,
     });
 
-    newSocket.on('connect', () => {
-      console.log('Connected to websocket');
-      newSocket.emit('tasks.subscribe', {}, (ack: any) => {
-        if (ack.ok) {
-          console.log(ack);
-          console.log('Subscribed to room:', ack.room);
-          setIsConnected(true);
-        } else {
-          console.error('Failed to subscribe to room');
-          setIsConnected(false);
+    const upsertOrRemoveTask = (task: Task) => {
+      setTasks((prev) => {
+        if (!taskMatchesSelectedProject(task)) {
+          return prev.filter((existingTask) => existingTask.id !== task.id);
         }
+        const exists = prev.some((existingTask) => existingTask.id === task.id);
+        if (!exists) {
+          return sortTasks([task, ...prev]);
+        }
+        return sortTasks(prev.map((existingTask) => (existingTask.id === task.id ? task : existingTask)));
+      });
+    };
+
+    newSocket.on('connect', () => {
+      newSocket.emit('tasks.subscribe', {}, (ack: any) => {
+        setIsConnected(Boolean(ack?.ok));
       });
       loadTasks();
     });
 
     newSocket.on('disconnect', () => {
-      console.log('WebSocket disconnected');
       setIsConnected(false);
     });
 
-    // Handle task created event
     newSocket.on(TaskWireEvents.TASK_CREATED, (event: TaskCreatedWireEvent) => {
-      console.log('task.created', event);
+      const task = event.payload as Task;
+      if (!taskMatchesSelectedProject(task)) {
+        return;
+      }
       setTasks((prev) => {
-        // Avoid duplicates - check if task already exists
-        if (prev.some(t => t.id === event.payload.id)) {
+        if (prev.some((existingTask) => existingTask.id === task.id)) {
           return prev;
         }
-        return sortTasks([event.payload as Task, ...prev]);
+        return sortTasks([task, ...prev]);
       });
     });
 
-    // Handle task updated event
     newSocket.on(TaskWireEvents.TASK_UPDATED, (event: TaskUpdatedWireEvent) => {
-      console.log('task.updated', event);
-      setTasks((prev) =>
-        sortTasks(prev.map((t) => (t.id === event.payload.id ? event.payload as Task : t)))
-      );
+      upsertOrRemoveTask(event.payload as Task);
     });
 
-    // Handle task deleted event
     newSocket.on(TaskWireEvents.TASK_DELETED, (event: TaskDeletedWireEvent) => {
-      console.log('task.deleted', event);
-      setTasks((prev) => prev.filter((t) => t.id !== event.payload.taskId));
+      setTasks((prev) => prev.filter((task) => task.id !== event.payload.taskId));
+      setActivityByTaskId((prev) => {
+        const { [event.payload.taskId]: _, ...rest } = prev;
+        return rest;
+      });
     });
 
-    // Handle task assigned event
     newSocket.on(TaskWireEvents.TASK_ASSIGNED, (event: TaskAssignedWireEvent) => {
-      console.log('task.assigned', event);
-      setTasks((prev) =>
-        sortTasks(prev.map((t) => (t.id === event.payload.id ? event.payload as Task : t)))
-      );
+      upsertOrRemoveTask(event.payload as Task);
     });
 
-    // Handle comment added event
     newSocket.on(TaskWireEvents.TASK_COMMENTED, async (event: TaskCommentedWireEvent) => {
-      console.log('task.commented', event);
       try {
-        // event.payload is CommentWirePayload with taskId
         const updatedTask = await TasksService.tasksControllerGetTask(event.payload.taskId);
-        setTasks((prev) => {
-          const existingTaskIndex = prev.findIndex((t) => t.id === updatedTask.id);
-          if (existingTaskIndex === -1) {
-            return sortTasks([updatedTask, ...prev]);
-          }
-          return sortTasks(prev.map((t) => (t.id === updatedTask.id ? updatedTask : t)));
-        });
-      } catch (err) {
-        console.error('Failed to refresh task after comment', err);
+        upsertOrRemoveTask(updatedTask);
+      } catch {
+        // Ignore refresh errors from transient fetches.
       }
     });
 
-    // Handle input request answered event
     newSocket.on(TaskWireEvents.INPUT_REQUEST_ANSWERED, async (event: InputRequestAnsweredWireEvent) => {
-      console.log('input.request.answered', event);
       try {
         const updatedTask = await TasksService.tasksControllerGetTask(event.payload.taskId);
-        setTasks((prev) => {
-          const existingTaskIndex = prev.findIndex((t) => t.id === updatedTask.id);
-          if (existingTaskIndex === -1) {
-            return sortTasks([updatedTask, ...prev]);
-          }
-          return sortTasks(prev.map((t) => (t.id === updatedTask.id ? updatedTask : t)));
-        });
-      } catch (err) {
-        console.error('Failed to refresh task after input request answer', err);
+        upsertOrRemoveTask(updatedTask);
+      } catch {
+        // Ignore refresh errors from transient fetches.
       }
     });
 
-    // Handle task status changed event
     newSocket.on(TaskWireEvents.TASK_STATUS_CHANGED, (event: TaskStatusChangedWireEvent) => {
-      console.log('task.status_changed', event);
-      setTasks((prev) =>
-        sortTasks(prev.map((t) => (t.id === event.payload.id ? event.payload as Task : t)))
-      );
+      upsertOrRemoveTask(event.payload as Task);
     });
 
-    // Handle task activity event (ephemeral UI feedback, not persisted)
     newSocket.on(TaskWireEvents.TASK_ACTIVITY, (evt: TaskActivityWireEvent) => {
-      console.log('task.activity', evt);
+      const shouldKeepEvent = tasksRef.current.some((task) => task.id === evt.taskId);
+      if (!shouldKeepEvent) {
+        return;
+      }
       upsertActivity(evt);
     });
-
-    setSocket(newSocket);
 
     return () => {
       newSocket.close();
     };
-  };
+  }, [loadTasks, taskMatchesSelectedProject]);
+
+  useEffect(() => {
+    tasksRef.current = tasks;
+  }, [tasks]);
+
+  useEffect(() => {
+    loadProjects();
+  }, [loadProjects]);
+
+  useEffect(() => {
+    const projectFromUrl = new URLSearchParams(location.search).get(PROJECT_QUERY_PARAM);
+    if (projectFromUrl) {
+      window.localStorage.setItem(PROJECT_STORAGE_KEY, projectFromUrl);
+      return;
+    }
+
+    const storedProjectId = window.localStorage.getItem(PROJECT_STORAGE_KEY);
+    if (!storedProjectId) {
+      return;
+    }
+
+    const next = new URLSearchParams(location.search);
+    next.set(PROJECT_QUERY_PARAM, storedProjectId);
+    setSearchParams(next, { replace: true });
+  }, [location.search, setSearchParams]);
+
+  useEffect(() => {
+    if (!projectsLoaded || !selectedProjectIdFromUrl) {
+      return;
+    }
+
+    const exists = projects.some((project) => project.id === selectedProjectIdFromUrl);
+    if (!exists) {
+      setSelectedProjectId(null, { replace: true });
+    }
+  }, [projects, projectsLoaded, selectedProjectIdFromUrl, setSelectedProjectId]);
+
+  useEffect(() => {
+    setActivityByTaskId({});
+    loadTasks();
+    const cleanup = setupWebsocket();
+    return cleanup;
+  }, [loadTasks, setupWebsocket]);
 
   return {
-    // UI feedback
     isLoading,
     error,
     activityByTaskId,
-
-    // Data
     tasks,
     createTask,
     deleteTask,
@@ -251,9 +317,12 @@ export const useTasks = () => {
     assignTask,
     assignTaskToMe,
     answerInputRequest,
-
-
-    // Transport
     isConnected,
+    projects,
+    selectedProjectId: selectedProjectIdFromUrl,
+    selectedProject,
+    setSelectedProjectId,
+    isLoadingProjects,
+    projectsError,
   };
 };

--- a/apps/ui2/src/features/tasks/useTasks.ts
+++ b/apps/ui2/src/features/tasks/useTasks.ts
@@ -26,7 +26,10 @@ import {
 const SOCKET_URL = getUIWebSocketUrl('/tasks');
 const TASKS_PAGE_SIZE = 100;
 const PROJECT_QUERY_PARAM = 'project';
-const PROJECT_STORAGE_KEY = 'tasks:selected-project-id';
+const PROJECT_STORAGE_KEY = 'tasks:selected-project-slug';
+const LEGACY_PROJECT_STORAGE_KEY = 'tasks:selected-project-id';
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export const useTasks = () => {
   const location = useLocation();
@@ -42,14 +45,26 @@ export const useTasks = () => {
   const [projectsError, setProjectsError] = useState<string | null>(null);
   const [projectsLoaded, setProjectsLoaded] = useState(false);
 
-  const selectedProjectIdFromUrl = searchParams.get(PROJECT_QUERY_PARAM);
+  const selectedProjectParamFromUrl = searchParams.get(PROJECT_QUERY_PARAM);
 
   const selectedProject = useMemo(
-    () => projects.find((project) => project.id === selectedProjectIdFromUrl) ?? null,
-    [projects, selectedProjectIdFromUrl],
+    () =>
+      projects.find(
+        (project) =>
+          project.slug === selectedProjectParamFromUrl || project.id === selectedProjectParamFromUrl,
+      ) ?? null,
+    [projects, selectedProjectParamFromUrl],
   );
 
-  const selectedProjectTagName = selectedProject?.tagName;
+  const selectedProjectTagName = useMemo(() => {
+    if (selectedProject?.tagName) {
+      return selectedProject.tagName;
+    }
+    if (!selectedProjectParamFromUrl || UUID_V4_PATTERN.test(selectedProjectParamFromUrl)) {
+      return undefined;
+    }
+    return `project:${selectedProjectParamFromUrl}`;
+  }, [selectedProject, selectedProjectParamFromUrl]);
   const tasksRef = useRef<Task[]>([]);
 
   const sortTasks = (items: Task[]): Task[] => {
@@ -71,14 +86,16 @@ export const useTasks = () => {
   );
 
   const setSelectedProjectId = useCallback(
-    (projectId: string | null, options?: { replace?: boolean }) => {
+    (projectSlug: string | null, options?: { replace?: boolean }) => {
       const next = new URLSearchParams(location.search);
-      if (projectId) {
-        next.set(PROJECT_QUERY_PARAM, projectId);
-        window.localStorage.setItem(PROJECT_STORAGE_KEY, projectId);
+      if (projectSlug) {
+        next.set(PROJECT_QUERY_PARAM, projectSlug);
+        window.localStorage.setItem(PROJECT_STORAGE_KEY, projectSlug);
+        window.localStorage.removeItem(LEGACY_PROJECT_STORAGE_KEY);
       } else {
         next.delete(PROJECT_QUERY_PARAM);
         window.localStorage.removeItem(PROJECT_STORAGE_KEY);
+        window.localStorage.removeItem(LEGACY_PROJECT_STORAGE_KEY);
       }
       setSearchParams(next, { replace: options?.replace ?? false });
     },
@@ -275,29 +292,45 @@ export const useTasks = () => {
     const projectFromUrl = new URLSearchParams(location.search).get(PROJECT_QUERY_PARAM);
     if (projectFromUrl) {
       window.localStorage.setItem(PROJECT_STORAGE_KEY, projectFromUrl);
+      window.localStorage.removeItem(LEGACY_PROJECT_STORAGE_KEY);
       return;
     }
 
-    const storedProjectId = window.localStorage.getItem(PROJECT_STORAGE_KEY);
-    if (!storedProjectId) {
+    const storedProjectSlug =
+      window.localStorage.getItem(PROJECT_STORAGE_KEY) ??
+      window.localStorage.getItem(LEGACY_PROJECT_STORAGE_KEY);
+    if (!storedProjectSlug) {
       return;
     }
 
     const next = new URLSearchParams(location.search);
-    next.set(PROJECT_QUERY_PARAM, storedProjectId);
+    next.set(PROJECT_QUERY_PARAM, storedProjectSlug);
     setSearchParams(next, { replace: true });
   }, [location.search, setSearchParams]);
 
   useEffect(() => {
-    if (!projectsLoaded || !selectedProjectIdFromUrl) {
+    if (!projectsLoaded || !selectedProjectParamFromUrl) {
       return;
     }
 
-    const exists = projects.some((project) => project.id === selectedProjectIdFromUrl);
-    if (!exists) {
+    if (selectedProject) {
+      if (selectedProject.slug !== selectedProjectParamFromUrl) {
+        setSelectedProjectId(selectedProject.slug, { replace: true });
+      }
+      return;
+    }
+
+    const existsAsSlug = projects.some((project) => project.slug === selectedProjectParamFromUrl);
+    if (!existsAsSlug) {
       setSelectedProjectId(null, { replace: true });
     }
-  }, [projects, projectsLoaded, selectedProjectIdFromUrl, setSelectedProjectId]);
+  }, [
+    projects,
+    projectsLoaded,
+    selectedProject,
+    selectedProjectParamFromUrl,
+    setSelectedProjectId,
+  ]);
 
   useEffect(() => {
     setActivityByTaskId({});
@@ -319,7 +352,7 @@ export const useTasks = () => {
     answerInputRequest,
     isConnected,
     projects,
-    selectedProjectId: selectedProjectIdFromUrl,
+    selectedProjectId: selectedProject?.slug ?? selectedProjectParamFromUrl,
     selectedProject,
     setSelectedProjectId,
     isLoadingProjects,


### PR DESCRIPTION
## Summary
- Add a project selector to the tasks experience (desktop header + mobile tasks page), with selection persisted in `?project=<id>` and localStorage fallback for session continuity.
- Scope task behavior to the selected project by resolving project id -> project tag and applying it to list queries, create-task defaults (`tagNames`), and websocket updates.
- Preserve project query params while navigating between task status routes and task detail pages so shared/bookmarked URLs keep the same project focus.

## Technical debt
- We currently resolve project id to tag name on the client; if backend later supports direct project-id filtering on task list/websocket subscriptions, we can simplify client-side filtering and reduce fetch/update churn on comment/input events.