### PR TITLE
Add agent tool permissions UX to agent detail page

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -4455,9 +4455,7 @@
             "name": "serverId",
             "required": true,
             "in": "path",
-            "description": "MCP server UUID used by this assignment",
             "schema": {
-              "example": "123e4567-e89b-12d3-a456-426614174000",
               "type": "string"
             }
           }

--- a/apps/ui2/src/features/agents/AddAgentToolPermissionPop.tsx
+++ b/apps/ui2/src/features/agents/AddAgentToolPermissionPop.tsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import type { ScopeResponseDto, ServerResponseDto } from "@taico/client/v2";
+import { PopShell } from "../../app/shells/PopShell";
+import { Avatar, Text } from "../../ui/primitives";
+import { ToolsService } from "./api";
+import "../actors/ActorSearchPop.css";
+
+type ToolPermission = {
+  serverId: string;
+};
+
+type AddAgentToolPermissionPopProps = {
+  currentPermissions: ToolPermission[];
+  onCancel?: () => void;
+  onSaveUnscopedTool: (tool: ServerResponseDto) => Promise<void>;
+  onConfigureScopedTool: (tool: ServerResponseDto, scopes: ScopeResponseDto[]) => void;
+};
+
+export function AddAgentToolPermissionPop({
+  currentPermissions,
+  onCancel,
+  onSaveUnscopedTool,
+  onConfigureScopedTool,
+}: AddAgentToolPermissionPopProps) {
+  const [availableTools, setAvailableTools] = useState<ServerResponseDto[]>([]);
+  const [loadingTools, setLoadingTools] = useState(true);
+  const [query, setQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [selectedToolId, setSelectedToolId] = useState<string>("");
+  const [selectedToolScopes, setSelectedToolScopes] = useState<ScopeResponseDto[]>([]);
+  const [loadingScopes, setLoadingScopes] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const loadTools = async () => {
+      setLoadingTools(true);
+      try {
+        const result = await ToolsService.McpRegistryController_listServers({});
+        setAvailableTools(result.items);
+      } catch (err) {
+        console.error("Failed to load tools:", err);
+      } finally {
+        setLoadingTools(false);
+      }
+    };
+
+    void loadTools();
+  }, []);
+
+  const assignedToolIds = new Set(currentPermissions.map((permission) => permission.serverId));
+  const unassignedTools = useMemo(
+    () => availableTools.filter((tool) => !assignedToolIds.has(tool.id)),
+    [availableTools, assignedToolIds],
+  );
+
+  const filteredTools = useMemo(() => {
+    const trimmedQuery = query.trim().toLowerCase();
+    if (!trimmedQuery) {
+      return unassignedTools;
+    }
+
+    return unassignedTools.filter((tool) =>
+      tool.name.toLowerCase().includes(trimmedQuery) ||
+      tool.type.toLowerCase().includes(trimmedQuery) ||
+      tool.description.toLowerCase().includes(trimmedQuery) ||
+      tool.providedId.toLowerCase().includes(trimmedQuery),
+    );
+  }, [query, unassignedTools]);
+
+  const selectedTool = filteredTools.find((tool) => tool.id === selectedToolId) ??
+    unassignedTools.find((tool) => tool.id === selectedToolId) ??
+    null;
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [filteredTools.length, query]);
+
+  useEffect(() => {
+    if (!listRef.current) {
+      return;
+    }
+
+    const highlightedEl = listRef.current.children[highlightedIndex] as HTMLElement | undefined;
+    highlightedEl?.scrollIntoView({ block: "nearest" });
+  }, [highlightedIndex]);
+
+  useEffect(() => {
+    if (!selectedTool || selectedTool.type !== "http") {
+      setSelectedToolScopes([]);
+      setLoadingScopes(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingScopes(true);
+
+    ToolsService.McpRegistryController_listScopes({ serverId: selectedTool.id })
+      .then((scopes) => {
+        if (!cancelled) {
+          setSelectedToolScopes(scopes);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("Failed to load scopes:", err);
+          setSelectedToolScopes([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoadingScopes(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedTool]);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing || filteredTools.length === 0) {
+      return;
+    }
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setHighlightedIndex((prev) => (prev < filteredTools.length - 1 ? prev + 1 : prev));
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+        break;
+      case "Enter":
+        event.preventDefault();
+        setSelectedToolId(filteredTools[highlightedIndex]?.id ?? "");
+        break;
+    }
+  }, [filteredTools, highlightedIndex]);
+
+  const handlePrimaryAction = useCallback(async () => {
+    if (!selectedTool || loadingScopes || isSaving) {
+      return;
+    }
+
+    if (selectedTool.type === "http" && selectedToolScopes.length > 0) {
+      onConfigureScopedTool(selectedTool, selectedToolScopes);
+      onCancel?.();
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSaveUnscopedTool(selectedTool);
+      onCancel?.();
+    } finally {
+      setIsSaving(false);
+    }
+  }, [isSaving, loadingScopes, onCancel, onConfigureScopedTool, onSaveUnscopedTool, selectedTool, selectedToolScopes]);
+
+  const primaryLabel = selectedTool?.type === "http" && selectedToolScopes.length > 0 ? "next" : (isSaving ? "saving" : "save");
+
+  return (
+    <PopShell
+      title="Add Tool"
+      onCancel={onCancel}
+      headerRight={(
+        <div
+          onClick={() => {
+            void handlePrimaryAction();
+          }}
+          style={{ opacity: !selectedTool || loadingScopes || isSaving ? 0.5 : 1, pointerEvents: !selectedTool || loadingScopes || isSaving ? "none" : "auto" }}
+        >
+          <Text size="4" weight="normal" className="pop-shell__main-title-button">
+            {primaryLabel}
+          </Text>
+        </div>
+      )}
+    >
+      <div className="actor-search-pop">
+        {loadingTools ? (
+          <div className="actor-search-pop__empty">
+            <Text tone="muted">Loading tools...</Text>
+          </div>
+        ) : unassignedTools.length === 0 ? (
+          <div className="actor-search-pop__empty">
+            <Text tone="muted">All available tools already assigned</Text>
+          </div>
+        ) : (
+          <>
+            <input
+              ref={inputRef}
+              type="text"
+              className="actor-search-pop__input"
+              placeholder="Search tools..."
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+
+            <div className="actor-search-pop__list" ref={listRef} role="listbox" aria-label="Tools">
+              {filteredTools.length === 0 ? (
+                <div className="actor-search-pop__empty">
+                  <Text tone="muted">No tools found</Text>
+                </div>
+              ) : (
+                filteredTools.map((tool, index) => {
+                  const isHighlighted = index === highlightedIndex;
+                  const isSelected = tool.id === selectedToolId;
+
+                  return (
+                    <button
+                      key={tool.id}
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      className={`actor-search-pop__item ${(isHighlighted || isSelected) ? "actor-search-pop__item--highlighted" : ""}`}
+                      onClick={() => {
+                        setSelectedToolId(tool.id);
+                        setHighlightedIndex(index);
+                      }}
+                      onMouseEnter={() => setHighlightedIndex(index)}
+                      disabled={isSaving}
+                    >
+                      <Avatar name={tool.name} size="sm" />
+                      <div className="actor-search-pop__item-info">
+                        <Text weight="medium" size="2">{tool.name}</Text>
+                        <Text tone="muted" size="1">@{tool.providedId} · {tool.type}</Text>
+                      </div>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </PopShell>
+  );
+}

--- a/apps/ui2/src/features/agents/AgentDetailPage.css
+++ b/apps/ui2/src/features/agents/AgentDetailPage.css
@@ -135,6 +135,36 @@
   flex-wrap: wrap;
 }
 
+/* Tool permissions */
+.agent-detail-page__tool-permission {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.agent-detail-page__tool-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.agent-detail-page__tool-scopes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  background: var(--surface);
+  border-radius: var(--r-2);
+  border: 1px solid var(--border-subtle);
+}
+
+.agent-detail-page__scope-badge {
+  display: inline-flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
 /* Dark mode support */
 @media (prefers-color-scheme: dark) {
   .agent-detail-page__system-prompt {

--- a/apps/ui2/src/features/agents/AgentDetailPage.css
+++ b/apps/ui2/src/features/agents/AgentDetailPage.css
@@ -135,36 +135,6 @@
   flex-wrap: wrap;
 }
 
-/* Tool permissions */
-.agent-detail-page__tool-permission {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
-.agent-detail-page__tool-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.agent-detail-page__tool-scopes {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-  padding: var(--space-2);
-  background: var(--surface);
-  border-radius: var(--r-2);
-  border: 1px solid var(--border-subtle);
-}
-
-.agent-detail-page__scope-badge {
-  display: inline-flex;
-  gap: var(--space-1);
-  flex-wrap: wrap;
-}
-
 /* Dark mode support */
 @media (prefers-color-scheme: dark) {
   .agent-detail-page__system-prompt {

--- a/apps/ui2/src/features/agents/AgentDetailPage.tsx
+++ b/apps/ui2/src/features/agents/AgentDetailPage.tsx
@@ -5,8 +5,8 @@ import { Text, Stack, Button, Avatar, DataRow, DataRowTag, DataRowContainer, Chi
 import { DeleteWithConfirmation } from '../../ui/components';
 import { elapsedTime } from "../../shared/helpers/elapsedTime";
 import { Agent, AgentToken } from './types';
-import type { AgentResponseDto, ScopeDto, MetaTagResponseDto } from "@taico/client/v2";
-import { AgentTokensService, AuthorizationServerService, MetaService } from './api';
+import type { AgentResponseDto, ScopeDto, MetaTagResponseDto, AgentToolPermissionResponseDto } from "@taico/client/v2";
+import { AgentTokensService, AgentToolPermissionsService, AuthorizationServerService, MetaService } from './api';
 import { EditSystemPromptPop } from './EditSystemPromptPop';
 import { EditStatusTriggersPop } from './EditStatusTriggersPop';
 import { EditTagTriggersPop } from './EditTagTriggersPop';
@@ -14,6 +14,7 @@ import { EditIntroductionPop } from './EditIntroductionPop';
 import { EditAgentTypePop } from './EditAgentTypePop';
 import { EditAgentModelPop } from './EditAgentModelPop';
 import { EditConcurrencyLimitPop } from './EditConcurrencyLimitPop';
+import { EditAgentToolPermissionsPop } from './EditAgentToolPermissionsPop';
 import { TaskStatus } from '../../shared/const/taskStatus';
 import { useDocumentTitle } from '../../shared/hooks/useDocumentTitle';
 import { useToast } from '../../shared/context/ToastContext';
@@ -49,6 +50,10 @@ export function AgentDetailPage() {
   const [allTags, setAllTags] = useState<MetaTagResponseDto[]>([]);
   const [tagsLoading, setTagsLoading] = useState(false);
 
+  // Tool permissions state
+  const [toolPermissions, setToolPermissions] = useState<AgentToolPermissionResponseDto[]>([]);
+  const [permissionsLoading, setPermissionsLoading] = useState(false);
+
   // Edit agent state
   const [showEditSystemPromptPop, setShowEditSystemPromptPop] = useState(false);
   const [showEditStatusTriggersPop, setShowEditStatusTriggersPop] = useState(false);
@@ -57,6 +62,7 @@ export function AgentDetailPage() {
   const [showEditIntroductionPop, setShowEditIntroductionPop] = useState(false);
   const [showEditModelPop, setShowEditModelPop] = useState(false);
   const [showEditConcurrencyLimitPop, setShowEditConcurrencyLimitPop] = useState(false);
+  const [showEditToolPermissionsPop, setShowEditToolPermissionsPop] = useState(false);
 
   // Load tokens for this agent
   const loadTokens = useCallback(async () => {
@@ -98,6 +104,22 @@ export function AgentDetailPage() {
     }
   }, []);
 
+  // Load tool permissions for this agent
+  const loadToolPermissions = useCallback(async () => {
+    if (!agent) return;
+    setPermissionsLoading(true);
+    try {
+      const permissions = await AgentToolPermissionsService.AgentToolPermissionsController_listAgentToolPermissions({
+        actorId: agent.actorId,
+      });
+      setToolPermissions(permissions);
+    } catch (err) {
+      console.error('Failed to load tool permissions:', err);
+    } finally {
+      setPermissionsLoading(false);
+    }
+  }, [agent]);
+
   // Load agent details if not in list
   useEffect(() => {
     if (!agentFromList && slug) {
@@ -114,13 +136,14 @@ export function AgentDetailPage() {
     }
   }, [slug, agentFromList, loadAgentDetails]);
 
-  // Load tokens when agent is loaded
+  // Load tokens, tags, and permissions when agent is loaded
   useEffect(() => {
     if (agent) {
       loadTokens();
       loadTags();
+      loadToolPermissions();
     }
-  }, [agent, loadTokens, loadTags]);
+  }, [agent, loadTokens, loadTags, loadToolPermissions]);
 
   // Load available scopes when create form is shown
   useEffect(() => {
@@ -315,6 +338,40 @@ export function AgentDetailPage() {
       console.error('Failed to update concurrency limit:', err);
       showError(err);
       return false;
+    }
+  };
+
+  // Handle deleting a tool permission
+  const handleDeleteToolPermission = async (serverId: string) => {
+    if (!agent) return;
+    if (!confirm('Remove this tool permission?')) return;
+
+    try {
+      await AgentToolPermissionsService.AgentToolPermissionsController_deleteAgentToolPermission({
+        actorId: agent.actorId,
+        serverId,
+      });
+      await loadToolPermissions();
+    } catch (err) {
+      console.error('Failed to delete tool permission:', err);
+      showError(err);
+    }
+  };
+
+  // Handle editing a tool permission (upsert scopes)
+  const handleEditToolPermission = async (serverId: string, scopeIds: string[]) => {
+    if (!agent) return;
+
+    try {
+      await AgentToolPermissionsService.AgentToolPermissionsController_upsertAgentToolPermission({
+        actorId: agent.actorId,
+        serverId,
+        body: { scopeIds },
+      });
+      await loadToolPermissions();
+    } catch (err) {
+      console.error('Failed to update tool permission:', err);
+      showError(err);
     }
   };
 
@@ -520,19 +577,138 @@ export function AgentDetailPage() {
         </DataRow>
       </DataRowContainer>
 
-      {/* Allowed Tools */}
-      {agent.allowedTools.length > 0 && (
-        <DataRowContainer className="agent-detail-page__section">
+      {/* Tool Permissions */}
+      <DataRowContainer
+        title="Tool Permissions"
+        className="agent-detail-page__section"
+        action={
+          <Button size="sm" onClick={() => setShowEditToolPermissionsPop(true)}>
+            Manage
+          </Button>
+        }
+      >
+        {permissionsLoading ? (
           <DataRow>
-            <Text as="span" weight="medium" size="3">
-              Allowed Tools ({agent.allowedTools.length})
-            </Text>
-            <Text tone="muted" size="2">
-              {agent.allowedTools.join(', ')}
-            </Text>
+            <Text tone="muted" size="2">Loading permissions...</Text>
           </DataRow>
-        </DataRowContainer>
-      )}
+        ) : toolPermissions.length === 0 ? (
+          <DataRow>
+            <Text tone="muted" size="2">No tool permissions configured</Text>
+          </DataRow>
+        ) : (
+          <>
+            {/* Separate core system tools from additional tools */}
+            {(() => {
+              const coreTools = toolPermissions.filter(p =>
+                p.server.providedId === 'tasks' || p.server.providedId === 'context'
+              );
+              const additionalTools = toolPermissions.filter(p =>
+                p.server.providedId !== 'tasks' && p.server.providedId !== 'context'
+              );
+
+              return (
+                <>
+                  {/* Core System Tools */}
+                  {coreTools.length > 0 && (
+                    <>
+                      <DataRow>
+                        <Text size="2" weight="medium" tone="muted">Core System Tools</Text>
+                        <Text size="1" tone="muted">
+                          These tools are always available to agents
+                        </Text>
+                      </DataRow>
+                      {coreTools.map(permission => (
+                        <DataRow key={permission.server.id}>
+                          <div className="agent-detail-page__tool-permission">
+                            <div className="agent-detail-page__tool-header">
+                              <div>
+                                <Text size="2" weight="medium">{permission.server.name}</Text>
+                                <Text size="1" tone="muted">{permission.server.description}</Text>
+                              </div>
+                              <Chip color={permission.server.type === 'http' ? 'green' : 'orange'}>
+                                {permission.server.type}
+                              </Chip>
+                            </div>
+                            {permission.server.type === 'http' && permission.availableScopes.length > 0 && (
+                              <div className="agent-detail-page__tool-scopes">
+                                <Text size="1" tone="muted">
+                                  {permission.hasAllScopes
+                                    ? 'All scopes granted'
+                                    : `${permission.grantedScopes.length} of ${permission.availableScopes.length} scopes granted`}
+                                </Text>
+                                <div className="agent-detail-page__scope-badge">
+                                  {permission.grantedScopes.map(scope => (
+                                    <Chip key={scope.id} color="blue">
+                                      {scope.id}
+                                    </Chip>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        </DataRow>
+                      ))}
+                    </>
+                  )}
+
+                  {/* Additional Tools */}
+                  {additionalTools.length > 0 && (
+                    <>
+                      <DataRow>
+                        <Text size="2" weight="medium" tone="muted">Additional Tools</Text>
+                      </DataRow>
+                      {additionalTools.map(permission => (
+                        <DataRow
+                          key={permission.server.id}
+                          topRight={
+                            <Button
+                              size="sm"
+                              variant="secondary"
+                              onClick={() => handleDeleteToolPermission(permission.server.id)}
+                            >
+                              Remove
+                            </Button>
+                          }
+                        >
+                          <div className="agent-detail-page__tool-permission">
+                            <div className="agent-detail-page__tool-header">
+                              <div>
+                                <Text size="2" weight="medium">{permission.server.name}</Text>
+                                <Text size="1" tone="muted">{permission.server.description}</Text>
+                              </div>
+                              <Chip color={permission.server.type === 'http' ? 'green' : 'orange'}>
+                                {permission.server.type}
+                              </Chip>
+                            </div>
+                            {permission.server.type === 'http' && permission.availableScopes.length > 0 ? (
+                              <div className="agent-detail-page__tool-scopes">
+                                <Text size="1" tone="muted">
+                                  {permission.hasAllScopes
+                                    ? 'All scopes granted'
+                                    : `${permission.grantedScopes.length} of ${permission.availableScopes.length} scopes granted`}
+                                </Text>
+                                <div className="agent-detail-page__scope-badge">
+                                  {permission.grantedScopes.map(scope => (
+                                    <Chip key={scope.id} color="blue">
+                                      {scope.id}
+                                    </Chip>
+                                  ))}
+                                </div>
+                              </div>
+                            ) : permission.server.type === 'stdio' ? (
+                              <Text size="1" tone="muted">No scopes required (STDIO tool)</Text>
+                            ) : null}
+                          </div>
+                        </DataRow>
+                      ))}
+                    </>
+                  )}
+                </>
+              );
+            })()}
+          </>
+        )}
+      </DataRowContainer>
 
       {/* Newly Created Token Alert */}
       {newlyCreatedToken && (
@@ -786,6 +962,25 @@ export function AgentDetailPage() {
           initialValue={concurrencyLimit}
           onCancel={() => setShowEditConcurrencyLimitPop(false)}
           onSave={handleSaveConcurrencyLimit}
+        />
+      )}
+      {showEditToolPermissionsPop && agent && (
+        <EditAgentToolPermissionsPop
+          agentActorId={agent.actorId}
+          currentPermissions={toolPermissions.map(p => ({
+            serverId: p.server.id,
+            serverName: p.server.name,
+            serverProvidedId: p.server.providedId,
+            serverType: p.server.type as 'http' | 'stdio',
+            scopeIds: p.grantedScopes.map(s => s.id),
+            availableScopes: p.availableScopes,
+            hasAllScopes: p.hasAllScopes,
+          }))}
+          onCancel={() => setShowEditToolPermissionsPop(false)}
+          onSave={async () => {
+            await loadToolPermissions();
+            setShowEditToolPermissionsPop(false);
+          }}
         />
       )}
     </div>

--- a/apps/ui2/src/features/agents/AgentDetailPage.tsx
+++ b/apps/ui2/src/features/agents/AgentDetailPage.tsx
@@ -63,6 +63,7 @@ export function AgentDetailPage() {
   const [showEditModelPop, setShowEditModelPop] = useState(false);
   const [showEditConcurrencyLimitPop, setShowEditConcurrencyLimitPop] = useState(false);
   const [showEditToolPermissionsPop, setShowEditToolPermissionsPop] = useState(false);
+  const [editingToolPermission, setEditingToolPermission] = useState<AgentToolPermissionResponseDto | null>(null);
 
   // Load tokens for this agent
   const loadTokens = useCallback(async () => {
@@ -358,21 +359,10 @@ export function AgentDetailPage() {
     }
   };
 
-  // Handle editing a tool permission (upsert scopes)
-  const handleEditToolPermission = async (serverId: string, scopeIds: string[]) => {
-    if (!agent) return;
-
-    try {
-      await AgentToolPermissionsService.AgentToolPermissionsController_upsertAgentToolPermission({
-        actorId: agent.actorId,
-        serverId,
-        body: { scopeIds },
-      });
-      await loadToolPermissions();
-    } catch (err) {
-      console.error('Failed to update tool permission:', err);
-      showError(err);
-    }
+  // Handle opening edit modal for a tool permission
+  const handleOpenEditToolPermission = (permission: AgentToolPermissionResponseDto) => {
+    setEditingToolPermission(permission);
+    setShowEditToolPermissionsPop(true);
   };
 
   // Handle revoking a token
@@ -625,9 +615,12 @@ export function AgentDetailPage() {
                                 <Text size="2" weight="medium">{permission.server.name}</Text>
                                 <Text size="1" tone="muted">{permission.server.description}</Text>
                               </div>
-                              <Chip color={permission.server.type === 'http' ? 'green' : 'orange'}>
-                                {permission.server.type}
-                              </Chip>
+                              <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                                <Chip color="purple">System Tool</Chip>
+                                <Chip color={permission.server.type === 'http' ? 'green' : 'orange'}>
+                                  {permission.server.type}
+                                </Chip>
+                              </div>
                             </div>
                             {permission.server.type === 'http' && permission.availableScopes.length > 0 && (
                               <div className="agent-detail-page__tool-scopes">
@@ -661,13 +654,22 @@ export function AgentDetailPage() {
                         <DataRow
                           key={permission.server.id}
                           topRight={
-                            <Button
-                              size="sm"
-                              variant="secondary"
-                              onClick={() => handleDeleteToolPermission(permission.server.id)}
-                            >
-                              Remove
-                            </Button>
+                            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                              <Button
+                                size="sm"
+                                variant="secondary"
+                                onClick={() => handleOpenEditToolPermission(permission)}
+                              >
+                                Edit
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="secondary"
+                                onClick={() => handleDeleteToolPermission(permission.server.id)}
+                              >
+                                Remove
+                              </Button>
+                            </div>
                           }
                         >
                           <div className="agent-detail-page__tool-permission">
@@ -976,10 +978,23 @@ export function AgentDetailPage() {
             availableScopes: p.availableScopes,
             hasAllScopes: p.hasAllScopes,
           }))}
-          onCancel={() => setShowEditToolPermissionsPop(false)}
+          editingPermission={editingToolPermission ? {
+            serverId: editingToolPermission.server.id,
+            serverName: editingToolPermission.server.name,
+            serverProvidedId: editingToolPermission.server.providedId,
+            serverType: editingToolPermission.server.type as 'http' | 'stdio',
+            scopeIds: editingToolPermission.grantedScopes.map(s => s.id),
+            availableScopes: editingToolPermission.availableScopes,
+            hasAllScopes: editingToolPermission.hasAllScopes,
+          } : null}
+          onCancel={() => {
+            setShowEditToolPermissionsPop(false);
+            setEditingToolPermission(null);
+          }}
           onSave={async () => {
             await loadToolPermissions();
             setShowEditToolPermissionsPop(false);
+            setEditingToolPermission(null);
           }}
         />
       )}

--- a/apps/ui2/src/features/agents/AgentDetailPage.tsx
+++ b/apps/ui2/src/features/agents/AgentDetailPage.tsx
@@ -14,7 +14,6 @@ import { EditIntroductionPop } from './EditIntroductionPop';
 import { EditAgentTypePop } from './EditAgentTypePop';
 import { EditAgentModelPop } from './EditAgentModelPop';
 import { EditConcurrencyLimitPop } from './EditConcurrencyLimitPop';
-import { EditAgentToolPermissionsPop } from './EditAgentToolPermissionsPop';
 import { TaskStatus } from '../../shared/const/taskStatus';
 import { useDocumentTitle } from '../../shared/hooks/useDocumentTitle';
 import { useToast } from '../../shared/context/ToastContext';
@@ -62,8 +61,6 @@ export function AgentDetailPage() {
   const [showEditIntroductionPop, setShowEditIntroductionPop] = useState(false);
   const [showEditModelPop, setShowEditModelPop] = useState(false);
   const [showEditConcurrencyLimitPop, setShowEditConcurrencyLimitPop] = useState(false);
-  const [showEditToolPermissionsPop, setShowEditToolPermissionsPop] = useState(false);
-  const [editingToolPermission, setEditingToolPermission] = useState<AgentToolPermissionResponseDto | null>(null);
 
   // Load tokens for this agent
   const loadTokens = useCallback(async () => {
@@ -342,29 +339,6 @@ export function AgentDetailPage() {
     }
   };
 
-  // Handle deleting a tool permission
-  const handleDeleteToolPermission = async (serverId: string) => {
-    if (!agent) return;
-    if (!confirm('Remove this tool permission?')) return;
-
-    try {
-      await AgentToolPermissionsService.AgentToolPermissionsController_deleteAgentToolPermission({
-        actorId: agent.actorId,
-        serverId,
-      });
-      await loadToolPermissions();
-    } catch (err) {
-      console.error('Failed to delete tool permission:', err);
-      showError(err);
-    }
-  };
-
-  // Handle opening edit modal for a tool permission
-  const handleOpenEditToolPermission = (permission: AgentToolPermissionResponseDto) => {
-    setEditingToolPermission(permission);
-    setShowEditToolPermissionsPop(true);
-  };
-
   // Handle revoking a token
   const handleRevokeToken = async (tokenId: string) => {
     if (!slug) return;
@@ -446,6 +420,20 @@ export function AgentDetailPage() {
     ? Math.floor(concurrencyValue)
     : null;
   const tagColorsByName = new Map(allTags.map((tag) => [tag.name, tag.color]));
+  const systemToolCount = toolPermissions.filter((permission) =>
+    permission.server.providedId === 'tasks' || permission.server.providedId === 'context'
+  ).length;
+  const additionalToolCount = toolPermissions.length - systemToolCount;
+  const toolSummary = permissionsLoading
+    ? 'Loading tool permissions...'
+    : toolPermissions.length === 0
+      ? 'No tools configured'
+      : `${toolPermissions.length} ${toolPermissions.length === 1 ? 'tool' : 'tools'} configured`;
+  const toolSupportText = permissionsLoading
+    ? 'Checking assigned tools and scopes'
+    : toolPermissions.length === 0
+      ? 'Tasks and Context can be configured from the dedicated tools page.'
+      : `${systemToolCount} system ${systemToolCount === 1 ? 'tool' : 'tools'}, ${additionalToolCount} additional ${additionalToolCount === 1 ? 'tool' : 'tools'}`;
 
   return (
     <div className="agent-detail-page">
@@ -569,147 +557,16 @@ export function AgentDetailPage() {
 
       {/* Tool Permissions */}
       <DataRowContainer
-        title="Tool Permissions"
+        title="Tools"
         className="agent-detail-page__section"
-        action={
-          <Button size="sm" onClick={() => setShowEditToolPermissionsPop(true)}>
-            Manage
-          </Button>
-        }
       >
-        {permissionsLoading ? (
-          <DataRow>
-            <Text tone="muted" size="2">Loading permissions...</Text>
-          </DataRow>
-        ) : toolPermissions.length === 0 ? (
-          <DataRow>
-            <Text tone="muted" size="2">No tool permissions configured</Text>
-          </DataRow>
-        ) : (
-          <>
-            {/* Separate core system tools from additional tools */}
-            {(() => {
-              const coreTools = toolPermissions.filter(p =>
-                p.server.providedId === 'tasks' || p.server.providedId === 'context'
-              );
-              const additionalTools = toolPermissions.filter(p =>
-                p.server.providedId !== 'tasks' && p.server.providedId !== 'context'
-              );
-
-              return (
-                <>
-                  {/* Core System Tools */}
-                  {coreTools.length > 0 && (
-                    <>
-                      <DataRow>
-                        <Text size="2" weight="medium" tone="muted">Core System Tools</Text>
-                        <Text size="1" tone="muted">
-                          These tools are always available to agents
-                        </Text>
-                      </DataRow>
-                      {coreTools.map(permission => (
-                        <DataRow key={permission.server.id}>
-                          <div className="agent-detail-page__tool-permission">
-                            <div className="agent-detail-page__tool-header">
-                              <div>
-                                <Text size="2" weight="medium">{permission.server.name}</Text>
-                                <Text size="1" tone="muted">{permission.server.description}</Text>
-                              </div>
-                              <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-                                <Chip color="purple">System Tool</Chip>
-                                <Chip color={permission.server.type === 'http' ? 'green' : 'orange'}>
-                                  {permission.server.type}
-                                </Chip>
-                              </div>
-                            </div>
-                            {permission.server.type === 'http' && permission.availableScopes.length > 0 && (
-                              <div className="agent-detail-page__tool-scopes">
-                                <Text size="1" tone="muted">
-                                  {permission.hasAllScopes
-                                    ? 'All scopes granted'
-                                    : `${permission.grantedScopes.length} of ${permission.availableScopes.length} scopes granted`}
-                                </Text>
-                                <div className="agent-detail-page__scope-badge">
-                                  {permission.grantedScopes.map(scope => (
-                                    <Chip key={scope.id} color="blue">
-                                      {scope.id}
-                                    </Chip>
-                                  ))}
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                        </DataRow>
-                      ))}
-                    </>
-                  )}
-
-                  {/* Additional Tools */}
-                  {additionalTools.length > 0 && (
-                    <>
-                      <DataRow>
-                        <Text size="2" weight="medium" tone="muted">Additional Tools</Text>
-                      </DataRow>
-                      {additionalTools.map(permission => (
-                        <DataRow
-                          key={permission.server.id}
-                          topRight={
-                            <div style={{ display: 'flex', gap: '0.5rem' }}>
-                              <Button
-                                size="sm"
-                                variant="secondary"
-                                onClick={() => handleOpenEditToolPermission(permission)}
-                              >
-                                Edit
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="secondary"
-                                onClick={() => handleDeleteToolPermission(permission.server.id)}
-                              >
-                                Remove
-                              </Button>
-                            </div>
-                          }
-                        >
-                          <div className="agent-detail-page__tool-permission">
-                            <div className="agent-detail-page__tool-header">
-                              <div>
-                                <Text size="2" weight="medium">{permission.server.name}</Text>
-                                <Text size="1" tone="muted">{permission.server.description}</Text>
-                              </div>
-                              <Chip color={permission.server.type === 'http' ? 'green' : 'orange'}>
-                                {permission.server.type}
-                              </Chip>
-                            </div>
-                            {permission.server.type === 'http' && permission.availableScopes.length > 0 ? (
-                              <div className="agent-detail-page__tool-scopes">
-                                <Text size="1" tone="muted">
-                                  {permission.hasAllScopes
-                                    ? 'All scopes granted'
-                                    : `${permission.grantedScopes.length} of ${permission.availableScopes.length} scopes granted`}
-                                </Text>
-                                <div className="agent-detail-page__scope-badge">
-                                  {permission.grantedScopes.map(scope => (
-                                    <Chip key={scope.id} color="blue">
-                                      {scope.id}
-                                    </Chip>
-                                  ))}
-                                </div>
-                              </div>
-                            ) : permission.server.type === 'stdio' ? (
-                              <Text size="1" tone="muted">No scopes required (STDIO tool)</Text>
-                            ) : null}
-                          </div>
-                        </DataRow>
-                      ))}
-                    </>
-                  )}
-                </>
-              );
-            })()}
-          </>
-        )}
+        <DataRow onClick={() => navigate(`/agents/agent/${agent.slug}/tools`)}>
+          <Stack spacing="1">
+            <Text size="2" weight="medium">{toolSummary}</Text>
+            <Text size="1" tone="muted">{toolSupportText}</Text>
+          </Stack>
+          <Text size="1" tone="muted">tap to manage</Text>
+        </DataRow>
       </DataRowContainer>
 
       {/* Newly Created Token Alert */}
@@ -964,38 +821,6 @@ export function AgentDetailPage() {
           initialValue={concurrencyLimit}
           onCancel={() => setShowEditConcurrencyLimitPop(false)}
           onSave={handleSaveConcurrencyLimit}
-        />
-      )}
-      {showEditToolPermissionsPop && agent && (
-        <EditAgentToolPermissionsPop
-          agentActorId={agent.actorId}
-          currentPermissions={toolPermissions.map(p => ({
-            serverId: p.server.id,
-            serverName: p.server.name,
-            serverProvidedId: p.server.providedId,
-            serverType: p.server.type as 'http' | 'stdio',
-            scopeIds: p.grantedScopes.map(s => s.id),
-            availableScopes: p.availableScopes,
-            hasAllScopes: p.hasAllScopes,
-          }))}
-          editingPermission={editingToolPermission ? {
-            serverId: editingToolPermission.server.id,
-            serverName: editingToolPermission.server.name,
-            serverProvidedId: editingToolPermission.server.providedId,
-            serverType: editingToolPermission.server.type as 'http' | 'stdio',
-            scopeIds: editingToolPermission.grantedScopes.map(s => s.id),
-            availableScopes: editingToolPermission.availableScopes,
-            hasAllScopes: editingToolPermission.hasAllScopes,
-          } : null}
-          onCancel={() => {
-            setShowEditToolPermissionsPop(false);
-            setEditingToolPermission(null);
-          }}
-          onSave={async () => {
-            await loadToolPermissions();
-            setShowEditToolPermissionsPop(false);
-            setEditingToolPermission(null);
-          }}
         />
       )}
     </div>

--- a/apps/ui2/src/features/agents/AgentToolsPage.css
+++ b/apps/ui2/src/features/agents/AgentToolsPage.css
@@ -1,0 +1,54 @@
+.agent-tools-page {
+  background: var(--bg);
+}
+
+.agent-tools-page__section {
+  margin: var(--space-5) 0;
+}
+
+.agent-tools-page__actions {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 8px;
+  margin: var(--space-3);
+}
+
+.agent-tools-page__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  width: 100%;
+}
+
+.agent-tools-page__row-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+  flex: 1;
+}
+
+.agent-tools-page__row-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.agent-tools-page__chips {
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+@media (max-width: 767px) {
+  .agent-tools-page__row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .agent-tools-page__row-title {
+    align-items: flex-start;
+  }
+}

--- a/apps/ui2/src/features/agents/AgentToolsPage.tsx
+++ b/apps/ui2/src/features/agents/AgentToolsPage.tsx
@@ -1,0 +1,352 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { AgentToolPermissionResponseDto } from '@taico/client/v2';
+import { useAgentsCtx } from './AgentsProvider';
+import { AgentToolPermissionsService } from './api';
+import { AddAgentToolPermissionPop } from './AddAgentToolPermissionPop';
+import { EditAgentToolPermissionsPop } from './EditAgentToolPermissionsPop';
+import { Text, Stack, Button, DataRow, DataRowContainer, Chip } from '../../ui/primitives';
+import { useToast } from '../../shared/context/ToastContext';
+import { useDocumentTitle } from '../../shared/hooks/useDocumentTitle';
+import type { Agent } from './types';
+import './AgentToolsPage.css';
+
+function isSystemTool(permission: AgentToolPermissionResponseDto) {
+  return permission.server.providedId === 'tasks' || permission.server.providedId === 'context';
+}
+
+function getScopeSummary(permission: AgentToolPermissionResponseDto) {
+  if (permission.server.type === 'stdio') {
+    return 'No scopes required';
+  }
+
+  if (permission.availableScopes.length === 0) {
+    return 'No scopes available';
+  }
+
+  if (permission.hasAllScopes) {
+    return 'All scopes';
+  }
+
+  return `${permission.grantedScopes.length} of ${permission.availableScopes.length} scopes`;
+}
+
+export function AgentToolsPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+  const { agents, setSectionTitle, loadAgentDetails } = useAgentsCtx();
+  const { showError } = useToast();
+
+  const agentFromList = agents.find((candidate) => candidate.slug === slug);
+  const [agent, setAgent] = useState<Agent | null>(agentFromList || null);
+  const [isLoading, setIsLoading] = useState(!agentFromList);
+  const [toolPermissions, setToolPermissions] = useState<AgentToolPermissionResponseDto[]>([]);
+  const [permissionsLoading, setPermissionsLoading] = useState(false);
+  const [showAddToolPop, setShowAddToolPop] = useState(false);
+  const [showEditToolPermissionsPop, setShowEditToolPermissionsPop] = useState(false);
+  const [editingToolPermission, setEditingToolPermission] = useState<AgentToolPermissionResponseDto | null>(null);
+  const [pendingScopedTool, setPendingScopedTool] = useState<{
+    serverId: string;
+    serverName: string;
+    serverProvidedId: string;
+    serverType: 'http' | 'stdio';
+    availableScopes: Array<{ id: string; description: string }>;
+  } | null>(null);
+
+  const loadToolPermissions = useCallback(async (actorId: string) => {
+    setPermissionsLoading(true);
+    try {
+      const permissions = await AgentToolPermissionsService.AgentToolPermissionsController_listAgentToolPermissions({
+        actorId,
+      });
+      setToolPermissions(permissions);
+    } catch (err) {
+      console.error('Failed to load tool permissions:', err);
+      showError(err);
+    } finally {
+      setPermissionsLoading(false);
+    }
+  }, [showError]);
+
+  useEffect(() => {
+    if (!agentFromList && slug) {
+      setIsLoading(true);
+      loadAgentDetails(slug).then((loadedAgent) => {
+        setAgent(loadedAgent);
+        setIsLoading(false);
+      }).catch(() => {
+        setAgent(null);
+        setIsLoading(false);
+      });
+    } else if (agentFromList) {
+      setAgent(agentFromList);
+      setIsLoading(false);
+    }
+  }, [slug, agentFromList, loadAgentDetails]);
+
+  useEffect(() => {
+    if (!agent) {
+      return;
+    }
+    loadToolPermissions(agent.actorId);
+  }, [agent, loadToolPermissions]);
+
+  useEffect(() => {
+    if (!agent) {
+      setSectionTitle('Tools');
+      return;
+    }
+    setSectionTitle(`${agent.name} Tools`);
+  }, [agent, setSectionTitle]);
+
+  useDocumentTitle({ agent: { name: agent ? `${agent.name} Tools` : undefined } });
+
+  const handleOpenAddTool = () => {
+    setShowAddToolPop(true);
+  };
+
+  const handleOpenEditTool = (permission: AgentToolPermissionResponseDto) => {
+    setEditingToolPermission(permission);
+    setShowEditToolPermissionsPop(true);
+  };
+
+  const handleDeleteToolPermission = async (serverId: string) => {
+    if (!agent) {
+      return;
+    }
+
+    if (!confirm('Remove this tool permission?')) {
+      return;
+    }
+
+    try {
+      await AgentToolPermissionsService.AgentToolPermissionsController_deleteAgentToolPermission({
+        actorId: agent.actorId,
+        serverId,
+      });
+      setShowEditToolPermissionsPop(false);
+      setEditingToolPermission(null);
+      await loadToolPermissions(agent.actorId);
+    } catch (err) {
+      console.error('Failed to delete tool permission:', err);
+      showError(err);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="agent-tools-page">
+        <Stack spacing="4" align="center">
+          <Text size="3" tone="muted">Loading tools...</Text>
+        </Stack>
+      </div>
+    );
+  }
+
+  if (!agent) {
+    return (
+      <div className="agent-tools-page">
+        <Stack spacing="4" align="center">
+          <Text size="3" tone="muted">Agent not found</Text>
+          <Button variant="secondary" onClick={() => navigate('/agents')}>
+            Back to agents
+          </Button>
+        </Stack>
+      </div>
+    );
+  }
+
+  const systemTools = toolPermissions.filter(isSystemTool);
+  const additionalTools = toolPermissions.filter((permission) => !isSystemTool(permission));
+
+  return (
+    <div className="agent-tools-page">
+      <DataRowContainer className="agent-tools-page__section">
+        <DataRow>
+          <Stack spacing="1">
+            <Text size="3" weight="medium">Tools</Text>
+            <Text size="2" tone="muted">
+              Tasks and Context stay available. Additional tools can be assigned per agent with scoped access.
+            </Text>
+          </Stack>
+        </DataRow>
+      </DataRowContainer>
+
+      <DataRowContainer title="System Tools" className="agent-tools-page__section">
+        {systemTools.map((permission) => (
+          <DataRow key={permission.server.id}>
+            <div className="agent-tools-page__row">
+              <div className="agent-tools-page__row-main">
+                <div className="agent-tools-page__row-title">
+                  <Text size="2" weight="medium">{permission.server.name}</Text>
+                  <div className="agent-tools-page__chips">
+                    <Chip color="purple">System Tool</Chip>
+                    <Chip color={permission.server.type === 'http' ? 'green' : 'orange'}>
+                      {permission.server.type}
+                    </Chip>
+                  </div>
+                </div>
+                <Text size="1" tone="muted">{permission.server.description}</Text>
+                <Text size="1" tone="muted">{getScopeSummary(permission)}</Text>
+              </div>
+            </div>
+          </DataRow>
+        ))}
+      </DataRowContainer>
+
+      <DataRowContainer
+        title="Additional Tools"
+        className="agent-tools-page__section"
+      >
+        {permissionsLoading ? (
+          <DataRow>
+            <Text size="2" tone="muted">Loading tool permissions...</Text>
+          </DataRow>
+        ) : additionalTools.length === 0 ? (
+          <DataRow>
+            <Stack spacing="1">
+              <Text size="2" tone="muted">No additional tools configured</Text>
+              <Text size="1" tone="muted">Add a tool to grant this agent access beyond Tasks and Context.</Text>
+            </Stack>
+          </DataRow>
+        ) : (
+          additionalTools.map((permission) => (
+            <DataRow
+              key={permission.server.id}
+              onClick={() => handleOpenEditTool(permission)}
+              trailing={<Text size="2" tone="muted">Edit</Text>}
+            >
+              <div className="agent-tools-page__row">
+                <div className="agent-tools-page__row-main">
+                  <div className="agent-tools-page__row-title">
+                    <Text size="2" weight="medium">{permission.server.name}</Text>
+                    <div className="agent-tools-page__chips">
+                      <Chip color={permission.server.type === 'http' ? 'green' : 'orange'}>
+                        {permission.server.type}
+                      </Chip>
+                    </div>
+                  </div>
+                  <Text size="1" tone="muted">{permission.server.description}</Text>
+                  <Text size="1" tone="muted">{getScopeSummary(permission)}</Text>
+                </div>
+              </div>
+            </DataRow>
+          ))
+        )}
+      </DataRowContainer>
+
+      <DataRowContainer className="agent-tools-page__actions">
+        <Button
+          size="lg"
+          onClick={handleOpenAddTool}
+        >
+          Add Tool
+        </Button>
+        <Button
+          size="lg"
+          variant="secondary"
+          onClick={() => navigate(`/agents/agent/${agent.slug}`)}
+        >
+          Back to agent details
+        </Button>
+      </DataRowContainer>
+
+      {showAddToolPop && (
+        <AddAgentToolPermissionPop
+          currentPermissions={toolPermissions.map((permission) => ({
+            serverId: permission.server.id,
+          }))}
+          onCancel={() => setShowAddToolPop(false)}
+          onSaveUnscopedTool={async (tool) => {
+            await AgentToolPermissionsService.AgentToolPermissionsController_upsertAgentToolPermission({
+              actorId: agent.actorId,
+              serverId: tool.id,
+              body: { scopeIds: [] },
+            });
+            await loadToolPermissions(agent.actorId);
+          }}
+          onConfigureScopedTool={(tool, scopes) => {
+            setPendingScopedTool({
+              serverId: tool.id,
+              serverName: tool.name,
+              serverProvidedId: tool.providedId,
+              serverType: tool.type,
+              availableScopes: scopes.map((scope) => ({
+                id: scope.id,
+                description: scope.description,
+              })),
+            });
+          }}
+        />
+      )}
+
+      {showEditToolPermissionsPop && (
+        <EditAgentToolPermissionsPop
+          agentActorId={agent.actorId}
+          currentPermissions={toolPermissions.map((permission) => ({
+            serverId: permission.server.id,
+            serverName: permission.server.name,
+            serverProvidedId: permission.server.providedId,
+            serverType: permission.server.type,
+            scopeIds: permission.grantedScopes.map((scope) => scope.id),
+            availableScopes: permission.availableScopes.map((scope) => ({
+              id: scope.id,
+              description: scope.description,
+            })),
+            hasAllScopes: permission.hasAllScopes,
+          }))}
+          editingPermission={editingToolPermission ? {
+            serverId: editingToolPermission.server.id,
+            serverName: editingToolPermission.server.name,
+            serverProvidedId: editingToolPermission.server.providedId,
+            serverType: editingToolPermission.server.type,
+            scopeIds: editingToolPermission.grantedScopes.map((scope) => scope.id),
+            availableScopes: editingToolPermission.availableScopes.map((scope) => ({
+              id: scope.id,
+              description: scope.description,
+            })),
+            hasAllScopes: editingToolPermission.hasAllScopes,
+          } : null}
+          onCancel={() => {
+            setShowEditToolPermissionsPop(false);
+            setEditingToolPermission(null);
+          }}
+          onSave={async () => {
+            await loadToolPermissions(agent.actorId);
+            setShowEditToolPermissionsPop(false);
+            setEditingToolPermission(null);
+          }}
+          onDelete={editingToolPermission ? async () => {
+            await handleDeleteToolPermission(editingToolPermission.server.id);
+          } : undefined}
+        />
+      )}
+
+      {pendingScopedTool && (
+        <EditAgentToolPermissionsPop
+          agentActorId={agent.actorId}
+          currentPermissions={toolPermissions.map((permission) => ({
+            serverId: permission.server.id,
+            serverName: permission.server.name,
+            serverProvidedId: permission.server.providedId,
+            serverType: permission.server.type,
+            scopeIds: permission.grantedScopes.map((scope) => scope.id),
+            availableScopes: permission.availableScopes.map((scope) => ({
+              id: scope.id,
+              description: scope.description,
+            })),
+            hasAllScopes: permission.hasAllScopes,
+          }))}
+          fixedTool={pendingScopedTool}
+          title="Select Scopes"
+          saveLabel="save"
+          onCancel={() => setPendingScopedTool(null)}
+          onSave={async () => {
+            await loadToolPermissions(agent.actorId);
+            setPendingScopedTool(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/ui2/src/features/agents/AgentsRoutes.tsx
+++ b/apps/ui2/src/features/agents/AgentsRoutes.tsx
@@ -3,6 +3,7 @@ import { AgentsPage } from "./AgentsPage";
 import { AgentsLayout } from "./AgentsLayout";
 import { AgentsProvider } from "./AgentsProvider";
 import { AgentDetailPage } from "./AgentDetailPage";
+import { AgentToolsPage } from "./AgentToolsPage";
 
 export function AgentsRoutes() {
   return (
@@ -11,6 +12,7 @@ export function AgentsRoutes() {
         <Route element={<AgentsLayout />}>
           <Route index element={<AgentsPage />} />
           <Route path="/agent/:slug" element={<AgentDetailPage />} />
+          <Route path="/agent/:slug/tools" element={<AgentToolsPage />} />
         </Route>
       </Routes>
     </AgentsProvider>

--- a/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.css
+++ b/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.css
@@ -1,21 +1,10 @@
-.edit-agent-tool-permissions-pop__wrapper {
-  padding: var(--space-4);
-}
-
-.edit-agent-tool-permissions-pop__select {
-  width: 100%;
-  padding: var(--space-2) var(--space-3);
-  font-size: var(--fs-2);
-  color: var(--text);
-  background-color: var(--surface);
-  border: 1px solid var(--border);
+.edit-agent-tool-permissions-pop__selected-tool {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--r-2);
-  font-family: inherit;
-}
-
-.edit-agent-tool-permissions-pop__select:focus {
-  outline: none;
-  border-color: var(--accent);
 }
 
 .edit-agent-tool-permissions-pop__scopes {

--- a/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.css
+++ b/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.css
@@ -1,0 +1,53 @@
+.edit-agent-tool-permissions-pop__wrapper {
+  padding: var(--space-4);
+}
+
+.edit-agent-tool-permissions-pop__select {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--fs-2);
+  color: var(--text);
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  font-family: inherit;
+}
+
+.edit-agent-tool-permissions-pop__select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.edit-agent-tool-permissions-pop__scopes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.edit-agent-tool-permissions-pop__scope-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-2);
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.edit-agent-tool-permissions-pop__scope-item:hover {
+  background-color: var(--surface);
+}
+
+.edit-agent-tool-permissions-pop__scope-item input[type="checkbox"] {
+  margin-top: 2px;
+  cursor: pointer;
+}
+
+.edit-agent-tool-permissions-pop__scope-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}

--- a/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.tsx
+++ b/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.tsx
@@ -20,6 +20,7 @@ type EditAgentToolPermissionsPopProps = {
   currentPermissions: ToolPermission[];
   onCancel?: () => void;
   onSave: () => Promise<void>;
+  editingPermission?: ToolPermission | null;
 };
 
 export function EditAgentToolPermissionsPop({
@@ -27,15 +28,19 @@ export function EditAgentToolPermissionsPop({
   currentPermissions,
   onCancel,
   onSave,
+  editingPermission = null,
 }: EditAgentToolPermissionsPopProps) {
   const [availableTools, setAvailableTools] = useState<ServerResponseDto[]>([]);
   const [loadingTools, setLoadingTools] = useState(true);
-  const [selectedToolId, setSelectedToolId] = useState<string>('');
+  const [selectedToolId, setSelectedToolId] = useState<string>(editingPermission?.serverId || '');
   const [availableScopes, setAvailableScopes] = useState<ScopeResponseDto[]>([]);
   const [loadingScopes, setLoadingScopes] = useState(false);
-  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
-  const [selectAllScopes, setSelectAllScopes] = useState(false);
+  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(
+    editingPermission ? new Set(editingPermission.scopeIds) : new Set()
+  );
+  const [selectAllScopes, setSelectAllScopes] = useState(editingPermission?.hasAllScopes || false);
   const [isSaving, setIsSaving] = useState(false);
+  const isEditMode = !!editingPermission;
 
   // Load available tools
   useEffect(() => {
@@ -63,6 +68,11 @@ export function EditAgentToolPermissionsPop({
       ToolsService.McpRegistryController_listScopes({ serverId: selectedToolId })
         .then(scopes => {
           setAvailableScopes(scopes);
+          // In edit mode, preserve the selected scopes after loading available scopes
+          if (editingPermission && editingPermission.serverId === selectedToolId) {
+            setSelectedScopes(new Set(editingPermission.scopeIds));
+            setSelectAllScopes(editingPermission.hasAllScopes);
+          }
         })
         .catch(err => {
           console.error('Failed to load scopes:', err);
@@ -73,10 +83,13 @@ export function EditAgentToolPermissionsPop({
         });
     } else {
       setAvailableScopes([]);
+      // Only reset scopes if not in edit mode
+      if (!isEditMode) {
+        setSelectedScopes(new Set());
+        setSelectAllScopes(false);
+      }
     }
-    setSelectedScopes(new Set());
-    setSelectAllScopes(false);
-  }, [selectedToolId, isHttpTool]);
+  }, [selectedToolId, isHttpTool, editingPermission, isEditMode]);
 
   // Handle "All scopes" toggle
   const handleAllScopesToggle = () => {
@@ -133,13 +146,15 @@ export function EditAgentToolPermissionsPop({
     }
   };
 
-  // Filter out tools that already have permissions
+  // Filter out tools that already have permissions (except when editing)
   const assignedToolIds = new Set(currentPermissions.map(p => p.serverId));
-  const unassignedTools = availableTools.filter(t => !assignedToolIds.has(t.id));
+  const unassignedTools = availableTools.filter(t =>
+    !assignedToolIds.has(t.id) || (isEditMode && t.id === editingPermission.serverId)
+  );
 
   return (
     <PopShell
-      title="Manage Tool Permissions"
+      title={isEditMode ? "Edit Tool Permission" : "Manage Tool Permissions"}
       onCancel={onCancel}
       headerRight={
         <div onClick={onCancel}>
@@ -151,9 +166,9 @@ export function EditAgentToolPermissionsPop({
     >
       <div className="edit-agent-tool-permissions-pop__wrapper">
         <Stack spacing="4">
-          {/* Add new tool */}
+          {/* Add/Edit tool */}
           <div>
-            <Text size="3" weight="medium">Add Tool Permission</Text>
+            <Text size="3" weight="medium">{isEditMode ? "Edit Tool Permission" : "Add Tool Permission"}</Text>
             <Stack spacing="2">
               {loadingTools ? (
                 <Text size="2" tone="muted">Loading available tools...</Text>
@@ -165,6 +180,7 @@ export function EditAgentToolPermissionsPop({
                     className="edit-agent-tool-permissions-pop__select"
                     value={selectedToolId}
                     onChange={(e) => setSelectedToolId(e.target.value)}
+                    disabled={isEditMode}
                   >
                     <option value="">Select a tool...</option>
                     {unassignedTools.map(tool => (
@@ -222,7 +238,7 @@ export function EditAgentToolPermissionsPop({
                       onClick={handleAddPermission}
                       disabled={isSaving || (isHttpTool && selectedScopes.size === 0)}
                     >
-                      {isSaving ? 'Adding...' : 'Add Permission'}
+                      {isSaving ? (isEditMode ? 'Saving...' : 'Adding...') : (isEditMode ? 'Save Changes' : 'Add Permission')}
                     </Button>
                   )}
                 </>

--- a/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.tsx
+++ b/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.tsx
@@ -1,0 +1,236 @@
+import React, { useState, useEffect } from "react";
+import { PopShell } from "../../app/shells/PopShell";
+import { Text, Stack, Button, Chip } from "../../ui/primitives";
+import { ToolsService, AgentToolPermissionsService } from "./api";
+import type { ServerResponseDto, ScopeResponseDto } from "@taico/client/v2";
+import "./EditAgentToolPermissionsPop.css";
+
+type ToolPermission = {
+  serverId: string;
+  serverName: string;
+  serverProvidedId: string;
+  serverType: 'http' | 'stdio';
+  scopeIds: string[];
+  availableScopes: Array<{ id: string; description: string }>;
+  hasAllScopes: boolean;
+};
+
+type EditAgentToolPermissionsPopProps = {
+  agentActorId: string;
+  currentPermissions: ToolPermission[];
+  onCancel?: () => void;
+  onSave: () => Promise<void>;
+};
+
+export function EditAgentToolPermissionsPop({
+  agentActorId,
+  currentPermissions,
+  onCancel,
+  onSave,
+}: EditAgentToolPermissionsPopProps) {
+  const [availableTools, setAvailableTools] = useState<ServerResponseDto[]>([]);
+  const [loadingTools, setLoadingTools] = useState(true);
+  const [selectedToolId, setSelectedToolId] = useState<string>('');
+  const [availableScopes, setAvailableScopes] = useState<ScopeResponseDto[]>([]);
+  const [loadingScopes, setLoadingScopes] = useState(false);
+  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
+  const [selectAllScopes, setSelectAllScopes] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Load available tools
+  useEffect(() => {
+    const loadTools = async () => {
+      setLoadingTools(true);
+      try {
+        const result = await ToolsService.McpRegistryController_listServers({});
+        setAvailableTools(result.items);
+      } catch (err) {
+        console.error('Failed to load tools:', err);
+      } finally {
+        setLoadingTools(false);
+      }
+    };
+    loadTools();
+  }, []);
+
+  const selectedTool = availableTools.find(t => t.id === selectedToolId);
+  const isHttpTool = selectedTool?.type === 'http';
+
+  // Load scopes when tool is selected
+  useEffect(() => {
+    if (selectedToolId && isHttpTool) {
+      setLoadingScopes(true);
+      ToolsService.McpRegistryController_listScopes({ serverId: selectedToolId })
+        .then(scopes => {
+          setAvailableScopes(scopes);
+        })
+        .catch(err => {
+          console.error('Failed to load scopes:', err);
+          setAvailableScopes([]);
+        })
+        .finally(() => {
+          setLoadingScopes(false);
+        });
+    } else {
+      setAvailableScopes([]);
+    }
+    setSelectedScopes(new Set());
+    setSelectAllScopes(false);
+  }, [selectedToolId, isHttpTool]);
+
+  // Handle "All scopes" toggle
+  const handleAllScopesToggle = () => {
+    const newValue = !selectAllScopes;
+    setSelectAllScopes(newValue);
+    if (newValue) {
+      setSelectedScopes(new Set(availableScopes.map((s: ScopeResponseDto) => s.id)));
+    } else {
+      setSelectedScopes(new Set());
+    }
+  };
+
+  // Toggle individual scope
+  const toggleScope = (scopeId: string) => {
+    setSelectedScopes((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(scopeId)) {
+        newSet.delete(scopeId);
+      } else {
+        newSet.add(scopeId);
+      }
+      // Update "all scopes" checkbox state
+      const allSelected = availableScopes.length > 0 && availableScopes.every((s: ScopeResponseDto) => newSet.has(s.id));
+      setSelectAllScopes(allSelected);
+      return newSet;
+    });
+  };
+
+  const handleAddPermission = async () => {
+    if (!selectedToolId) return;
+
+    setIsSaving(true);
+    try {
+      await AgentToolPermissionsService.AgentToolPermissionsController_upsertAgentToolPermission({
+        actorId: agentActorId,
+        serverId: selectedToolId,
+        body: {
+          scopeIds: Array.from(selectedScopes),
+        },
+      });
+
+      // Reset form
+      setSelectedToolId('');
+      setSelectedScopes(new Set());
+      setSelectAllScopes(false);
+
+      // Refresh parent
+      await onSave();
+    } catch (err) {
+      console.error('Failed to add permission:', err);
+      alert('Failed to add tool permission');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  // Filter out tools that already have permissions
+  const assignedToolIds = new Set(currentPermissions.map(p => p.serverId));
+  const unassignedTools = availableTools.filter(t => !assignedToolIds.has(t.id));
+
+  return (
+    <PopShell
+      title="Manage Tool Permissions"
+      onCancel={onCancel}
+      headerRight={
+        <div onClick={onCancel}>
+          <Text size="4" weight="normal" className="pop-shell__main-title-button">
+            close
+          </Text>
+        </div>
+      }
+    >
+      <div className="edit-agent-tool-permissions-pop__wrapper">
+        <Stack spacing="4">
+          {/* Add new tool */}
+          <div>
+            <Text size="3" weight="medium">Add Tool Permission</Text>
+            <Stack spacing="2">
+              {loadingTools ? (
+                <Text size="2" tone="muted">Loading available tools...</Text>
+              ) : unassignedTools.length === 0 ? (
+                <Text size="2" tone="muted">All available tools already assigned</Text>
+              ) : (
+                <>
+                  <select
+                    className="edit-agent-tool-permissions-pop__select"
+                    value={selectedToolId}
+                    onChange={(e) => setSelectedToolId(e.target.value)}
+                  >
+                    <option value="">Select a tool...</option>
+                    {unassignedTools.map(tool => (
+                      <option key={tool.id} value={tool.id}>
+                        {tool.name} ({tool.type})
+                      </option>
+                    ))}
+                  </select>
+
+                  {/* Scope selection for HTTP tools */}
+                  {selectedToolId && isHttpTool && availableScopes.length > 0 && (
+                    <div className="edit-agent-tool-permissions-pop__scopes">
+                      <Text size="2" weight="medium">Select Scopes</Text>
+
+                      {/* All scopes shortcut */}
+                      <label className="edit-agent-tool-permissions-pop__scope-item">
+                        <input
+                          type="checkbox"
+                          checked={selectAllScopes}
+                          onChange={handleAllScopesToggle}
+                        />
+                        <div className="edit-agent-tool-permissions-pop__scope-info">
+                          <Text size="2" weight="medium">All scopes</Text>
+                          <Text size="1" tone="muted">Grant all available scopes</Text>
+                        </div>
+                      </label>
+
+                      {/* Individual scopes */}
+                      {availableScopes.map((scope: ScopeResponseDto) => (
+                        <label key={scope.id} className="edit-agent-tool-permissions-pop__scope-item">
+                          <input
+                            type="checkbox"
+                            checked={selectedScopes.has(scope.id)}
+                            onChange={() => toggleScope(scope.id)}
+                          />
+                          <div className="edit-agent-tool-permissions-pop__scope-info">
+                            <Text size="2" weight="medium" style="mono">{scope.id}</Text>
+                            <Text size="1" tone="muted">{scope.description}</Text>
+                          </div>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Info for STDIO tools */}
+                  {selectedToolId && !isHttpTool && (
+                    <Text size="2" tone="muted">
+                      This STDIO tool does not require scope configuration.
+                    </Text>
+                  )}
+
+                  {selectedToolId && (
+                    <Button
+                      size="sm"
+                      onClick={handleAddPermission}
+                      disabled={isSaving || (isHttpTool && selectedScopes.size === 0)}
+                    >
+                      {isSaving ? 'Adding...' : 'Add Permission'}
+                    </Button>
+                  )}
+                </>
+              )}
+            </Stack>
+          </div>
+        </Stack>
+      </div>
+    </PopShell>
+  );
+}

--- a/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.tsx
+++ b/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { PopShell } from "../../app/shells/PopShell";
-import { Text, Stack, Button, Chip } from "../../ui/primitives";
+import { Avatar, Text, Stack, Button } from "../../ui/primitives";
 import { ToolsService, AgentToolPermissionsService } from "./api";
 import type { ServerResponseDto, ScopeResponseDto } from "@taico/client/v2";
+import "../actors/ActorSearchPop.css";
 import "./EditAgentToolPermissionsPop.css";
 
 type ToolPermission = {
@@ -21,6 +22,15 @@ type EditAgentToolPermissionsPopProps = {
   onCancel?: () => void;
   onSave: () => Promise<void>;
   editingPermission?: ToolPermission | null;
+  onDelete?: () => Promise<void>;
+  fixedTool?: {
+    serverId: string;
+    serverName: string;
+    serverProvidedId: string;
+    serverType: 'http' | 'stdio';
+  } | null;
+  title?: string;
+  saveLabel?: string;
 };
 
 export function EditAgentToolPermissionsPop({
@@ -29,10 +39,16 @@ export function EditAgentToolPermissionsPop({
   onCancel,
   onSave,
   editingPermission = null,
+  onDelete,
+  fixedTool = null,
+  title,
+  saveLabel,
 }: EditAgentToolPermissionsPopProps) {
   const [availableTools, setAvailableTools] = useState<ServerResponseDto[]>([]);
   const [loadingTools, setLoadingTools] = useState(true);
-  const [selectedToolId, setSelectedToolId] = useState<string>(editingPermission?.serverId || '');
+  const [query, setQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [selectedToolId, setSelectedToolId] = useState<string>(fixedTool?.serverId || editingPermission?.serverId || '');
   const [availableScopes, setAvailableScopes] = useState<ScopeResponseDto[]>([]);
   const [loadingScopes, setLoadingScopes] = useState(false);
   const [selectedScopes, setSelectedScopes] = useState<Set<string>>(
@@ -41,6 +57,9 @@ export function EditAgentToolPermissionsPop({
   const [selectAllScopes, setSelectAllScopes] = useState(editingPermission?.hasAllScopes || false);
   const [isSaving, setIsSaving] = useState(false);
   const isEditMode = !!editingPermission;
+  const isFixedToolMode = !!fixedTool;
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   // Load available tools
   useEffect(() => {
@@ -60,6 +79,48 @@ export function EditAgentToolPermissionsPop({
 
   const selectedTool = availableTools.find(t => t.id === selectedToolId);
   const isHttpTool = selectedTool?.type === 'http';
+  const requiresScopeSelection = Boolean(isHttpTool && availableScopes.length > 0);
+  const assignedToolIds = new Set(currentPermissions.map(p => p.serverId));
+  const unassignedTools = availableTools.filter(t =>
+    !assignedToolIds.has(t.id) || (isEditMode && editingPermission && t.id === editingPermission.serverId)
+  );
+  const filteredTools = useMemo(() => {
+    if (isEditMode || isFixedToolMode) {
+      return unassignedTools;
+    }
+
+    const trimmedQuery = query.trim().toLowerCase();
+    if (!trimmedQuery) {
+      return unassignedTools;
+    }
+
+    return unassignedTools.filter((tool) => {
+      return (
+        tool.name.toLowerCase().includes(trimmedQuery) ||
+        tool.type.toLowerCase().includes(trimmedQuery) ||
+        tool.description.toLowerCase().includes(trimmedQuery)
+      );
+    });
+  }, [isEditMode, isFixedToolMode, query, unassignedTools]);
+
+  useEffect(() => {
+    if (!isEditMode && !isFixedToolMode) {
+      inputRef.current?.focus();
+    }
+  }, [isEditMode, isFixedToolMode]);
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [filteredTools.length, query]);
+
+  useEffect(() => {
+    if (!listRef.current || isEditMode || isFixedToolMode) {
+      return;
+    }
+
+    const highlightedEl = listRef.current.children[highlightedIndex] as HTMLElement | undefined;
+    highlightedEl?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex, isEditMode, isFixedToolMode]);
 
   // Load scopes when tool is selected
   useEffect(() => {
@@ -84,12 +145,12 @@ export function EditAgentToolPermissionsPop({
     } else {
       setAvailableScopes([]);
       // Only reset scopes if not in edit mode
-      if (!isEditMode) {
+      if (!isEditMode && !isFixedToolMode) {
         setSelectedScopes(new Set());
         setSelectAllScopes(false);
       }
     }
-  }, [selectedToolId, isHttpTool, editingPermission, isEditMode]);
+  }, [selectedToolId, isHttpTool, editingPermission, isEditMode, isFixedToolMode]);
 
   // Handle "All scopes" toggle
   const handleAllScopesToggle = () => {
@@ -118,8 +179,10 @@ export function EditAgentToolPermissionsPop({
     });
   };
 
-  const handleAddPermission = async () => {
-    if (!selectedToolId) return;
+  const handleAddPermission = useCallback(async (): Promise<boolean> => {
+    if (!selectedToolId) {
+      return false;
+    }
 
     setIsSaving(true);
     try {
@@ -132,119 +195,185 @@ export function EditAgentToolPermissionsPop({
       });
 
       // Reset form
-      setSelectedToolId('');
+      if (!isFixedToolMode && !isEditMode) {
+        setSelectedToolId('');
+      }
       setSelectedScopes(new Set());
       setSelectAllScopes(false);
 
       // Refresh parent
       await onSave();
+      return true;
     } catch (err) {
       console.error('Failed to add permission:', err);
       alert('Failed to add tool permission');
+      return false;
     } finally {
       setIsSaving(false);
     }
-  };
+  }, [agentActorId, isEditMode, isFixedToolMode, onSave, requiresScopeSelection, selectedScopes, selectedToolId]);
 
-  // Filter out tools that already have permissions (except when editing)
-  const assignedToolIds = new Set(currentPermissions.map(p => p.serverId));
-  const unassignedTools = availableTools.filter(t =>
-    !assignedToolIds.has(t.id) || (isEditMode && t.id === editingPermission.serverId)
-  );
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing || filteredTools.length === 0) {
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        setHighlightedIndex((prev) => (prev < filteredTools.length - 1 ? prev + 1 : prev));
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+        break;
+      case 'Enter':
+        event.preventDefault();
+        setSelectedToolId(filteredTools[highlightedIndex]?.id ?? '');
+        break;
+    }
+  }, [filteredTools, highlightedIndex]);
 
   return (
     <PopShell
-      title={isEditMode ? "Edit Tool Permission" : "Manage Tool Permissions"}
+      title={title ?? (isEditMode ? "Edit Tool Permission" : "Select Scopes")}
       onCancel={onCancel}
-      headerRight={
-        <div onClick={onCancel}>
+      onSave={handleAddPermission}
+      headerRight={saveLabel ? (
+        <div
+          onClick={() => {
+            void handleAddPermission();
+          }}
+          style={{ opacity: isSaving ? 0.5 : 1, pointerEvents: isSaving ? "none" : "auto" }}
+        >
           <Text size="4" weight="normal" className="pop-shell__main-title-button">
-            close
+            {isSaving ? "saving" : saveLabel}
           </Text>
         </div>
-      }
+      ) : undefined}
     >
-      <div className="edit-agent-tool-permissions-pop__wrapper">
-        <Stack spacing="4">
-          {/* Add/Edit tool */}
-          <div>
-            <Text size="3" weight="medium">{isEditMode ? "Edit Tool Permission" : "Add Tool Permission"}</Text>
-            <Stack spacing="2">
-              {loadingTools ? (
-                <Text size="2" tone="muted">Loading available tools...</Text>
-              ) : unassignedTools.length === 0 ? (
-                <Text size="2" tone="muted">All available tools already assigned</Text>
-              ) : (
+      <div className="actor-search-pop">
+        <Stack spacing="2">
+          {loadingTools ? (
+            <Text size="2" tone="muted">Loading available tools...</Text>
+          ) : unassignedTools.length === 0 ? (
+            <Text size="2" tone="muted">All available tools already assigned</Text>
+          ) : (
+            <>
+              {!isEditMode && !isFixedToolMode ? (
                 <>
-                  <select
-                    className="edit-agent-tool-permissions-pop__select"
-                    value={selectedToolId}
-                    onChange={(e) => setSelectedToolId(e.target.value)}
-                    disabled={isEditMode}
-                  >
-                    <option value="">Select a tool...</option>
-                    {unassignedTools.map(tool => (
-                      <option key={tool.id} value={tool.id}>
-                        {tool.name} ({tool.type})
-                      </option>
-                    ))}
-                  </select>
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    className="actor-search-pop__input"
+                    placeholder="Search tools..."
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                  />
 
-                  {/* Scope selection for HTTP tools */}
-                  {selectedToolId && isHttpTool && availableScopes.length > 0 && (
-                    <div className="edit-agent-tool-permissions-pop__scopes">
-                      <Text size="2" weight="medium">Select Scopes</Text>
+                  <div className="actor-search-pop__list" ref={listRef} role="listbox" aria-label="Tools">
+                    {filteredTools.length === 0 ? (
+                      <div className="actor-search-pop__empty">
+                        <Text tone="muted" size="2">No tools found</Text>
+                      </div>
+                    ) : (
+                      filteredTools.map((tool, index) => {
+                        const isHighlighted = index === highlightedIndex;
+                        const isSelected = tool.id === selectedToolId;
 
-                      {/* All scopes shortcut */}
-                      <label className="edit-agent-tool-permissions-pop__scope-item">
-                        <input
-                          type="checkbox"
-                          checked={selectAllScopes}
-                          onChange={handleAllScopesToggle}
-                        />
-                        <div className="edit-agent-tool-permissions-pop__scope-info">
-                          <Text size="2" weight="medium">All scopes</Text>
-                          <Text size="1" tone="muted">Grant all available scopes</Text>
-                        </div>
-                      </label>
-
-                      {/* Individual scopes */}
-                      {availableScopes.map((scope: ScopeResponseDto) => (
-                        <label key={scope.id} className="edit-agent-tool-permissions-pop__scope-item">
-                          <input
-                            type="checkbox"
-                            checked={selectedScopes.has(scope.id)}
-                            onChange={() => toggleScope(scope.id)}
-                          />
-                          <div className="edit-agent-tool-permissions-pop__scope-info">
-                            <Text size="2" weight="medium" style="mono">{scope.id}</Text>
-                            <Text size="1" tone="muted">{scope.description}</Text>
-                          </div>
-                        </label>
-                      ))}
-                    </div>
-                  )}
-
-                  {/* Info for STDIO tools */}
-                  {selectedToolId && !isHttpTool && (
-                    <Text size="2" tone="muted">
-                      This STDIO tool does not require scope configuration.
-                    </Text>
-                  )}
-
-                  {selectedToolId && (
-                    <Button
-                      size="sm"
-                      onClick={handleAddPermission}
-                      disabled={isSaving || (isHttpTool && selectedScopes.size === 0)}
-                    >
-                      {isSaving ? (isEditMode ? 'Saving...' : 'Adding...') : (isEditMode ? 'Save Changes' : 'Add Permission')}
-                    </Button>
-                  )}
+                        return (
+                          <button
+                            key={tool.id}
+                            type="button"
+                            role="option"
+                            aria-selected={isSelected}
+                            className={`actor-search-pop__item ${(isHighlighted || isSelected) ? 'actor-search-pop__item--highlighted' : ''}`}
+                            onClick={() => {
+                              setSelectedToolId(tool.id);
+                              setHighlightedIndex(index);
+                            }}
+                            onMouseEnter={() => setHighlightedIndex(index)}
+                            disabled={isSaving}
+                          >
+                            <Avatar name={tool.name} size="sm" />
+                            <div className="actor-search-pop__item-info">
+                              <Text weight="medium" size="2">{tool.name}</Text>
+                              <Text tone="muted" size="1">@{tool.providedId} · {tool.type}</Text>
+                            </div>
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
                 </>
+              ) : (
+                <div className="edit-agent-tool-permissions-pop__selected-tool">
+                  <Text size="2" weight="medium">{selectedTool?.name ?? fixedTool?.serverName ?? editingPermission?.serverName}</Text>
+                  <Text size="1" tone="muted">{selectedTool?.description ?? 'Update the scopes for this tool.'}</Text>
+                </div>
               )}
-            </Stack>
-          </div>
+
+              {/* Scope selection for HTTP tools */}
+              {selectedToolId && isHttpTool && availableScopes.length > 0 && (
+                <div className="edit-agent-tool-permissions-pop__scopes">
+                  <Text size="2" weight="medium">Select Scopes</Text>
+
+                  <label className="edit-agent-tool-permissions-pop__scope-item">
+                    <input
+                      type="checkbox"
+                      checked={selectAllScopes}
+                      onChange={handleAllScopesToggle}
+                    />
+                    <div className="edit-agent-tool-permissions-pop__scope-info">
+                      <Text size="2" weight="medium">All scopes</Text>
+                      <Text size="1" tone="muted">Grant all available scopes</Text>
+                    </div>
+                  </label>
+
+                  {availableScopes.map((scope: ScopeResponseDto) => (
+                    <label key={scope.id} className="edit-agent-tool-permissions-pop__scope-item">
+                      <input
+                        type="checkbox"
+                        checked={selectedScopes.has(scope.id)}
+                        onChange={() => toggleScope(scope.id)}
+                      />
+                      <div className="edit-agent-tool-permissions-pop__scope-info">
+                        <Text size="2" weight="medium" style="mono">{scope.id}</Text>
+                        <Text size="1" tone="muted">{scope.description}</Text>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              )}
+
+              {selectedToolId && isHttpTool && availableScopes.length === 0 && !loadingScopes && (
+                <Text size="2" tone="muted">
+                  This HTTP tool does not define scopes. Access will be granted without scope selection.
+                </Text>
+              )}
+
+              {selectedToolId && !isHttpTool && (
+                <Text size="2" tone="muted">
+                  This STDIO tool does not require scope configuration.
+                </Text>
+              )}
+
+              {selectedToolId && isEditMode && onDelete && (
+                <Stack spacing="2">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => {
+                      void onDelete();
+                    }}
+                  >
+                    Remove Tool
+                  </Button>
+                </Stack>
+              )}
+            </>
+          )}
         </Stack>
       </div>
     </PopShell>

--- a/apps/ui2/src/features/agents/api.ts
+++ b/apps/ui2/src/features/agents/api.ts
@@ -11,13 +11,17 @@ const client = new ApiClient({
 // Export resources needed by the agents feature
 export const AgentsService = client.agent;
 export const AgentTokensService = client.agentTokens;
+export const AgentToolPermissionsService = client.agent; // Tool permissions methods are on the agent resource
 export const AuthorizationServerService = client.authorizationServer;
 export const MetaService = client.meta;
+export const ToolsService = client.tools;
 
 // Export API client for easier access to all endpoints
 export const api = {
   agent: client.agent,
   tokens: client.agentTokens,
+  toolPermissions: client.agent, // Tool permissions methods are on the agent resource
   authorizationServer: client.authorizationServer,
   meta: client.meta,
+  tools: client.tools,
 };

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -4455,9 +4455,7 @@
             "name": "serverId",
             "required": true,
             "in": "path",
-            "description": "MCP server UUID used by this assignment",
             "schema": {
-              "example": "123e4567-e89b-12d3-a456-426614174000",
               "type": "string"
             }
           }

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -8752,7 +8752,6 @@ export interface operations {
             header?: never;
             path: {
                 actorId: string;
-                /** @description MCP server UUID used by this assignment */
                 serverId: string;
             };
             cookie?: never;

--- a/packages/client/src/v1/client/services/AgentService.ts
+++ b/packages/client/src/v1/client/services/AgentService.ts
@@ -133,7 +133,7 @@ export class AgentService {
     /**
      * Create or replace an agent tool permission assignment
      * @param actorId
-     * @param serverId MCP server UUID used by this assignment
+     * @param serverId
      * @param requestBody
      * @returns AgentToolPermissionResponseDto
      * @throws ApiError


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the agent tool permissions project, adding a complete permissions management experience to the agent detail page in `ui2`. The new UI is powered by the backend APIs added in Phase 1 (#822).

### What's Changed

- **New Component**: `EditAgentToolPermissionsPop` - Pop-up for managing tool permissions with scope selection, inspired by the tools feature's `EditToolScopesPop`
- **Redesigned Permissions Section**: Agent detail page now shows:
  - Core system tools (Tasks/Context) displayed separately at the top with "System Tool" badges
  - Additional tools shown below with full add/edit/remove functionality
  - Clear visual distinction between different tool types
- **Scope Management**:
  - For HTTP tools with scopes: shows granted vs available scopes with individual selection
  - "All scopes" toggle for quickly granting all available scopes
  - For STDIO tools: displays "No scopes required" clearly
- **Responsive Design**:
  - Mobile-friendly stacked layout
  - Improved desktop experience with intentional grid layouts
  - Uses token-based styling and existing ui2 primitives throughout

### Technical Details

- Permissions are kept decoupled from the core agent DTO flow (loaded separately via `/agents/:actorId/tool-permissions`)
- All styling follows `ui2` token-based patterns from `tokens.css`
- Reused established primitives: `DataRow`, `DataRowContainer`, `Chip`, `Icon`, `Pop`, etc.
- TypeScript compilation validated with `npm run build:dev`
- App startup validated with `npm run dev:3`

### What's Next

Runtime behavior is still unchanged - agents continue to use the `allowedTools` array. Phase 3 will update the runtime to derive permissions from the new model and clean up the deprecated field.

### Dependencies

- Depends on: #822 (Phase 1 backend APIs - merged)
- Blocks: Phase 3 runtime implementation

🤖 Generated with Claude Code