### PR TITLE
Add clickable task links in executions view

### DIFF
--- a/apps/ui2/src/features/executions/ExecutionsPage.css
+++ b/apps/ui2/src/features/executions/ExecutionsPage.css
@@ -233,6 +233,11 @@
   gap: var(--space-1);
 }
 
+.executions-task-cell[style*="cursor: pointer"]:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
 .executions-code-copy {
   color: var(--text-muted);
 }

--- a/apps/ui2/src/features/executions/ExecutionsPage.css
+++ b/apps/ui2/src/features/executions/ExecutionsPage.css
@@ -233,9 +233,26 @@
   gap: var(--space-1);
 }
 
-.executions-task-cell[style*="cursor: pointer"]:hover {
+.executions-task-cell--clickable {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  font: inherit;
+  color: inherit;
+}
+
+.executions-task-cell--clickable:hover {
   color: var(--accent);
   text-decoration: underline;
+}
+
+.executions-task-cell--clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--r-2);
 }
 
 .executions-code-copy {
@@ -304,6 +321,28 @@
   gap: var(--space-3);
   padding: var(--space-4);
   border-top: 1px solid var(--border-subtle);
+}
+
+.executions-mobile-card--clickable {
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  transition: background-color 0.15s ease;
+}
+
+.executions-mobile-card--clickable:hover {
+  background: color-mix(in srgb, var(--surface) 45%, var(--card-bg));
+}
+
+.executions-mobile-card--clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  background: color-mix(in srgb, var(--surface) 35%, var(--card-bg));
 }
 
 .executions-mobile-card__header {

--- a/apps/ui2/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui2/src/features/executions/ExecutionsPage.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
 import { Button, Card, Text } from "../../ui/primitives";
 import { useExecutions } from "./useExecutions";
@@ -10,6 +11,7 @@ import type {
 import "./ExecutionsPage.css";
 
 export function ExecutionsPage() {
+  const navigate = useNavigate();
   const {
     queue,
     active,
@@ -98,7 +100,7 @@ export function ExecutionsPage() {
                   key: entry.taskId,
                   cells: [
                     <StatusPill key="state" tone="accent">Queued</StatusPill>,
-                    <TaskCell key="task" taskId={entry.taskId} taskName={entry.taskName} />,
+                    <TaskCell key="task" taskId={entry.taskId} taskName={entry.taskName} onClick={() => navigate(`/tasks/task/${entry.taskId}`)} />,
                     <StatusPill key="status" tone={taskStatusTone(entry.taskStatus)}>
                       {entry.taskStatus ?? "Unknown"}
                     </StatusPill>,
@@ -133,7 +135,7 @@ export function ExecutionsPage() {
                   key: entry.id,
                   cells: [
                     <StatusPill key="state" tone="warning">Active</StatusPill>,
-                    <TaskCell key="task" taskId={entry.taskId} taskName={entry.taskName} />,
+                    <TaskCell key="task" taskId={entry.taskId} taskName={entry.taskName} onClick={() => navigate(`/tasks/task/${entry.taskId}`)} />,
                     <CodeCell key="worker" value={entry.workerClientId} />,
                     <CodeCell key="agent" value={entry.agentActorId} />,
                     <TimeCell key="claimed" value={entry.claimedAt} />,
@@ -183,7 +185,7 @@ export function ExecutionsPage() {
                     <StatusPill key="result" tone={entry.status === "SUCCEEDED" ? "success" : "danger"}>
                       {entry.status}
                     </StatusPill>,
-                    <TaskCell key="task" taskId={entry.taskId} taskName={entry.taskName} />,
+                    <TaskCell key="task" taskId={entry.taskId} taskName={entry.taskName} onClick={() => navigate(`/tasks/task/${entry.taskId}`)} />,
                     <TimeCell key="transitioned" value={entry.transitionedAt} />,
                     <StatusPill key="task-status" tone={taskStatusTone(entry.taskStatus)}>
                       {entry.taskStatus ?? "Unknown"}
@@ -346,12 +348,18 @@ function StatusPill({
 function TaskCell({
   taskId,
   taskName,
+  onClick,
 }: {
   taskId: string;
   taskName: string | null;
+  onClick?: () => void;
 }) {
   return (
-    <div className="executions-task-cell">
+    <div
+      className="executions-task-cell"
+      onClick={onClick}
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
       <Text as="div" size="2" weight="semibold">{taskName ?? "Untitled task"}</Text>
       <Text as="div" size="1" tone="muted" style="mono">{shortId(taskId)}</Text>
     </div>

--- a/apps/ui2/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui2/src/features/executions/ExecutionsPage.tsx
@@ -116,6 +116,7 @@ export function ExecutionsPage() {
                         { label: "Task status", value: entry.taskStatus ?? "Unknown" },
                         { label: "Task ID", value: shortId(entry.taskId), mono: true },
                       ]}
+                      onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
                     />
                   ),
                 }))}
@@ -157,6 +158,7 @@ export function ExecutionsPage() {
                         { label: "Agent", value: shortId(entry.agentActorId), mono: true },
                         { label: "Before claim", value: entry.taskStatusBeforeClaim },
                       ]}
+                      onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
                     />
                   ),
                 }))}
@@ -214,6 +216,7 @@ export function ExecutionsPage() {
                           ? [{ label: "Message", value: entry.errorMessage }]
                           : []),
                       ]}
+                      onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
                     />
                   ),
                 }))}
@@ -354,12 +357,22 @@ function TaskCell({
   taskName: string | null;
   onClick?: () => void;
 }) {
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className="executions-task-cell executions-task-cell--clickable"
+        onClick={onClick}
+        aria-label={`Navigate to task: ${taskName ?? "Untitled task"}`}
+      >
+        <Text as="div" size="2" weight="semibold">{taskName ?? "Untitled task"}</Text>
+        <Text as="div" size="1" tone="muted" style="mono">{shortId(taskId)}</Text>
+      </button>
+    );
+  }
+
   return (
-    <div
-      className="executions-task-cell"
-      onClick={onClick}
-      style={{ cursor: onClick ? 'pointer' : 'default' }}
-    >
+    <div className="executions-task-cell">
       <Text as="div" size="2" weight="semibold">{taskName ?? "Untitled task"}</Text>
       <Text as="div" size="1" tone="muted" style="mono">{shortId(taskId)}</Text>
     </div>
@@ -449,14 +462,20 @@ function ExecutionMobileCard({
   badge,
   tone,
   lines,
+  onClick,
 }: {
   title: string;
   badge: string;
   tone: "accent" | "warning" | "success" | "danger";
   lines: Array<{ label: string; value: string; mono?: boolean }>;
+  onClick?: () => void;
 }) {
-  return (
-    <div className="executions-mobile-card">
+  const className = onClick
+    ? "executions-mobile-card executions-mobile-card--clickable"
+    : "executions-mobile-card";
+
+  const CardContent = (
+    <>
       <div className="executions-mobile-card__header">
         <Text as="div" size="3" weight="semibold" wrap>{title}</Text>
         <StatusPill tone={tone}>{badge}</StatusPill>
@@ -476,6 +495,25 @@ function ExecutionMobileCard({
           </div>
         ))}
       </div>
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className={className}
+        onClick={onClick}
+        aria-label={`Navigate to task: ${title}`}
+      >
+        {CardContent}
+      </button>
+    );
+  }
+
+  return (
+    <div className={className}>
+      {CardContent}
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -558,7 +558,7 @@
     },
     "apps/worker": {
       "name": "@taico/worker",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",


### PR DESCRIPTION
## Summary
- Makes task names in the executions page clickable to navigate to task detail pages
- Users can now click on any task in Queue, Active, or History sections to view full task details
- Follows the same navigation pattern used throughout the app (TasksPage, ThreadTaskCard, etc.)

## Changes
- Added `useNavigate` hook from react-router-dom to ExecutionsPage
- Updated `TaskCell` component to accept optional `onClick` handler
- Added cursor pointer styling for clickable task cells  
- Added hover effect (accent color + underline) for better UX
- Applied onClick navigation to all three execution sections

## Test plan
- [x] Build passes: `npm run build:dev`
- [x] Dev server starts: `npm run dev:1`
- [ ] Manual testing: Click on task names in executions page to verify navigation works
- [ ] Verify hover states show correct styling (pointer cursor, accent color, underline)
- [ ] Test on mobile view to ensure touch targets work properly

## Technical notes
Navigation uses `/tasks/task/:taskId` route, consistent with other task navigation in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)