### PR TITLE
Fix executions-v2 tag trigger queue matching

### DIFF
--- a/apps/backend/src/executions-v2/readiness/task-execution-queue-populator.service.ts
+++ b/apps/backend/src/executions-v2/readiness/task-execution-queue-populator.service.ts
@@ -120,12 +120,26 @@ export class TaskExecutionQueuePopulatorService {
   }
 
   private matchesTagTriggers(task: TaskEntity, agent: AgentResult): boolean {
-    if (agent.tagTriggers.length === 0) {
+    const normalizedTagTriggers = agent.tagTriggers
+      .map((tagTrigger) => this.normalizeTagName(tagTrigger))
+      .filter((tagTrigger): tagTrigger is string => tagTrigger !== null);
+
+    if (normalizedTagTriggers.length === 0) {
       return true; // no tags triggers means it reacts to all tags
     }
 
-    const taskTagNames = new Set(task.tags.map((tag) => tag.name));
-    return agent.tagTriggers.every((tagTrigger) => taskTagNames.has(tagTrigger));
+    const taskTagNames = new Set(
+      task.tags
+        .map((tag) => this.normalizeTagName(tag.name))
+        .filter((tagName): tagName is string => tagName !== null),
+    );
+
+    return normalizedTagTriggers.some((tagTrigger) => taskTagNames.has(tagTrigger));
+  }
+
+  private normalizeTagName(tagName: string): string | null {
+    const normalized = tagName.trim().toLowerCase();
+    return normalized.length > 0 ? normalized : null;
   }
 
   private async loadAgentsByActorId(


### PR DESCRIPTION
## Summary
- Fix `TaskExecutionQueuePopulatorService` tag-trigger eligibility to queue tasks when there is any overlap between task tags and agent tag triggers, matching the executions-v2 design docs.
- Normalize both agent triggers and task tag names with `trim().toLowerCase()` to avoid case/whitespace mismatches.
- Keep empty/whitespace-only trigger entries non-blocking so an effectively empty trigger set still means "react to all tags".

## Technical Debt
- This path still lacks targeted automated coverage for tag-trigger queue eligibility semantics; adding a unit test suite for `TaskExecutionQueuePopulatorService` would reduce regression risk.