### PR TITLE
Add file upload functionality for context blocks

### DIFF
--- a/apps/ui2/src/app/shells/BetaShellDesktop.css
+++ b/apps/ui2/src/app/shells/BetaShellDesktop.css
@@ -42,7 +42,8 @@
 }
 
 /* Context desktop uses its own full-height split layout. */
-.beta-shell__desktop__main:has(.context-desktop) {
+.beta-shell__desktop__main:has(.context-desktop),
+.beta-shell__desktop__main:has(.context-layout) {
   padding: 0;
   overflow: hidden;
 }

--- a/apps/ui2/src/features/context/ContextBlockCreatePage.css
+++ b/apps/ui2/src/features/context/ContextBlockCreatePage.css
@@ -1,0 +1,125 @@
+.context-block-create {
+  padding: var(--space-4);
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.context-block-create__breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  font-size: var(--fs-2);
+}
+
+.context-block-create__breadcrumb {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+}
+
+.context-block-create__breadcrumb:hover:not(.context-block-create__breadcrumb--current) {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+.context-block-create__breadcrumb--current {
+  color: var(--text);
+  cursor: default;
+}
+
+.context-block-create__breadcrumb-separator {
+  color: var(--text-muted);
+}
+
+.context-block-create__form {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+  padding: var(--space-4);
+}
+
+.context-block-create__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.context-block-create__label {
+  display: block;
+}
+
+.context-block-create__input,
+.context-block-create__textarea {
+  width: 100%;
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--fs-3);
+  font-family: inherit;
+  transition: border-color 0.2s;
+}
+
+.context-block-create__input:focus,
+.context-block-create__textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.context-block-create__textarea {
+  resize: vertical;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+  font-size: var(--fs-2);
+  line-height: 1.5;
+}
+
+.context-block-create__file-input {
+  padding: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.context-block-create__file-input::-webkit-file-upload-button {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  margin-right: var(--space-2);
+}
+
+.context-block-create__file-input::-webkit-file-upload-button:hover {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: var(--accent);
+}
+
+.context-block-create__actions {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+
+@media (max-width: 768px) {
+  .context-block-create {
+    padding: var(--space-3);
+  }
+
+  .context-block-create__actions {
+    flex-direction: column;
+  }
+
+  .context-block-create__actions button {
+    width: 100%;
+  }
+}

--- a/apps/ui2/src/features/context/ContextBlockCreatePage.css
+++ b/apps/ui2/src/features/context/ContextBlockCreatePage.css
@@ -1,30 +1,35 @@
+/* Full-height editor layout — flex column, fills the main panel */
 .context-block-create {
-  padding: var(--space-4);
-  max-width: 800px;
-  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  padding: var(--space-5);
+  gap: var(--space-3);
+  overflow: hidden;
 }
 
+/* ── Breadcrumbs ─────────────────────────────────────────── */
 .context-block-create__breadcrumbs {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  margin-bottom: var(--space-4);
   font-size: var(--fs-2);
+  flex-shrink: 0;
 }
 
 .context-block-create__breadcrumb {
   background: none;
   border: none;
   padding: 0;
-  color: var(--accent);
+  color: var(--text-muted);
   cursor: pointer;
   font-size: inherit;
   font-family: inherit;
 }
 
 .context-block-create__breadcrumb:hover:not(.context-block-create__breadcrumb--current) {
-  color: var(--accent-hover);
-  text-decoration: underline;
+  color: var(--text);
 }
 
 .context-block-create__breadcrumb--current {
@@ -36,83 +41,92 @@
   color: var(--text-muted);
 }
 
-.context-block-create__form {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--r-3);
-  padding: var(--space-4);
-}
-
-.context-block-create__field {
+/* ── Title row ───────────────────────────────────────────── */
+.context-block-create__title-row {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
 }
 
-.context-block-create__label {
-  display: block;
-}
-
-.context-block-create__input,
-.context-block-create__textarea {
-  width: 100%;
-  padding: var(--space-3);
-  border: 1px solid var(--border);
-  border-radius: var(--r-2);
-  background: var(--bg);
-  color: var(--text);
-  font-size: var(--fs-3);
-  font-family: inherit;
-  transition: border-color 0.2s;
-}
-
-.context-block-create__input:focus,
-.context-block-create__textarea:focus {
+.context-block-create__title-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
   outline: none;
-  border-color: var(--accent);
+  color: var(--text);
+  font-size: clamp(1.8rem, 3vw, 2.5rem);
+  font-weight: var(--fw-bold);
+  font-family: inherit;
+  padding: 0 0 var(--space-1) 0;
+  transition: border-color 0.15s;
 }
 
-.context-block-create__textarea {
-  resize: vertical;
+.context-block-create__title-input:focus {
+  outline: none;
+  border-bottom-color: transparent;
+}
+
+.context-block-create__title-input::placeholder {
+  color: var(--text-muted);
+}
+
+/* Hidden real file input */
+.context-block-create__file-input-hidden {
+  display: none;
+}
+
+
+/* ── Markdown editor — fills available space ─────────────── */
+.context-block-create__editor {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  resize: none;
+  padding: var(--space-3);
+  border: none;
+  background: transparent;
+  color: var(--text);
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
   font-size: var(--fs-2);
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
-.context-block-create__file-input {
-  padding: var(--space-2);
-  border: 1px solid var(--border);
-  border-radius: var(--r-2);
-  background: var(--bg);
-  color: var(--text);
-  cursor: pointer;
+.context-block-create__editor:focus {
+  outline: none;
 }
 
-.context-block-create__file-input::-webkit-file-upload-button {
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border);
-  border-radius: var(--r-2);
-  background: var(--surface);
-  color: var(--text);
-  cursor: pointer;
-  margin-right: var(--space-2);
+/* ── Bottom bar ──────────────────────────────────────────── */
+.context-block-create__bottom-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
-.context-block-create__file-input::-webkit-file-upload-button:hover {
-  background: var(--accent);
-  color: var(--accent-contrast);
-  border-color: var(--accent);
-}
 
 .context-block-create__actions {
   display: flex;
-  gap: var(--space-3);
-  margin-top: var(--space-2);
+  gap: var(--space-2);
+  flex-shrink: 0;
 }
 
+/* ── Mobile tweaks ───────────────────────────────────────── */
 @media (max-width: 768px) {
   .context-block-create {
     padding: var(--space-3);
+  }
+
+  .context-block-create__title-input {
+    font-size: clamp(1.5rem, 6vw, 2rem);
+  }
+
+  .context-block-create__bottom-bar {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .context-block-create__actions {

--- a/apps/ui2/src/features/context/ContextBlockCreatePage.tsx
+++ b/apps/ui2/src/features/context/ContextBlockCreatePage.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button, Text, Stack } from '../../ui/primitives';
+import { useContextCtx } from './ContextProvider';
+import { ContextService } from './api';
+import { useToast } from '../../shared/context/ToastContext';
+import { useIsDesktop } from '../../app/hooks/useIsDesktop';
+import './ContextBlockCreatePage.css';
+
+export function ContextBlockCreatePage() {
+  const { setSectionTitle } = useContextCtx();
+  const navigate = useNavigate();
+  const { showError, showToast } = useToast();
+  const isDesktop = useIsDesktop();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [tagNames, setTagNames] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSectionTitle(isDesktop ? 'Context' : 'New Block');
+  }, [setSectionTitle, isDesktop]);
+
+  const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    // Validate file type
+    if (!file.name.endsWith('.md')) {
+      showError(new Error('Please select a markdown (.md) file'));
+      return;
+    }
+
+    setSelectedFileName(file.name);
+
+    try {
+      const text = await file.text();
+      setContent(text);
+
+      // Try to extract title from first H1 heading
+      const h1Match = text.match(/^#\s+(.+)$/m);
+      if (h1Match) {
+        setTitle(h1Match[1].trim());
+      } else {
+        // Fallback to filename without extension
+        const titleFromFilename = file.name.replace(/\.md$/, '');
+        setTitle(titleFromFilename);
+      }
+    } catch (err) {
+      showError(err);
+      setSelectedFileName(null);
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!title.trim()) {
+      showError(new Error('Title is required'));
+      return;
+    }
+
+    if (!content.trim()) {
+      showError(new Error('Content is required'));
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const block = await ContextService.ContextController_createBlock({
+        body: {
+          title: title.trim(),
+          content: content.trim(),
+          tagNames: tagNames.length > 0 ? tagNames : undefined,
+        },
+      });
+
+      showToast('Context block created successfully', 'success');
+      navigate(`/context/block/${block.id}`);
+    } catch (err) {
+      showError(err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleTagsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    // Split by comma and trim each tag
+    const tags = value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+    setTagNames(tags);
+  };
+
+  return (
+    <div className="context-block-create">
+      {isDesktop && (
+        <div className="context-block-create__breadcrumbs">
+          <button
+            type="button"
+            className="context-block-create__breadcrumb"
+            onClick={() => navigate('/context/home')}
+          >
+            Home
+          </button>
+          <span className="context-block-create__breadcrumb-separator">›</span>
+          <span className="context-block-create__breadcrumb context-block-create__breadcrumb--current">
+            New Block
+          </span>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="context-block-create__form">
+        <Stack spacing="4">
+          {isDesktop && (
+            <Text as="div" size="6" weight="bold">
+              Create Context Block
+            </Text>
+          )}
+
+          <div className="context-block-create__field">
+            <label htmlFor="file-upload" className="context-block-create__label">
+              <Text size="3" weight="medium">
+                Upload Markdown File
+              </Text>
+            </label>
+            <input
+              ref={fileInputRef}
+              id="file-upload"
+              type="file"
+              accept=".md"
+              onChange={handleFileSelect}
+              className="context-block-create__file-input"
+            />
+            {selectedFileName && (
+              <Text size="2" tone="muted">
+                Selected: {selectedFileName}
+              </Text>
+            )}
+          </div>
+
+          <div className="context-block-create__field">
+            <label htmlFor="title" className="context-block-create__label">
+              <Text size="3" weight="medium">
+                Title
+              </Text>
+            </label>
+            <input
+              id="title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Enter block title"
+              className="context-block-create__input"
+              required
+              maxLength={255}
+            />
+          </div>
+
+          <div className="context-block-create__field">
+            <label htmlFor="content" className="context-block-create__label">
+              <Text size="3" weight="medium">
+                Content (Markdown)
+              </Text>
+            </label>
+            <textarea
+              id="content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Enter markdown content or upload a file above"
+              className="context-block-create__textarea"
+              required
+              rows={15}
+            />
+          </div>
+
+          <div className="context-block-create__field">
+            <label htmlFor="tags" className="context-block-create__label">
+              <Text size="3" weight="medium">
+                Tags (optional)
+              </Text>
+            </label>
+            <input
+              id="tags"
+              type="text"
+              onChange={handleTagsChange}
+              placeholder="Enter tags separated by commas (e.g., documentation, onboarding)"
+              className="context-block-create__input"
+            />
+            {tagNames.length > 0 && (
+              <Text size="2" tone="muted">
+                Tags: {tagNames.join(', ')}
+              </Text>
+            )}
+          </div>
+
+          <div className="context-block-create__actions">
+            <Button
+              type="submit"
+              size="lg"
+              variant="primary"
+              disabled={isSubmitting || !title.trim() || !content.trim()}
+            >
+              {isSubmitting ? 'Creating...' : 'Create Block'}
+            </Button>
+            <Button
+              type="button"
+              size="lg"
+              variant="secondary"
+              onClick={() => navigate('/context/home')}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+          </div>
+        </Stack>
+      </form>
+    </div>
+  );
+}

--- a/apps/ui2/src/features/context/ContextBlockCreatePage.tsx
+++ b/apps/ui2/src/features/context/ContextBlockCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button, Text } from '../../ui/primitives';
 import { useContextCtx } from './ContextProvider';
 import { ContextService } from './api';
@@ -10,6 +10,8 @@ import './ContextBlockCreatePage.css';
 export function ContextBlockCreatePage() {
   const { setSectionTitle } = useContextCtx();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const parentId = searchParams.get('parentId') ?? undefined;
   const { showError, showToast } = useToast();
   const isDesktop = useIsDesktop();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -70,6 +72,7 @@ export function ContextBlockCreatePage() {
           title: title.trim(),
           content: content.trim(),
           tagNames: tagNames.length > 0 ? tagNames : undefined,
+          parentId,
         },
       });
 

--- a/apps/ui2/src/features/context/ContextBlockCreatePage.tsx
+++ b/apps/ui2/src/features/context/ContextBlockCreatePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button, Text, Stack } from '../../ui/primitives';
+import { Button, Text } from '../../ui/primitives';
 import { useContextCtx } from './ContextProvider';
 import { ContextService } from './api';
 import { useToast } from '../../shared/context/ToastContext';
@@ -16,7 +16,7 @@ export function ContextBlockCreatePage() {
 
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [tagNames, setTagNames] = useState<string[]>([]);
+  const [tagNames] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
 
@@ -26,11 +26,8 @@ export function ContextBlockCreatePage() {
 
   const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (!file) {
-      return;
-    }
+    if (!file) return;
 
-    // Validate file type
     if (!file.name.endsWith('.md')) {
       showError(new Error('Please select a markdown (.md) file'));
       return;
@@ -42,14 +39,11 @@ export function ContextBlockCreatePage() {
       const text = await file.text();
       setContent(text);
 
-      // Try to extract title from first H1 heading
       const h1Match = text.match(/^#\s+(.+)$/m);
       if (h1Match) {
         setTitle(h1Match[1].trim());
       } else {
-        // Fallback to filename without extension
-        const titleFromFilename = file.name.replace(/\.md$/, '');
-        setTitle(titleFromFilename);
+        setTitle(file.name.replace(/\.md$/, ''));
       }
     } catch (err) {
       showError(err);
@@ -57,9 +51,7 @@ export function ContextBlockCreatePage() {
     }
   };
 
-  const handleSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
-
+  const handleSubmit = async () => {
     if (!title.trim()) {
       showError(new Error('Title is required'));
       return;
@@ -90,18 +82,9 @@ export function ContextBlockCreatePage() {
     }
   };
 
-  const handleTagsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    // Split by comma and trim each tag
-    const tags = value
-      .split(',')
-      .map((tag) => tag.trim())
-      .filter((tag) => tag.length > 0);
-    setTagNames(tags);
-  };
-
   return (
     <div className="context-block-create">
+      {/* Breadcrumbs (desktop only) */}
       {isDesktop && (
         <div className="context-block-create__breadcrumbs">
           <button
@@ -118,111 +101,72 @@ export function ContextBlockCreatePage() {
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="context-block-create__form">
-        <Stack spacing="4">
-          {isDesktop && (
-            <Text as="div" size="6" weight="bold">
-              Create Context Block
-            </Text>
-          )}
+      {/* Title row */}
+      <div className="context-block-create__title-row">
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Untitled"
+          className="context-block-create__title-input"
+          maxLength={255}
+          aria-label="Block title"
+          autoFocus
+        />
 
-          <div className="context-block-create__field">
-            <label htmlFor="file-upload" className="context-block-create__label">
-              <Text size="3" weight="medium">
-                Upload Markdown File
-              </Text>
-            </label>
-            <input
-              ref={fileInputRef}
-              id="file-upload"
-              type="file"
-              accept=".md"
-              onChange={handleFileSelect}
-              className="context-block-create__file-input"
-            />
-            {selectedFileName && (
-              <Text size="2" tone="muted">
-                Selected: {selectedFileName}
-              </Text>
-            )}
-          </div>
+        {/* File upload button */}
+        <Button
+          type="button"
+          size="lg"
+          variant="secondary"
+          onClick={() => fileInputRef.current?.click()}
+          title={selectedFileName ? `File: ${selectedFileName}` : 'Upload markdown file'}
+          tabIndex={-1}
+        >
+          {selectedFileName ? `↑ ${selectedFileName}` : '↑ Upload .md'}
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".md"
+          onChange={handleFileSelect}
+          className="context-block-create__file-input-hidden"
+          aria-hidden="true"
+        />
+      </div>
 
-          <div className="context-block-create__field">
-            <label htmlFor="title" className="context-block-create__label">
-              <Text size="3" weight="medium">
-                Title
-              </Text>
-            </label>
-            <input
-              id="title"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="Enter block title"
-              className="context-block-create__input"
-              required
-              maxLength={255}
-            />
-          </div>
+      {/* Markdown editor — fills remaining space */}
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Write markdown content here, or upload a .md file above…"
+        className="context-block-create__editor"
+        aria-label="Block content (Markdown)"
+      />
 
-          <div className="context-block-create__field">
-            <label htmlFor="content" className="context-block-create__label">
-              <Text size="3" weight="medium">
-                Content (Markdown)
-              </Text>
-            </label>
-            <textarea
-              id="content"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder="Enter markdown content or upload a file above"
-              className="context-block-create__textarea"
-              required
-              rows={15}
-            />
-          </div>
-
-          <div className="context-block-create__field">
-            <label htmlFor="tags" className="context-block-create__label">
-              <Text size="3" weight="medium">
-                Tags (optional)
-              </Text>
-            </label>
-            <input
-              id="tags"
-              type="text"
-              onChange={handleTagsChange}
-              placeholder="Enter tags separated by commas (e.g., documentation, onboarding)"
-              className="context-block-create__input"
-            />
-            {tagNames.length > 0 && (
-              <Text size="2" tone="muted">
-                Tags: {tagNames.join(', ')}
-              </Text>
-            )}
-          </div>
-
-          <div className="context-block-create__actions">
-            <Button
-              type="submit"
-              size="lg"
-              variant="primary"
-              disabled={isSubmitting || !title.trim() || !content.trim()}
-            >
-              {isSubmitting ? 'Creating...' : 'Create Block'}
-            </Button>
-            <Button
-              type="button"
-              size="lg"
-              variant="secondary"
-              onClick={() => navigate('/context/home')}
-              disabled={isSubmitting}
-            >
-              Cancel
-            </Button>
-          </div>
-        </Stack>
-      </form>
+      {/* Bottom bar: actions */}
+      <div className="context-block-create__bottom-bar">
+        <div className="context-block-create__actions">
+          <Button
+            type="button"
+            size="lg"
+            variant="secondary"
+            onClick={() => navigate('/context/home')}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="lg"
+            variant="primary"
+            onClick={handleSubmit}
+            disabled={isSubmitting || !title.trim() || !content.trim()}
+          >
+            {isSubmitting ? 'Creating…' : 'Create'}
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/ui2/src/features/context/ContextBlockCreatePage.tsx
+++ b/apps/ui2/src/features/context/ContextBlockCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams, useParams } from 'react-router-dom';
 import { Button, Text } from '../../ui/primitives';
 import { useContextCtx } from './ContextProvider';
 import { ContextService } from './api';
@@ -7,7 +7,12 @@ import { useToast } from '../../shared/context/ToastContext';
 import { useIsDesktop } from '../../app/hooks/useIsDesktop';
 import './ContextBlockCreatePage.css';
 
+// Used for both create (/context/new) and edit (/context/block/:id/edit).
+// Edit mode is detected by the presence of the :id route param.
 export function ContextBlockCreatePage() {
+  const { id: editId } = useParams<{ id?: string }>();
+  const isEditMode = Boolean(editId);
+
   const { setSectionTitle } = useContextCtx();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -20,11 +25,29 @@ export function ContextBlockCreatePage() {
   const [content, setContent] = useState('');
   const [tagNames] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoadingBlock, setIsLoadingBlock] = useState(isEditMode);
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
 
+  // Load existing block in edit mode
   useEffect(() => {
-    setSectionTitle(isDesktop ? 'Context' : 'New Block');
-  }, [setSectionTitle, isDesktop]);
+    if (!editId) return;
+
+    setIsLoadingBlock(true);
+    ContextService.ContextController_getBlock({ id: editId })
+      .then((block) => {
+        setTitle(block.title);
+        setContent(block.content);
+      })
+      .catch((err) => {
+        showError(err);
+        navigate('/context/home');
+      })
+      .finally(() => setIsLoadingBlock(false));
+  }, [editId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    setSectionTitle(isDesktop ? 'Context' : isEditMode ? 'Edit Block' : 'New Block');
+  }, [setSectionTitle, isDesktop, isEditMode]);
 
   const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -67,23 +90,44 @@ export function ContextBlockCreatePage() {
     setIsSubmitting(true);
 
     try {
-      const block = await ContextService.ContextController_createBlock({
-        body: {
-          title: title.trim(),
-          content: content.trim(),
-          tagNames: tagNames.length > 0 ? tagNames : undefined,
-          parentId,
-        },
-      });
-
-      showToast('Context block created successfully', 'success');
-      navigate(`/context/block/${block.id}`);
+      if (isEditMode && editId) {
+        await ContextService.ContextController_updateBlock({
+          id: editId,
+          body: {
+            title: title.trim(),
+            content: content.trim(),
+          },
+        });
+        showToast('Context block updated', 'success');
+        navigate(`/context/block/${editId}`);
+      } else {
+        const block = await ContextService.ContextController_createBlock({
+          body: {
+            title: title.trim(),
+            content: content.trim(),
+            tagNames: tagNames.length > 0 ? tagNames : undefined,
+            parentId,
+          },
+        });
+        showToast('Context block created', 'success');
+        navigate(`/context/block/${block.id}`);
+      }
     } catch (err) {
       showError(err);
     } finally {
       setIsSubmitting(false);
     }
   };
+
+  const cancelTarget = isEditMode && editId ? `/context/block/${editId}` : '/context/home';
+
+  if (isLoadingBlock) {
+    return (
+      <div className="context-block-create">
+        <Text tone="muted">Loading…</Text>
+      </div>
+    );
+  }
 
   return (
     <div className="context-block-create">
@@ -99,7 +143,7 @@ export function ContextBlockCreatePage() {
           </button>
           <span className="context-block-create__breadcrumb-separator">›</span>
           <span className="context-block-create__breadcrumb context-block-create__breadcrumb--current">
-            New Block
+            {isEditMode ? 'Edit Block' : 'New Block'}
           </span>
         </div>
       )}
@@ -154,7 +198,7 @@ export function ContextBlockCreatePage() {
             type="button"
             size="lg"
             variant="secondary"
-            onClick={() => navigate('/context/home')}
+            onClick={() => navigate(cancelTarget)}
             disabled={isSubmitting}
           >
             Cancel
@@ -166,7 +210,7 @@ export function ContextBlockCreatePage() {
             onClick={handleSubmit}
             disabled={isSubmitting || !title.trim() || !content.trim()}
           >
-            {isSubmitting ? 'Creating…' : 'Create'}
+            {isSubmitting ? (isEditMode ? 'Saving…' : 'Creating…') : isEditMode ? 'Save' : 'Create'}
           </Button>
         </div>
       </div>

--- a/apps/ui2/src/features/context/ContextBlockDetailPage.tsx
+++ b/apps/ui2/src/features/context/ContextBlockDetailPage.tsx
@@ -203,6 +203,13 @@ export function ContextBlockDetailPage() {
       />
 
       <DataRowContainer className='context-block-detail__actions'>
+        <Button
+          size='lg'
+          variant='secondary'
+          onClick={() => navigate(`/context/block/${block.id}/edit`)}
+        >
+          Edit
+        </Button>
         {threadId && (
           <Button
             size='lg'

--- a/apps/ui2/src/features/context/ContextBlockTree.css
+++ b/apps/ui2/src/features/context/ContextBlockTree.css
@@ -166,6 +166,28 @@
   background: color-mix(in srgb, var(--accent) 16%, var(--surface));
 }
 
+/* ── Add-child hover button ─────────────────────────────── */
+.context-tree__add-child {
+  flex-shrink: 0;
+  opacity: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--fs-4);
+  line-height: 1;
+  padding: 0 var(--space-2);
+  cursor: pointer;
+  transition: opacity 0.1s, color 0.1s;
+}
+
+.context-tree__row:hover .context-tree__add-child {
+  opacity: 1;
+}
+
+.context-tree__add-child:hover {
+  color: var(--accent);
+}
+
 @media (max-width: 640px) {
   .context-tree__tags {
     grid-column: 2;

--- a/apps/ui2/src/features/context/ContextBlockTree.tsx
+++ b/apps/ui2/src/features/context/ContextBlockTree.tsx
@@ -14,6 +14,7 @@ const MAX_DEPTH = 6;
 type ContextBlockTreeProps = {
   blocks: ContextBlockSummary[];
   onOpenBlock: (blockId: string) => void;
+  onAddChild?: (parentBlockId: string) => void;
   selectedBlockId?: string;
   compact?: boolean;
 };
@@ -114,6 +115,7 @@ function TreeBranch({
   nodes,
   depth,
   onOpenBlock,
+  onAddChild,
   collapsedIds,
   onToggleNode,
   selectedBlockId,
@@ -122,6 +124,7 @@ function TreeBranch({
   nodes: TreeNode[];
   depth: number;
   onOpenBlock: (blockId: string) => void;
+  onAddChild?: (parentBlockId: string) => void;
   collapsedIds: Set<string>;
   onToggleNode: (blockId: string) => void;
   selectedBlockId?: string;
@@ -186,6 +189,16 @@ function TreeBranch({
                   </div>
                 ) : null}
               </button>
+              {onAddChild ? (
+                <button
+                  type="button"
+                  className="context-tree__add-child"
+                  aria-label={`Add child block under ${node.block.title}`}
+                  onClick={(e) => { e.stopPropagation(); onAddChild(node.block.id); }}
+                >
+                  +
+                </button>
+              ) : null}
             </div>
 
             {hasChildren && isExpanded ? (
@@ -193,6 +206,7 @@ function TreeBranch({
                 nodes={node.children}
                 depth={depth + 1}
                 onOpenBlock={onOpenBlock}
+                onAddChild={onAddChild}
                 collapsedIds={collapsedIds}
                 onToggleNode={onToggleNode}
                 selectedBlockId={selectedBlockId}
@@ -225,6 +239,7 @@ function getAllParentIds(tree: TreeNode[]): Set<string> {
 export function ContextBlockTree({
   blocks,
   onOpenBlock,
+  onAddChild,
   selectedBlockId,
   compact = false,
 }: ContextBlockTreeProps): JSX.Element {
@@ -288,6 +303,7 @@ export function ContextBlockTree({
         nodes={tree}
         depth={0}
         onOpenBlock={onOpenBlock}
+        onAddChild={onAddChild}
         collapsedIds={collapsedIds}
         onToggleNode={handleToggleNode}
         selectedBlockId={selectedBlockId}

--- a/apps/ui2/src/features/context/ContextHome.css
+++ b/apps/ui2/src/features/context/ContextHome.css
@@ -258,6 +258,27 @@
   color: var(--accent);
 }
 
+.context-desktop__sidebar-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.context-desktop__sidebar-new {
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--fs-4);
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.context-desktop__sidebar-new:hover {
+  color: var(--accent);
+}
+
 .context-desktop__sidebar-body {
   flex: 1;
   min-height: 0;

--- a/apps/ui2/src/features/context/ContextHome.css
+++ b/apps/ui2/src/features/context/ContextHome.css
@@ -5,6 +5,11 @@
   padding-right: var(--space-1);
 }
 
+.context-home__header {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+
 .context-desktop {
   height: 100%;
   min-height: 0;
@@ -100,8 +105,10 @@
 }
 
 .context-home-desktop__hero {
-  display: grid;
-  gap: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
 }
 
 .context-home-desktop__title,

--- a/apps/ui2/src/features/context/ContextHome.css
+++ b/apps/ui2/src/features/context/ContextHome.css
@@ -10,6 +10,202 @@
   border-bottom: 1px solid var(--border);
 }
 
+/* ── Unified layout wrapper (replaces old .context-desktop) ── */
+.context-layout {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+/* Desktop: row — sidebar | main */
+.context-layout--desktop {
+  flex-direction: row;
+}
+
+/* Mobile: column — header / main */
+.context-layout--mobile {
+  flex-direction: column;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+/* Shared main content area */
+.context-layout__main {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+/* ── Mobile header ─────────────────────────────────────────── */
+.context-layout__mobile-header {
+  flex-shrink: 0;
+  padding: var(--space-2);
+  padding-top: calc(env(safe-area-inset-top) + var(--space-2));
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  z-index: 10;
+}
+
+.context-layout__mobile-section-title {
+  margin-left: auto;
+  color: var(--text-muted);
+}
+
+.context-layout__hamburger {
+  background: none;
+  border: none;
+  font-size: var(--fs-4);
+  cursor: pointer;
+  color: var(--text);
+  padding: var(--space-1);
+  line-height: 1;
+}
+
+/* ── Mobile drawer ─────────────────────────────────────────── */
+.context-layout__drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+}
+
+.context-layout__drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 280px;
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  z-index: 101;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform 0.25s ease;
+}
+
+.context-layout__drawer--open {
+  transform: translateX(0);
+}
+
+.context-layout__drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) var(--space-4) var(--space-3);
+  padding-top: calc(env(safe-area-inset-top) + var(--space-4));
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.context-layout__drawer-close {
+  background: none;
+  border: none;
+  font-size: var(--fs-3);
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: var(--space-1);
+  line-height: 1;
+}
+
+.context-layout__drawer-nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-2) 0;
+}
+
+.context-layout__drawer-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  text-decoration: none;
+  color: var(--text);
+  font-size: var(--fs-3);
+  transition: background 0.15s;
+}
+
+.context-layout__drawer-item:hover {
+  background: var(--surface);
+}
+
+.context-layout__drawer-item--active {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-weight: var(--fw-medium);
+}
+
+.context-layout__drawer-icon {
+  font-size: var(--fs-4);
+  width: 1.5rem;
+  text-align: center;
+}
+
+/* ── FAB ───────────────────────────────────────────────────── */
+.context-fab {
+  position: fixed;
+  right: var(--space-5);
+  bottom: calc(var(--space-5) + env(safe-area-inset-bottom));
+  z-index: 999;
+
+  width: 52px;
+  height: 52px;
+  border-radius: 999px;
+
+  border: 0;
+  background: var(--accent);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+
+  font-size: 28px;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  color: var(--accent-contrast);
+
+  transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
+}
+
+.context-fab:hover {
+  background-color: var(--accent-hover);
+}
+
+.context-fab:active {
+  transform: translateY(1px) scale(0.98);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.16);
+}
+
+.context-fab--desktop {
+  width: auto;
+  height: 44px;
+  padding: 0 14px;
+  gap: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+}
+
+.context-fab__plus {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.context-fab__label {
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Keep old .context-desktop class working for any remaining references */
 .context-desktop {
   height: 100%;
   min-height: 0;

--- a/apps/ui2/src/features/context/ContextHome.css
+++ b/apps/ui2/src/features/context/ContextHome.css
@@ -189,7 +189,15 @@
 }
 
 .context-home__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
   color: var(--text-muted);
+}
+
+.context-home__empty-message {
+  /* Inherits text styling from parent */
 }
 
 @media (max-width: 768px) {

--- a/apps/ui2/src/features/context/ContextHome.tsx
+++ b/apps/ui2/src/features/context/ContextHome.tsx
@@ -4,7 +4,7 @@ import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
 import { useContextCtx } from "./ContextProvider";
 import { ContextBlockTree } from "./ContextBlockTree";
 import { useIsDesktop } from "../../app/hooks/useIsDesktop";
-import { DataRow, Text, Button } from "../../ui/primitives";
+import { DataRow, Text } from "../../ui/primitives";
 import { elapsedTime } from "../../shared/helpers/elapsedTime";
 import "./ContextHome.css";
 
@@ -32,43 +32,52 @@ export function ContextHome(): JSX.Element {
 
   if (blocks.length === 0) {
     return (
-      <div className="context-home__empty">
-        <div className="context-home__empty-message">No context blocks found</div>
-        <Button
-          size="lg"
-          variant="primary"
-          onClick={() => navigate('/context/new')}
-        >
-          + Create Block
-        </Button>
-      </div>
+      <>
+        <div className="context-home__empty">
+          <div className="context-home__empty-message">No context blocks found</div>
+        </div>
+        <ContextFab onClick={() => navigate('/context/new')} isDesktop={isDesktop} />
+      </>
     );
   }
 
   if (isDesktop) {
     return (
-      <DesktopContextHome
-        blocks={blocks}
-        searchQuery={searchQuery}
-        onSearchQueryChange={setSearchQuery}
-        onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)}
-      />
+      <>
+        <DesktopContextHome
+          blocks={blocks}
+          searchQuery={searchQuery}
+          onSearchQueryChange={setSearchQuery}
+          onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)}
+        />
+        <ContextFab onClick={() => navigate('/context/new')} isDesktop={isDesktop} />
+      </>
     );
   }
 
   return (
-    <div className="context-home">
-      <div className="context-home__header">
-        <Button
-          size="lg"
-          variant="primary"
-          onClick={() => navigate('/context/new')}
-        >
-          + Create Block
-        </Button>
+    <>
+      <div className="context-home">
+        <ContextBlockTree blocks={blocks} onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)} />
       </div>
-      <ContextBlockTree blocks={blocks} onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)} />
-    </div>
+      <ContextFab onClick={() => navigate('/context/new')} isDesktop={isDesktop} />
+    </>
+  );
+}
+
+function ContextFab({ onClick, isDesktop }: { onClick: () => void; isDesktop: boolean }): JSX.Element {
+  if (isDesktop) {
+    return (
+      <button className="context-fab context-fab--desktop" type="button" onClick={onClick}>
+        <span className="context-fab__plus">+</span>
+        <span className="context-fab__label">New block</span>
+      </button>
+    );
+  }
+  return (
+    <button className="context-fab" type="button" onClick={onClick} aria-label="Create new block">
+      +
+    </button>
   );
 }
 
@@ -83,7 +92,6 @@ function DesktopContextHome({
   onSearchQueryChange: (value: string) => void;
   onOpenBlock: (blockId: string) => void;
 }): JSX.Element {
-  const navigate = useNavigate();
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const filteredBlocks = useMemo(() => {
     if (!normalizedQuery) {
@@ -108,13 +116,6 @@ function DesktopContextHome({
         <Text as="div" size="6" weight="bold" className="context-home-desktop__title">
           Blocks
         </Text>
-        <Button
-          size="md"
-          variant="primary"
-          onClick={() => navigate('/context/new')}
-        >
-          + Create Block
-        </Button>
       </div>
 
       <div className="context-home-desktop__search-box">

--- a/apps/ui2/src/features/context/ContextHome.tsx
+++ b/apps/ui2/src/features/context/ContextHome.tsx
@@ -4,7 +4,7 @@ import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
 import { useContextCtx } from "./ContextProvider";
 import { ContextBlockTree } from "./ContextBlockTree";
 import { useIsDesktop } from "../../app/hooks/useIsDesktop";
-import { DataRow, Text } from "../../ui/primitives";
+import { DataRow, Text, Button } from "../../ui/primitives";
 import { elapsedTime } from "../../shared/helpers/elapsedTime";
 import "./ContextHome.css";
 
@@ -47,6 +47,15 @@ export function ContextHome(): JSX.Element {
 
   return (
     <div className="context-home">
+      <div className="context-home__header">
+        <Button
+          size="lg"
+          variant="primary"
+          onClick={() => navigate('/context/new')}
+        >
+          + Create Block
+        </Button>
+      </div>
       <ContextBlockTree blocks={blocks} onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)} />
     </div>
   );
@@ -87,6 +96,13 @@ function DesktopContextHome({
         <Text as="div" size="6" weight="bold" className="context-home-desktop__title">
           Blocks
         </Text>
+        <Button
+          size="md"
+          variant="primary"
+          onClick={() => onOpenBlock('new')}
+        >
+          + Create Block
+        </Button>
       </div>
 
       <div className="context-home-desktop__search-box">

--- a/apps/ui2/src/features/context/ContextHome.tsx
+++ b/apps/ui2/src/features/context/ContextHome.tsx
@@ -31,7 +31,18 @@ export function ContextHome(): JSX.Element {
   }
 
   if (blocks.length === 0) {
-    return <div className="context-home__empty">No context blocks found</div>;
+    return (
+      <div className="context-home__empty">
+        <div className="context-home__empty-message">No context blocks found</div>
+        <Button
+          size="lg"
+          variant="primary"
+          onClick={() => navigate('/context/new')}
+        >
+          + Create Block
+        </Button>
+      </div>
+    );
   }
 
   if (isDesktop) {
@@ -72,6 +83,7 @@ function DesktopContextHome({
   onSearchQueryChange: (value: string) => void;
   onOpenBlock: (blockId: string) => void;
 }): JSX.Element {
+  const navigate = useNavigate();
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const filteredBlocks = useMemo(() => {
     if (!normalizedQuery) {
@@ -99,7 +111,7 @@ function DesktopContextHome({
         <Button
           size="md"
           variant="primary"
-          onClick={() => onOpenBlock('new')}
+          onClick={() => navigate('/context/new')}
         >
           + Create Block
         </Button>

--- a/apps/ui2/src/features/context/ContextHome.tsx
+++ b/apps/ui2/src/features/context/ContextHome.tsx
@@ -58,7 +58,11 @@ export function ContextHome(): JSX.Element {
   return (
     <>
       <div className="context-home">
-        <ContextBlockTree blocks={blocks} onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)} />
+        <ContextBlockTree
+          blocks={blocks}
+          onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)}
+          onAddChild={(parentId) => navigate(`/context/new?parentId=${parentId}`)}
+        />
       </div>
       <ContextFab onClick={() => navigate('/context/new')} isDesktop={isDesktop} />
     </>

--- a/apps/ui2/src/features/context/ContextLayout.tsx
+++ b/apps/ui2/src/features/context/ContextLayout.tsx
@@ -108,7 +108,18 @@ export function ContextLayout(): JSX.Element {
                 >
                   <Text as="span" size="2" weight="semibold">Context</Text>
                 </button>
-                <Text as="div" size="1" tone="muted">{blocks.length}</Text>
+                <div className="context-desktop__sidebar-header-actions">
+                  <Text as="div" size="1" tone="muted">{blocks.length}</Text>
+                  <button
+                    type="button"
+                    className="context-desktop__sidebar-new"
+                    onClick={() => navigate("/context/new")}
+                    aria-label="New block"
+                    title="New block"
+                  >
+                    +
+                  </button>
+                </div>
               </>
             ) : (
               <Text as="div" size="1" tone="muted">{blocks.length}</Text>
@@ -127,6 +138,7 @@ export function ContextLayout(): JSX.Element {
                 <ContextBlockTree
                   blocks={blocks}
                   onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)}
+                  onAddChild={(parentId) => navigate(`/context/new?parentId=${parentId}`)}
                   selectedBlockId={selectedBlockId}
                   compact
                 />

--- a/apps/ui2/src/features/context/ContextLayout.tsx
+++ b/apps/ui2/src/features/context/ContextLayout.tsx
@@ -1,99 +1,155 @@
-import { Outlet, useNavigate, useParams } from "react-router-dom";
+import { Outlet, useNavigate, useParams, Link, useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { useIsDesktop } from "../../app/hooks/useIsDesktop";
-import { IosShell } from "../../app/shells/IosShell";
 import { useContextCtx } from "./ContextProvider";
 import { ContextBlockTree } from "./ContextBlockTree";
-import { Text } from "../../ui/primitives";
+import { Text, Row } from "../../ui/primitives";
+import { MAIN_NAVEGATION_ITEMS } from "../../shared/const/mainNavegationItems";
 import "./ContextHome.css";
 
 export function ContextLayout(): JSX.Element {
   const isDesktop = useIsDesktop();
   const { sectionTitle, blocks, isLoading, error } = useContextCtx();
   const navigate = useNavigate();
+  const location = useLocation();
   const { id: selectedBlockId } = useParams<{ id?: string }>();
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   useEffect(() => {
-    if (!isDesktop) {
-      return;
-    }
-
+    if (!isDesktop) return;
     const stored = localStorage.getItem("context-sidebar-collapsed");
     setIsSidebarCollapsed(stored === "true");
   }, [isDesktop]);
 
   useEffect(() => {
-    if (!isDesktop) {
-      return;
-    }
-
+    if (!isDesktop) return;
     localStorage.setItem("context-sidebar-collapsed", String(isSidebarCollapsed));
   }, [isDesktop, isSidebarCollapsed]);
 
+  // Close drawer when navigating
+  useEffect(() => {
+    setIsDrawerOpen(false);
+  }, [location.pathname]);
+
   return (
-    <div style={{ minHeight: 0 }}>
-      {isDesktop ?
-        <div className="context-desktop">
-          <aside className={`context-desktop__sidebar ${isSidebarCollapsed ? "context-desktop__sidebar--collapsed" : ""}`}>
-            <div className="context-desktop__sidebar-header">
-              {!isSidebarCollapsed ? (
-                <>
-                  <button
-                    type="button"
-                    className="context-desktop__sidebar-title"
-                    onClick={() => navigate("/context/home")}
+    <div className={`context-layout ${isDesktop ? 'context-layout--desktop' : 'context-layout--mobile'}`}>
+
+      {/* ── Mobile: drawer ─────────────────────────────────── */}
+      {!isDesktop && (
+        <>
+          {isDrawerOpen && (
+            <div
+              className="context-layout__drawer-overlay"
+              onClick={() => setIsDrawerOpen(false)}
+            />
+          )}
+          <aside className={`context-layout__drawer ${isDrawerOpen ? 'context-layout__drawer--open' : ''}`}>
+            <div className="context-layout__drawer-header">
+              <Text size="4" weight="bold">taico</Text>
+              <button
+                className="context-layout__drawer-close"
+                onClick={() => setIsDrawerOpen(false)}
+                aria-label="Close menu"
+              >
+                ✕
+              </button>
+            </div>
+            <nav className="context-layout__drawer-nav">
+              {MAIN_NAVEGATION_ITEMS.map((item) => {
+                const isActive =
+                  location.pathname === item.path ||
+                  location.pathname.startsWith(item.path + '/');
+                return (
+                  <Link
+                    key={item.path}
+                    to={item.path}
+                    className={`context-layout__drawer-item ${isActive ? 'context-layout__drawer-item--active' : ''}`}
                   >
-                    <Text as="span" size="2" weight="semibold">Context</Text>
-                  </button>
-                  <Text as="div" size="1" tone="muted">{blocks.length}</Text>
-                </>
-              ) : (
-                <Text as="div" size="1" tone="muted">{blocks.length}</Text>
-              )}
-            </div>
-
-            <div className="context-desktop__sidebar-body">
-              {!isSidebarCollapsed ? (
-                isLoading ? (
-                  <div className="context-home__loading">Loading context blocks...</div>
-                ) : error ? (
-                  <div className="context-home__error">Error: {error}</div>
-                ) : blocks.length === 0 ? (
-                  <div className="context-home__empty">No context blocks found</div>
-                ) : (
-                  <ContextBlockTree
-                    blocks={blocks}
-                    onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)}
-                    selectedBlockId={selectedBlockId}
-                    compact
-                  />
-                )
-              ) : null}
-            </div>
-
-            <button
-              type="button"
-              className="context-desktop__sidebar-toggle"
-              onClick={() => setIsSidebarCollapsed((current) => !current)}
-              aria-label={isSidebarCollapsed ? "Expand context sidebar" : "Collapse context sidebar"}
-            >
-              {isSidebarCollapsed ? "→" : "←"}
-            </button>
+                    <span className="context-layout__drawer-icon">{item.icon}</span>
+                    <span>{item.label}</span>
+                  </Link>
+                );
+              })}
+            </nav>
           </aside>
+        </>
+      )}
 
-          <main className="context-desktop__main">
-            <Outlet />
-          </main>
-        </div>
-        :
-        <IosShell
-          appTitle="Context"
-          sectionTitle={sectionTitle}
-          navItems={[]}
-        >
-          <Outlet />
-        </IosShell>}
+      {/* ── Mobile: header ─────────────────────────────────── */}
+      {!isDesktop && (
+        <header className="context-layout__mobile-header">
+          <Row spacing="5" align="center">
+            <button
+              className="context-layout__hamburger"
+              onClick={() => setIsDrawerOpen(true)}
+              aria-label="Open menu"
+            >
+              ☰
+            </button>
+            <Text size="3" weight="normal" as="div">Context</Text>
+            <Text size="3" weight="semibold" as="div" className="context-layout__mobile-section-title">
+              {sectionTitle}
+            </Text>
+          </Row>
+        </header>
+      )}
+
+      {/* ── Desktop: sidebar ───────────────────────────────── */}
+      {isDesktop && (
+        <aside className={`context-desktop__sidebar ${isSidebarCollapsed ? "context-desktop__sidebar--collapsed" : ""}`}>
+          <div className="context-desktop__sidebar-header">
+            {!isSidebarCollapsed ? (
+              <>
+                <button
+                  type="button"
+                  className="context-desktop__sidebar-title"
+                  onClick={() => navigate("/context/home")}
+                >
+                  <Text as="span" size="2" weight="semibold">Context</Text>
+                </button>
+                <Text as="div" size="1" tone="muted">{blocks.length}</Text>
+              </>
+            ) : (
+              <Text as="div" size="1" tone="muted">{blocks.length}</Text>
+            )}
+          </div>
+
+          <div className="context-desktop__sidebar-body">
+            {!isSidebarCollapsed ? (
+              isLoading ? (
+                <div className="context-home__loading">Loading context blocks...</div>
+              ) : error ? (
+                <div className="context-home__error">Error: {error}</div>
+              ) : blocks.length === 0 ? (
+                <div className="context-home__empty">No context blocks found</div>
+              ) : (
+                <ContextBlockTree
+                  blocks={blocks}
+                  onOpenBlock={(blockId) => navigate(`/context/block/${blockId}`)}
+                  selectedBlockId={selectedBlockId}
+                  compact
+                />
+              )
+            ) : null}
+          </div>
+
+          <button
+            type="button"
+            className="context-desktop__sidebar-toggle"
+            onClick={() => setIsSidebarCollapsed((current) => !current)}
+            aria-label={isSidebarCollapsed ? "Expand context sidebar" : "Collapse context sidebar"}
+          >
+            {isSidebarCollapsed ? "→" : "←"}
+          </button>
+        </aside>
+      )}
+
+      {/* ── Content — always in the same tree position ─────── */}
+      <main className="context-layout__main">
+        <Outlet />
+      </main>
+
     </div>
-  )
+  );
 }

--- a/apps/ui2/src/features/context/ContextRoutes.tsx
+++ b/apps/ui2/src/features/context/ContextRoutes.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import { ContextLayout } from "./ContextLayout";
 import { ContextHome } from "./ContextHome";
 import { ContextBlockDetailPage } from "./ContextBlockDetailPage";
+import { ContextBlockCreatePage } from "./ContextBlockCreatePage";
 import { ContextProvider } from "./ContextProvider";
 
 export function ContextRoutes() {
@@ -11,6 +12,7 @@ export function ContextRoutes() {
         <Route element={<ContextLayout />}>
           <Route index element={<Navigate to="home" replace />} />
           <Route path="home" element={<ContextHome />} />
+          <Route path="new" element={<ContextBlockCreatePage />} />
           <Route path="block/:id" element={<ContextBlockDetailPage />} />
         </Route>
       </Routes >

--- a/apps/ui2/src/features/context/ContextRoutes.tsx
+++ b/apps/ui2/src/features/context/ContextRoutes.tsx
@@ -14,6 +14,7 @@ export function ContextRoutes() {
           <Route path="home" element={<ContextHome />} />
           <Route path="new" element={<ContextBlockCreatePage />} />
           <Route path="block/:id" element={<ContextBlockDetailPage />} />
+          <Route path="block/:id/edit" element={<ContextBlockCreatePage />} />
         </Route>
       </Routes >
     </ContextProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -558,7 +558,7 @@
     },
     "apps/worker": {
       "name": "@taico/worker",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",

--- a/package-lock.json
+++ b/package-lock.json
@@ -558,7 +558,7 @@
     },
     "apps/worker": {
       "name": "@taico/worker",
-      "version": "0.2.3",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",


### PR DESCRIPTION
## Summary
Implements the ability to create context blocks from uploaded markdown files in the context UI.

## Changes
- **New Component**: `ContextBlockCreatePage` - Dedicated page for creating context blocks with file upload
- **Route Addition**: Added `/context/new` route in `ContextRoutes.tsx`
- **UI Updates**: Added "Create Block" buttons to both desktop and mobile views in `ContextHome`
- **Styling**: Updated hero section styling and added responsive CSS for the create page

## Features
✨ Upload `.md` files via file input  
✨ Auto-extract title from first H1 heading (falls back to filename)  
✨ Manual editing of title, content, and tags before submission  
✨ Form validation for required fields  
✨ Toast notifications for success/error states  
✨ Responsive design (mobile + desktop)  
✨ Navigate to created block on successful submission  

## Technical Details
- Follows existing feature pattern documented in `ui2/CLAUDE.md`
- Uses design tokens from `tokens.css` for consistent styling
- Integrates with existing `ContextService.ContextController_createBlock` API
- Type-safe with generated `@taico/client` package

## Testing
- [x] `npm run build:dev` - Build succeeds
- [x] `npm run dev:1` - App starts without errors
- [ ] Manual testing of file upload flow
- [ ] CI validation pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)