### PR TITLE
Use mobile-safe font size in context block editor on mobile

### DIFF
--- a/apps/ui2/src/features/context/ContextBlockCreatePage.css
+++ b/apps/ui2/src/features/context/ContextBlockCreatePage.css
@@ -120,6 +120,10 @@
     padding: var(--space-3);
   }
 
+  .context-block-create__editor {
+    font-size: var(--fs-input-mobile-safe);
+  }
+
   .context-block-create__title-input {
     font-size: clamp(1.5rem, 6vw, 2rem);
   }


### PR DESCRIPTION
## Summary
- apply `--fs-input-mobile-safe` to the context block markdown editor textarea in create/edit mode on mobile breakpoints
- keep desktop typography unchanged by scoping the change to the existing mobile media query in `ContextBlockCreatePage.css`
- this prevents iOS input zoom when editing/creating context block content

## Validation
- `npm run build:dev` ✅
- `npm run dev:1` ⚠️ backend started successfully; `apps/ui` and `apps/ui2` Vite watchers hit `ENOSPC` (file watcher limit in environment)

## Technical debt
- Dev startup currently depends on host watcher limits; consider documenting or hardening fallback watcher configuration for constrained environments.