### PR TITLE
Derive runtime MCP mounts and execution scopes from tool permissions

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -10314,6 +10314,27 @@
               "stdio"
             ],
             "example": "http"
+          },
+          "url": {
+            "type": "string",
+            "description": "HTTP endpoint for servers with http transport",
+            "example": "https://example.com/mcp"
+          },
+          "cmd": {
+            "type": "string",
+            "description": "Command for servers with stdio transport",
+            "example": "npx"
+          },
+          "args": {
+            "description": "Command arguments for servers with stdio transport",
+            "example": [
+              "-y",
+              "@taico/example-mcp"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -10572,7 +10593,7 @@
         "type": "object",
         "properties": {
           "scopes": {
-            "description": "Scopes to grant to the short-lived execution token.",
+            "description": "Scopes to grant to the short-lived execution token. When omitted, scopes are derived from baseline system access plus assigned tool permissions.",
             "example": [
               "tasks:read",
               "tasks:write"
@@ -10589,10 +10610,7 @@
             "minimum": 1,
             "maximum": 3600
           }
-        },
-        "required": [
-          "scopes"
-        ]
+        }
       },
       "AgentExecutionTokenResponseDto": {
         "type": "object",

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -10314,27 +10314,6 @@
               "stdio"
             ],
             "example": "http"
-          },
-          "url": {
-            "type": "string",
-            "description": "HTTP endpoint for servers with http transport",
-            "example": "https://example.com/mcp"
-          },
-          "cmd": {
-            "type": "string",
-            "description": "Command for servers with stdio transport",
-            "example": "npx"
-          },
-          "args": {
-            "description": "Command arguments for servers with stdio transport",
-            "example": [
-              "-y",
-              "@taico/example-mcp"
-            ],
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           }
         },
         "required": [
@@ -10370,13 +10349,6 @@
           "server": {
             "$ref": "#/components/schemas/AgentToolPermissionServerResponseDto"
           },
-          "availableScopes": {
-            "description": "All scopes currently available on this MCP server",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AgentToolPermissionScopeResponseDto"
-            }
-          },
           "grantedScopes": {
             "description": "Subset of scopes granted to this agent for this server",
             "type": "array",
@@ -10392,7 +10364,6 @@
         },
         "required": [
           "server",
-          "availableScopes",
           "grantedScopes",
           "hasAllScopes"
         ]

--- a/apps/backend/src/agents/agent-execution-tokens.controller.ts
+++ b/apps/backend/src/agents/agent-execution-tokens.controller.ts
@@ -17,6 +17,9 @@ import { ActorService } from '../identity-provider/actor.service';
 import { IssuedAccessTokenService } from '../authorization-server/issued-access-token.service';
 import { AgentExecutionTokenResponseDto } from './dto/agent-execution-token-response.dto';
 import { RequestAgentExecutionTokenDto } from './dto/request-agent-execution-token.dto';
+import { AgentToolPermissionsService } from './agent-tool-permissions.service';
+import { deriveExecutionScopesFromToolPermissions } from '@taico/shared';
+import { AgentToolPermissionRecord } from './dto/service/agent-tool-permissions.service.types';
 
 @ApiTags('Agent Execution Tokens')
 @ApiCookieAuth('JWT-Cookie')
@@ -28,6 +31,7 @@ export class AgentExecutionTokensController {
     private readonly agentsService: AgentsService,
     private readonly actorService: ActorService,
     private readonly issuedAccessTokenService: IssuedAccessTokenService,
+    private readonly agentToolPermissionsService: AgentToolPermissionsService,
   ) {}
 
   @Post()
@@ -56,19 +60,48 @@ export class AgentExecutionTokensController {
       );
     }
 
+    const scopes =
+      dto.scopes && dto.scopes.length > 0
+        ? dto.scopes
+        : deriveExecutionScopesFromToolPermissions(
+            (
+              await this.agentToolPermissionsService.listAgentToolPermissions(
+                agent.actorId,
+              )
+            ).map((permission) => this.toRuntimePermission(permission)),
+          );
+
     const issuedToken = await this.issuedAccessTokenService.issueSystemToken({
       subjectActor,
       issuedByActor,
-      scopes: dto.scopes,
+      scopes,
       expirationSeconds: dto.expirationSeconds,
     });
 
     return {
       token: issuedToken.token,
-      scopes: dto.scopes,
+      scopes,
       expiresAt: issuedToken.expiresAt.toISOString(),
       agentSlug: subjectActor.slug,
       requestedByClientId: auth.claims.client_id,
+    };
+  }
+
+  private toRuntimePermission(permission: AgentToolPermissionRecord): {
+    server: { providedId: string };
+    availableScopes: { id: string }[];
+    grantedScopes: { id: string }[];
+  } {
+    return {
+      server: {
+        providedId: permission.serverProvidedId,
+      },
+      availableScopes: permission.availableScopes.map((scope) => ({
+        id: scope.id,
+      })),
+      grantedScopes: permission.grantedScopes.map((scope) => ({
+        id: scope.id,
+      })),
     };
   }
 }

--- a/apps/backend/src/agents/agent-execution-tokens.controller.ts
+++ b/apps/backend/src/agents/agent-execution-tokens.controller.ts
@@ -89,16 +89,12 @@ export class AgentExecutionTokensController {
 
   private toRuntimePermission(permission: AgentToolPermissionRecord): {
     server: { providedId: string };
-    availableScopes: { id: string }[];
     grantedScopes: { id: string }[];
   } {
     return {
       server: {
         providedId: permission.serverProvidedId,
       },
-      availableScopes: permission.availableScopes.map((scope) => ({
-        id: scope.id,
-      })),
       grantedScopes: permission.grantedScopes.map((scope) => ({
         id: scope.id,
       })),

--- a/apps/backend/src/agents/agent-tool-permissions.service.ts
+++ b/apps/backend/src/agents/agent-tool-permissions.service.ts
@@ -132,13 +132,6 @@ export class AgentToolPermissionsService {
       serverName: server.name,
       serverDescription: server.description,
       serverType: server.type,
-      serverUrl: server.url,
-      serverCommand: server.cmd,
-      serverArgs: server.args ?? undefined,
-      availableScopes: availableScopes.map((scope) => ({
-        id: scope.id,
-        description: scope.description,
-      })),
       grantedScopes: normalizedScopeIds.map((scopeId) => {
         const scope = scopeById.get(scopeId);
         return {
@@ -209,10 +202,6 @@ export class AgentToolPermissionsService {
       serverName: permission.server.name,
       serverDescription: permission.server.description,
       serverType: permission.server.type,
-      serverUrl: permission.server.url,
-      serverCommand: permission.server.cmd,
-      serverArgs: permission.server.args ?? undefined,
-      availableScopes,
       grantedScopes,
       hasAllScopes:
         availableScopes.length > 0 && grantedScopes.length === availableScopes.length,
@@ -233,10 +222,6 @@ export class AgentToolPermissionsService {
       serverName: server.name,
       serverDescription: server.description,
       serverType: server.type,
-      serverUrl: server.url,
-      serverCommand: server.cmd,
-      serverArgs: server.args ?? undefined,
-      availableScopes,
       grantedScopes: availableScopes,
       hasAllScopes: true,
     };

--- a/apps/backend/src/agents/agent-tool-permissions.service.ts
+++ b/apps/backend/src/agents/agent-tool-permissions.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { AgentEntity } from './agent.entity';
 import { AgentNotFoundError } from './errors/agents.errors';
 import { McpServerEntity } from '../mcp-registry/entities/mcp-server.entity';
@@ -16,6 +16,7 @@ import {
   AgentToolPermissionNotFoundError,
   InvalidAgentToolPermissionScopeError,
 } from './errors/agents.errors';
+import { BASELINE_SYSTEM_TOOL_PROVIDED_IDS } from '@taico/shared';
 
 @Injectable()
 export class AgentToolPermissionsService {
@@ -41,13 +42,35 @@ export class AgentToolPermissionsService {
       },
     });
 
-    return permissions
+    const explicitPermissions = permissions
       .filter(
         (permission): permission is AgentToolPermissionEntity & {
           server: McpServerEntity;
         } => Boolean(permission.server),
       )
       .map((permission) => this.mapPermissionToRecord(permission));
+
+    const permissionsByProvidedId = new Map(
+      explicitPermissions.map((permission) => [permission.serverProvidedId, permission]),
+    );
+
+    const baselineServers = await this.serverRepository.find({
+      where: {
+        providedId: In([...BASELINE_SYSTEM_TOOL_PROVIDED_IDS]),
+      },
+      relations: ['scopes'],
+    });
+
+    for (const baselineServer of baselineServers) {
+      permissionsByProvidedId.set(
+        baselineServer.providedId,
+        this.mapBaselineServerToRecord(baselineServer),
+      );
+    }
+
+    return [...permissionsByProvidedId.values()].sort((a, b) =>
+      a.serverName.localeCompare(b.serverName),
+    );
   }
 
   async upsertAgentToolPermission(
@@ -109,6 +132,9 @@ export class AgentToolPermissionsService {
       serverName: server.name,
       serverDescription: server.description,
       serverType: server.type,
+      serverUrl: server.url,
+      serverCommand: server.cmd,
+      serverArgs: server.args ?? undefined,
       availableScopes: availableScopes.map((scope) => ({
         id: scope.id,
         description: scope.description,
@@ -183,10 +209,36 @@ export class AgentToolPermissionsService {
       serverName: permission.server.name,
       serverDescription: permission.server.description,
       serverType: permission.server.type,
+      serverUrl: permission.server.url,
+      serverCommand: permission.server.cmd,
+      serverArgs: permission.server.args ?? undefined,
       availableScopes,
       grantedScopes,
       hasAllScopes:
         availableScopes.length > 0 && grantedScopes.length === availableScopes.length,
+    };
+  }
+
+  private mapBaselineServerToRecord(server: McpServerEntity): AgentToolPermissionRecord {
+    const availableScopes: AgentToolPermissionScopeRecord[] = (server.scopes ?? [])
+      .map((scope) => ({
+        id: scope.id,
+        description: scope.description,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+
+    return {
+      serverId: server.id,
+      serverProvidedId: server.providedId,
+      serverName: server.name,
+      serverDescription: server.description,
+      serverType: server.type,
+      serverUrl: server.url,
+      serverCommand: server.cmd,
+      serverArgs: server.args ?? undefined,
+      availableScopes,
+      grantedScopes: availableScopes,
+      hasAllScopes: true,
     };
   }
 }

--- a/apps/backend/src/agents/dto/agent-tool-permission-response.dto.ts
+++ b/apps/backend/src/agents/dto/agent-tool-permission-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { MCP_SERVER_TYPES } from '../../mcp-registry/mcp-server.types';
 import type {
   AgentToolPermissionRecord,
@@ -59,6 +59,25 @@ class AgentToolPermissionServerResponseDto {
     example: 'http',
   })
   type!: string;
+
+  @ApiPropertyOptional({
+    description: 'HTTP endpoint for servers with http transport',
+    example: 'https://example.com/mcp',
+  })
+  url?: string;
+
+  @ApiPropertyOptional({
+    description: 'Command for servers with stdio transport',
+    example: 'npx',
+  })
+  cmd?: string;
+
+  @ApiPropertyOptional({
+    description: 'Command arguments for servers with stdio transport',
+    type: [String],
+    example: ['-y', '@taico/example-mcp'],
+  })
+  args?: string[];
 }
 
 export class AgentToolPermissionResponseDto {
@@ -92,6 +111,9 @@ export class AgentToolPermissionResponseDto {
         name: record.serverName,
         description: record.serverDescription,
         type: record.serverType,
+        url: record.serverUrl,
+        cmd: record.serverCommand,
+        args: record.serverArgs,
       },
       availableScopes: record.availableScopes.map((scope) =>
         AgentToolPermissionScopeResponseDto.fromRecord(scope),

--- a/apps/backend/src/agents/dto/agent-tool-permission-response.dto.ts
+++ b/apps/backend/src/agents/dto/agent-tool-permission-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { MCP_SERVER_TYPES } from '../../mcp-registry/mcp-server.types';
 import type {
   AgentToolPermissionRecord,
@@ -59,36 +59,11 @@ class AgentToolPermissionServerResponseDto {
     example: 'http',
   })
   type!: string;
-
-  @ApiPropertyOptional({
-    description: 'HTTP endpoint for servers with http transport',
-    example: 'https://example.com/mcp',
-  })
-  url?: string;
-
-  @ApiPropertyOptional({
-    description: 'Command for servers with stdio transport',
-    example: 'npx',
-  })
-  cmd?: string;
-
-  @ApiPropertyOptional({
-    description: 'Command arguments for servers with stdio transport',
-    type: [String],
-    example: ['-y', '@taico/example-mcp'],
-  })
-  args?: string[];
 }
 
 export class AgentToolPermissionResponseDto {
   @ApiProperty({ type: AgentToolPermissionServerResponseDto })
   server!: AgentToolPermissionServerResponseDto;
-
-  @ApiProperty({
-    description: 'All scopes currently available on this MCP server',
-    type: [AgentToolPermissionScopeResponseDto],
-  })
-  availableScopes!: AgentToolPermissionScopeResponseDto[];
 
   @ApiProperty({
     description: 'Subset of scopes granted to this agent for this server',
@@ -111,13 +86,7 @@ export class AgentToolPermissionResponseDto {
         name: record.serverName,
         description: record.serverDescription,
         type: record.serverType,
-        url: record.serverUrl,
-        cmd: record.serverCommand,
-        args: record.serverArgs,
       },
-      availableScopes: record.availableScopes.map((scope) =>
-        AgentToolPermissionScopeResponseDto.fromRecord(scope),
-      ),
       grantedScopes: record.grantedScopes.map((scope) =>
         AgentToolPermissionScopeResponseDto.fromRecord(scope),
       ),

--- a/apps/backend/src/agents/dto/request-agent-execution-token.dto.ts
+++ b/apps/backend/src/agents/dto/request-agent-execution-token.dto.ts
@@ -1,22 +1,17 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  IsArray,
-  IsInt,
-  IsOptional,
-  IsString,
-  Max,
-  Min,
-} from 'class-validator';
+import { IsArray, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 export class RequestAgentExecutionTokenDto {
-  @ApiProperty({
-    description: 'Scopes to grant to the short-lived execution token.',
+  @ApiPropertyOptional({
+    description:
+      'Scopes to grant to the short-lived execution token. When omitted, scopes are derived from baseline system access plus assigned tool permissions.',
     example: ['tasks:read', 'tasks:write'],
     type: [String],
   })
+  @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  scopes!: string[];
+  scopes?: string[];
 
   @ApiPropertyOptional({
     description:

--- a/apps/backend/src/agents/dto/service/agent-tool-permissions.service.types.ts
+++ b/apps/backend/src/agents/dto/service/agent-tool-permissions.service.types.ts
@@ -11,6 +11,9 @@ export type AgentToolPermissionRecord = {
   serverName: string;
   serverDescription: string;
   serverType: McpServerType;
+  serverUrl?: string;
+  serverCommand?: string;
+  serverArgs?: string[];
   availableScopes: AgentToolPermissionScopeRecord[];
   grantedScopes: AgentToolPermissionScopeRecord[];
   hasAllScopes: boolean;

--- a/apps/backend/src/agents/dto/service/agent-tool-permissions.service.types.ts
+++ b/apps/backend/src/agents/dto/service/agent-tool-permissions.service.types.ts
@@ -11,10 +11,6 @@ export type AgentToolPermissionRecord = {
   serverName: string;
   serverDescription: string;
   serverType: McpServerType;
-  serverUrl?: string;
-  serverCommand?: string;
-  serverArgs?: string[];
-  availableScopes: AgentToolPermissionScopeRecord[];
   grantedScopes: AgentToolPermissionScopeRecord[];
   hasAllScopes: boolean;
 };

--- a/apps/backend/src/worker/execution-orchestrator.ts
+++ b/apps/backend/src/worker/execution-orchestrator.ts
@@ -1,10 +1,12 @@
 import { RunAssignedWireEvent, StopRequestedWireEvent } from '@taico/events';
 import { prepareWorkspace } from './helpers/prepare-workspace';
 import { getSession, setSession } from './helpers/session-store';
+import { EXECUTION_ID_HEADER } from '../auth/guards/constants/headers.constants';
 import { ClaudeAgentRunner } from './runners/claude-agent-runner';
 import { OpencodeAgentRunner } from './runners/opencode-agent-runner';
-import { AgentRunner } from './runners/agent-runner.types';
+import { AgentRunner, RuntimeMcpServerConfig } from './runners/agent-runner.types';
 import { WorkerGatewayClient } from './worker-gateway-client';
+import { deriveAllowedToolsFromProvidedIds } from '@taico/shared';
 
 type ExecutionOrchestratorOptions = {
   serverUrl: string;
@@ -41,6 +43,25 @@ type AgentResponse = {
 
 type AgentListResponse = {
   items: AgentResponse[];
+};
+
+type AgentToolPermissionScopeResponse = {
+  id: string;
+  description: string;
+};
+
+type AgentToolPermissionResponse = {
+  server: {
+    id: string;
+    providedId: string;
+    type: 'http' | 'stdio';
+    url?: string;
+    cmd?: string;
+    args?: string[];
+  };
+  availableScopes: AgentToolPermissionScopeResponse[];
+  grantedScopes: AgentToolPermissionScopeResponse[];
+  hasAllScopes: boolean;
 };
 
 type ProjectResponse = {
@@ -110,7 +131,16 @@ export class ExecutionOrchestrator {
       throw new Error(`Agent @${agent.slug} has no system prompt configured`);
     }
 
+    const permissions = await this.fetchAgentToolPermissions(agent.actorId);
     const executionToken = await this.requestExecutionToken(agent.slug);
+    const runtimeMcpServers = this.buildRuntimeMcpServers(
+      permissions,
+      executionToken,
+      event.executionId,
+    );
+    const allowedTools = deriveAllowedToolsFromProvidedIds(
+      Object.keys(runtimeMcpServers),
+    );
     const repoUrl = await this.resolveRepoUrl(task.tags ?? []);
     const workspaceDir = await prepareWorkspace(task.id, agent.actorId, repoUrl);
     const thread = await this.fetchThreadByTaskId(task.id);
@@ -130,6 +160,8 @@ export class ExecutionOrchestrator {
         baseUrl: this.options.serverUrl,
         resume: getSession(agent.actorId, task.id) ?? undefined,
         agentSlug: agent.slug,
+        mcpServers: runtimeMcpServers,
+        allowedTools,
         options: {
           model:
             agent.providerId && agent.modelId
@@ -225,13 +257,53 @@ export class ExecutionOrchestrator {
       {
         method: 'POST',
         body: JSON.stringify({
-          scopes: ['tasks:read', 'tasks:write', 'context:read', 'context:write'],
           expirationSeconds: 3600,
         }),
       },
     );
 
     return response.token;
+  }
+
+  private async fetchAgentToolPermissions(
+    actorId: string,
+  ): Promise<AgentToolPermissionResponse[]> {
+    return this.fetchJson<AgentToolPermissionResponse[]>(
+      `/api/v1/agents/${actorId}/tool-permissions`,
+    );
+  }
+
+  private buildRuntimeMcpServers(
+    permissions: AgentToolPermissionResponse[],
+    accessToken: string,
+    executionId: string,
+  ): Record<string, RuntimeMcpServerConfig> {
+    const runtimeMcpServers: Record<string, RuntimeMcpServerConfig> = {};
+
+    for (const permission of permissions) {
+      const providedId = permission.server.providedId;
+      if (permission.server.type === 'http' && permission.server.url) {
+        runtimeMcpServers[providedId] = {
+          type: 'http',
+          url: permission.server.url,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            [EXECUTION_ID_HEADER]: executionId,
+          },
+        };
+        continue;
+      }
+
+      if (permission.server.type === 'stdio' && permission.server.cmd) {
+        runtimeMcpServers[providedId] = {
+          type: 'stdio',
+          command: permission.server.cmd,
+          args: permission.server.args ?? [],
+        };
+      }
+    }
+
+    return runtimeMcpServers;
   }
 
   private async resolveRepoUrl(tags: TaskTag[]): Promise<string | null> {

--- a/apps/backend/src/worker/execution-orchestrator.ts
+++ b/apps/backend/src/worker/execution-orchestrator.ts
@@ -55,13 +55,18 @@ type AgentToolPermissionResponse = {
     id: string;
     providedId: string;
     type: 'http' | 'stdio';
-    url?: string;
-    cmd?: string;
-    args?: string[];
   };
-  availableScopes: AgentToolPermissionScopeResponse[];
   grantedScopes: AgentToolPermissionScopeResponse[];
   hasAllScopes: boolean;
+};
+
+type McpServerResponse = {
+  id: string;
+  providedId: string;
+  type: 'http' | 'stdio';
+  url?: string;
+  cmd?: string;
+  args?: string[];
 };
 
 type ProjectResponse = {
@@ -132,9 +137,11 @@ export class ExecutionOrchestrator {
     }
 
     const permissions = await this.fetchAgentToolPermissions(agent.actorId);
+    const serversById = await this.fetchMcpServersById(permissions);
     const executionToken = await this.requestExecutionToken(agent.slug);
     const runtimeMcpServers = this.buildRuntimeMcpServers(
       permissions,
+      serversById,
       executionToken,
       event.executionId,
     );
@@ -273,8 +280,23 @@ export class ExecutionOrchestrator {
     );
   }
 
+  private async fetchMcpServersById(
+    permissions: AgentToolPermissionResponse[],
+  ): Promise<Map<string, McpServerResponse>> {
+    const serverIds = Array.from(
+      new Set(permissions.map((permission) => permission.server.id)),
+    );
+    const servers = await Promise.all(
+      serverIds.map((serverId) =>
+        this.fetchJson<McpServerResponse>(`/api/v1/mcp/servers/${serverId}`),
+      ),
+    );
+    return new Map(servers.map((server) => [server.id, server]));
+  }
+
   private buildRuntimeMcpServers(
     permissions: AgentToolPermissionResponse[],
+    serversById: Map<string, McpServerResponse>,
     accessToken: string,
     executionId: string,
   ): Record<string, RuntimeMcpServerConfig> {
@@ -282,10 +304,15 @@ export class ExecutionOrchestrator {
 
     for (const permission of permissions) {
       const providedId = permission.server.providedId;
-      if (permission.server.type === 'http' && permission.server.url) {
+      const server = serversById.get(permission.server.id);
+      if (!server) {
+        continue;
+      }
+
+      if (server.type === 'http' && server.url) {
         runtimeMcpServers[providedId] = {
           type: 'http',
-          url: permission.server.url,
+          url: server.url,
           headers: {
             Authorization: `Bearer ${accessToken}`,
             [EXECUTION_ID_HEADER]: executionId,
@@ -294,11 +321,11 @@ export class ExecutionOrchestrator {
         continue;
       }
 
-      if (permission.server.type === 'stdio' && permission.server.cmd) {
+      if (server.type === 'stdio' && server.cmd) {
         runtimeMcpServers[providedId] = {
           type: 'stdio',
-          command: permission.server.cmd,
-          args: permission.server.args ?? [],
+          command: server.cmd,
+          args: server.args ?? [],
         };
       }
     }

--- a/apps/backend/src/worker/runners/agent-runner.types.ts
+++ b/apps/backend/src/worker/runners/agent-runner.types.ts
@@ -1,3 +1,15 @@
+export type RuntimeMcpServerConfig =
+  | {
+      type: 'http';
+      url: string;
+      headers: Record<string, string>;
+    }
+  | {
+      type: 'stdio';
+      command: string;
+      args: string[];
+    };
+
 export type AgentRunContext = {
   taskId: string;
   prompt: string;
@@ -8,6 +20,8 @@ export type AgentRunContext = {
   resume?: string;
   options?: Record<string, unknown>;
   agentSlug?: string;
+  mcpServers?: Record<string, RuntimeMcpServerConfig>;
+  allowedTools?: string[];
 };
 
 export type AgentRunCallbacks = {

--- a/apps/backend/src/worker/runners/claude-agent-runner.ts
+++ b/apps/backend/src/worker/runners/claude-agent-runner.ts
@@ -3,6 +3,7 @@ import { EXECUTION_ID_HEADER } from '../../auth/guards/constants/headers.constan
 import { ClaudeMessageFormatter } from '../formatters/claude-message-formatter';
 import { BaseAgentRunner } from './base-agent-runner';
 import { AgentRunContext } from './agent-runner.types';
+import { DEFAULT_AGENT_ALLOWED_TOOLS } from '@taico/shared';
 
 export class ClaudeAgentRunner extends BaseAgentRunner {
   readonly kind = 'claude';
@@ -15,6 +16,25 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
   ): Promise<string> {
     const formatter = new ClaudeMessageFormatter(ctx.agentSlug);
     let finalResult = '';
+    const mcpServers =
+      ctx.mcpServers ?? {
+        tasks: {
+          type: 'http',
+          url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+        context: {
+          type: 'http',
+          url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+      };
 
     const stream = query({
       prompt: ctx.prompt,
@@ -24,33 +44,8 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
         persistSession: true,
         settingSources: ['user', 'project', 'local'],
         ...(ctx.options ?? {}),
-        mcpServers: {
-          tasks: {
-            type: 'http',
-            url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
-            headers: {
-              Authorization: `Bearer ${ctx.accessToken}`,
-              [EXECUTION_ID_HEADER]: ctx.executionId,
-            },
-          },
-          context: {
-            type: 'http',
-            url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
-            headers: {
-              Authorization: `Bearer ${ctx.accessToken}`,
-              [EXECUTION_ID_HEADER]: ctx.executionId,
-            },
-          },
-        },
-        allowedTools: [
-          'mcp__tasks__*',
-          'mcp__context__*',
-          'SlashCommand',
-          'Bash',
-          'Read',
-          'Write',
-          'Edit',
-        ],
+        mcpServers,
+        allowedTools: ctx.allowedTools ?? [...DEFAULT_AGENT_ALLOWED_TOOLS],
       },
     });
 

--- a/apps/backend/src/worker/runners/opencode-agent-runner.ts
+++ b/apps/backend/src/worker/runners/opencode-agent-runner.ts
@@ -139,26 +139,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
           timeout: 20 * 3600,
           signal: this.abortController.signal,
           config: {
-            mcp: {
-              tasks: {
-                type: 'remote',
-                url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
-                headers: {
-                  Authorization: `Bearer ${ctx.accessToken}`,
-                  [EXECUTION_ID_HEADER]: ctx.executionId,
-                },
-                enabled: true,
-              },
-              context: {
-                type: 'remote',
-                url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
-                headers: {
-                  Authorization: `Bearer ${ctx.accessToken}`,
-                  [EXECUTION_ID_HEADER]: ctx.executionId,
-                },
-                enabled: true,
-              },
-            },
+            mcp: this.buildMcpConfig(ctx),
           },
         });
 
@@ -205,5 +186,59 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
       providerID,
       modelID,
     };
+  }
+
+  private buildMcpConfig(ctx: AgentRunContext): Record<
+    string,
+    {
+      type: 'remote';
+      url: string;
+      headers: Record<string, string>;
+      enabled: true;
+    }
+  > {
+    const runtimeMcpServers =
+      ctx.mcpServers ?? {
+        tasks: {
+          type: 'http' as const,
+          url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+        context: {
+          type: 'http' as const,
+          url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+      };
+
+    const config: Record<
+      string,
+      {
+        type: 'remote';
+        url: string;
+        headers: Record<string, string>;
+        enabled: true;
+      }
+    > = {};
+    for (const [providedId, server] of Object.entries(runtimeMcpServers)) {
+      if (server.type !== 'http') {
+        continue;
+      }
+
+      config[providedId] = {
+        type: 'remote',
+        url: server.url,
+        headers: server.headers,
+        enabled: true,
+      };
+    }
+
+    return config;
   }
 }

--- a/apps/ui2/src/features/agents/AgentToolsPage.tsx
+++ b/apps/ui2/src/features/agents/AgentToolsPage.tsx
@@ -20,15 +20,11 @@ function getScopeSummary(permission: AgentToolPermissionResponseDto) {
     return 'No scopes required';
   }
 
-  if (permission.availableScopes.length === 0) {
-    return 'No scopes available';
-  }
-
   if (permission.hasAllScopes) {
     return 'All scopes';
   }
 
-  return `${permission.grantedScopes.length} of ${permission.availableScopes.length} scopes`;
+  return `${permission.grantedScopes.length} scope${permission.grantedScopes.length === 1 ? '' : 's'} granted`;
 }
 
 export function AgentToolsPage() {
@@ -50,7 +46,6 @@ export function AgentToolsPage() {
     serverName: string;
     serverProvidedId: string;
     serverType: 'http' | 'stdio';
-    availableScopes: Array<{ id: string; description: string }>;
   } | null>(null);
 
   const loadToolPermissions = useCallback(async (actorId: string) => {
@@ -265,16 +260,12 @@ export function AgentToolsPage() {
             });
             await loadToolPermissions(agent.actorId);
           }}
-          onConfigureScopedTool={(tool, scopes) => {
+          onConfigureScopedTool={(tool, _scopes) => {
             setPendingScopedTool({
               serverId: tool.id,
               serverName: tool.name,
               serverProvidedId: tool.providedId,
               serverType: tool.type,
-              availableScopes: scopes.map((scope) => ({
-                id: scope.id,
-                description: scope.description,
-              })),
             });
           }}
         />
@@ -289,10 +280,6 @@ export function AgentToolsPage() {
             serverProvidedId: permission.server.providedId,
             serverType: permission.server.type,
             scopeIds: permission.grantedScopes.map((scope) => scope.id),
-            availableScopes: permission.availableScopes.map((scope) => ({
-              id: scope.id,
-              description: scope.description,
-            })),
             hasAllScopes: permission.hasAllScopes,
           }))}
           editingPermission={editingToolPermission ? {
@@ -301,10 +288,6 @@ export function AgentToolsPage() {
             serverProvidedId: editingToolPermission.server.providedId,
             serverType: editingToolPermission.server.type,
             scopeIds: editingToolPermission.grantedScopes.map((scope) => scope.id),
-            availableScopes: editingToolPermission.availableScopes.map((scope) => ({
-              id: scope.id,
-              description: scope.description,
-            })),
             hasAllScopes: editingToolPermission.hasAllScopes,
           } : null}
           onCancel={() => {
@@ -331,10 +314,6 @@ export function AgentToolsPage() {
             serverProvidedId: permission.server.providedId,
             serverType: permission.server.type,
             scopeIds: permission.grantedScopes.map((scope) => scope.id),
-            availableScopes: permission.availableScopes.map((scope) => ({
-              id: scope.id,
-              description: scope.description,
-            })),
             hasAllScopes: permission.hasAllScopes,
           }))}
           fixedTool={pendingScopedTool}

--- a/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.tsx
+++ b/apps/ui2/src/features/agents/EditAgentToolPermissionsPop.tsx
@@ -12,7 +12,6 @@ type ToolPermission = {
   serverProvidedId: string;
   serverType: 'http' | 'stdio';
   scopeIds: string[];
-  availableScopes: Array<{ id: string; description: string }>;
   hasAllScopes: boolean;
 };
 

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -9,7 +9,11 @@ import {
 } from "@google/adk";
 import { ADKMessageFormatter } from "../formatters/ADKMessageFormatter.js";
 import { EXECUTION_ID_HEADER } from "../helpers/config.js";
-import { AgentModelConfig, AgentRunContext } from "./AgentRunner.js";
+import {
+  AgentModelConfig,
+  AgentRunContext,
+  RuntimeMcpServerConfig,
+} from "./AgentRunner.js";
 
 class NamespacedTool extends BaseTool {
   constructor(
@@ -44,7 +48,7 @@ class NamespacedTool extends BaseTool {
 class NamespacedMCPToolset extends MCPToolset {
   constructor(
     connectionParams: ConstructorParameters<typeof MCPToolset>[0],
-    private readonly serverName: string,
+    readonly serverName: string,
   ) {
     super(connectionParams);
   }
@@ -90,29 +94,40 @@ export class ADKAgentRunner extends BaseAgentRunner {
       userId: 'user-123',
     });
 
+    const mcpServers =
+      ctx.mcpServers ?? {
+        tasks: {
+          type: 'http' as const,
+          url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+        context: {
+          type: 'http' as const,
+          url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+      };
+    const toolsets = Object.entries(mcpServers).map(([serverName, serverConfig]) =>
+      new NamespacedMCPToolset(
+        this.toConnectionParams(serverConfig),
+        serverName,
+      ),
+    );
+
+    await this.preflightToolsets(toolsets, mcpServers);
+
     const agent = new LlmAgent({
       name: 'agent',
       model: this.modelId,
       description: '',
       instruction: '',
-      tools: [
-        new NamespacedMCPToolset({
-          type: 'StreamableHTTPConnectionParams',
-          url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
-          header: {
-            Authorization: `Bearer ${ctx.accessToken}`,
-            [EXECUTION_ID_HEADER]: ctx.executionId,
-          },
-        }, 'tasks'),
-        new NamespacedMCPToolset({
-          type: 'StreamableHTTPConnectionParams',
-          url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
-          header: {
-            Authorization: `Bearer ${ctx.accessToken}`,
-            [EXECUTION_ID_HEADER]: ctx.executionId,
-          },
-        }, 'context')
-      ]
+      tools: toolsets,
     });
 
     const runner = new Runner({
@@ -142,6 +157,85 @@ export class ADKAgentRunner extends BaseAgentRunner {
       });
     }
 
+    await Promise.all(toolsets.map((toolset) => toolset.close()));
+
     return finalResult;
+  }
+
+  private toConnectionParams(serverConfig: RuntimeMcpServerConfig) {
+    if (serverConfig.type === 'http') {
+      return {
+        type: 'StreamableHTTPConnectionParams' as const,
+        url: serverConfig.url,
+        header: serverConfig.headers,
+      };
+    }
+
+    return {
+      type: 'StdioConnectionParams' as const,
+      serverParams: {
+        command: serverConfig.command,
+        args: serverConfig.args,
+      },
+    };
+  }
+
+  private async preflightToolsets(
+    toolsets: NamespacedMCPToolset[],
+    mcpServers: Record<string, RuntimeMcpServerConfig>,
+  ): Promise<void> {
+    for (const toolset of toolsets) {
+      try {
+        await toolset.getTools();
+      } catch (error) {
+        const serverConfig = mcpServers[toolset.serverName];
+        throw new Error(
+          this.formatMcpConnectionError(toolset.serverName, serverConfig, error),
+          { cause: error },
+        );
+      }
+    }
+  }
+
+  private formatMcpConnectionError(
+    serverName: string,
+    serverConfig: RuntimeMcpServerConfig,
+    error: unknown,
+  ): string {
+    const details = this.collectErrorDetails(error);
+    const location =
+      serverConfig.type === 'http'
+        ? serverConfig.url
+        : `${serverConfig.command} ${serverConfig.args.join(' ')}`.trim();
+    const protocol = serverConfig.type === 'http' ? 'HTTP' : 'stdio';
+    const suffix = details.length > 0 ? `: ${details.join(' | ')}` : '';
+
+    return `Failed to connect to MCP server "${serverName}" via ${protocol} (${location})${suffix}`;
+  }
+
+  private collectErrorDetails(error: unknown): string[] {
+    const details: string[] = [];
+    const seen = new Set<unknown>();
+
+    let current: unknown = error;
+    while (current && typeof current === 'object' && !seen.has(current)) {
+      seen.add(current);
+
+      if ('message' in current && typeof current.message === 'string') {
+        details.push(current.message);
+      }
+
+      if ('code' in current && typeof current.code === 'string') {
+        details.push(`code=${current.code}`);
+      }
+
+      current = 'cause' in current ? current.cause : undefined;
+    }
+
+    if (details.length === 0 && error instanceof Error) {
+      details.push(error.message);
+    }
+
+    return [...new Set(details)];
   }
 }

--- a/apps/worker/src/runners/AgentRunner.ts
+++ b/apps/worker/src/runners/AgentRunner.ts
@@ -8,6 +8,18 @@ export type AgentModelConfig = {
   modelId?: string | null;
 }
 
+export type RuntimeMcpServerConfig =
+  | {
+      type: 'http';
+      url: string;
+      headers: Record<string, string>;
+    }
+  | {
+      type: 'stdio';
+      command: string;
+      args: string[];
+    };
+
 export type AgentRunContext = {
   /** Task / job identity */
   taskId: string;
@@ -37,6 +49,12 @@ export type AgentRunContext = {
 
   /** Agent slug for personalized activity messages */
   agentSlug?: string;
+
+  /** Runtime MCP servers that should be mounted for this run */
+  mcpServers?: Record<string, RuntimeMcpServerConfig>;
+
+  /** Allowed tool list for SDKs that support tool filtering */
+  allowedTools?: string[];
 };
 
 export type AgentRunCallbacks = {

--- a/apps/worker/src/runners/ClaudeAgentRunner.ts
+++ b/apps/worker/src/runners/ClaudeAgentRunner.ts
@@ -4,6 +4,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import { ClaudeMessageFormatter } from "../formatters/ClaudeMessageFormatter.js";
 import { EXECUTION_ID_HEADER } from "../helpers/config.js";
 import { AgentModelConfig, AgentRunContext } from "./AgentRunner.js";
+import { DEFAULT_AGENT_ALLOWED_TOOLS } from '@taico/shared';
 
 export class ClaudeAgentRunner extends BaseAgentRunner {
   readonly kind = 'claude';
@@ -21,6 +22,26 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
     const formatter = new ClaudeMessageFormatter(ctx.agentSlug);
 
     let finalResult = '';
+    const mcpServers =
+      ctx.mcpServers ?? {
+        tasks: {
+          type: 'http',
+          url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+        context: {
+          type: 'http',
+          url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+      };
+
     const stream = query({
       prompt: ctx.prompt,
       options: {
@@ -29,33 +50,8 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
         persistSession: true,
         settingSources: ['user', 'project', 'local'],
         ...(ctx.options ?? {}),
-        mcpServers: {
-          tasks: {
-            type: "http",
-            url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
-            headers: {
-              Authorization: `Bearer ${ctx.accessToken}`,
-              [EXECUTION_ID_HEADER]: ctx.executionId,
-            },
-          },
-          context: {
-            type: "http",
-            url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
-            headers: {
-              Authorization: `Bearer ${ctx.accessToken}`,
-              [EXECUTION_ID_HEADER]: ctx.executionId,
-            },
-          }
-        },
-        allowedTools: [
-          'mcp__tasks__*',
-          'mcp__context__*',
-          'SlashCommand',
-          'Bash',
-          'Read',
-          'Write',
-          'Edit',
-        ],
+        mcpServers,
+        allowedTools: ctx.allowedTools ?? [...DEFAULT_AGENT_ALLOWED_TOOLS],
       },
     });
 

--- a/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
@@ -1,7 +1,11 @@
 import { BaseAgentRunner } from "./BaseAgentRunner.js";
 import { EXECUTION_ID_HEADER } from "../helpers/config.js";
-import { AgentModelConfig, AgentRunContext } from "./AgentRunner.js";
-import { approveAll, CopilotClient, MCPRemoteServerConfig } from "@github/copilot-sdk";
+import {
+  AgentModelConfig,
+  AgentRunContext,
+  RuntimeMcpServerConfig,
+} from "./AgentRunner.js";
+import { approveAll, CopilotClient, MCPRemoteServerConfig, MCPLocalServerConfig } from "@github/copilot-sdk";
 
 export class GitHubCopilotAgentRunner extends BaseAgentRunner {
   readonly kind = 'githubcopilot';
@@ -29,34 +33,13 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
         });
         await this.client.start();
 
-        const taskMcpServer: MCPRemoteServerConfig = {
-          type: "http",
-          url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
-          headers: {
-            Authorization: `Bearer ${ctx.accessToken}`,
-            [EXECUTION_ID_HEADER]: ctx.executionId,
-          },
-          tools: ["*"],
-        };
-
-        const contextMcpServer: MCPRemoteServerConfig = {
-          type: "http",
-          url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
-          headers: {
-            Authorization: `Bearer ${ctx.accessToken}`,
-            [EXECUTION_ID_HEADER]: ctx.executionId,
-          },
-          tools: ["*"],
-        };
+        const mcpServers = this.buildMcpServers(ctx);
 
         // Create a session for this work
         const session = await this.client.createSession({
           model: this.model,
           onPermissionRequest: approveAll,
-          mcpServers: {
-            tasks: taskMcpServer,
-            context: contextMcpServer,
-          },
+          mcpServers,
         });
 
         if (session?.sessionId) {
@@ -106,5 +89,56 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
         reject(err);
       }
     });
+  }
+
+  private buildMcpServers(
+    ctx: AgentRunContext,
+  ): Record<string, MCPRemoteServerConfig | MCPLocalServerConfig> {
+    const runtimeMcpServers =
+      ctx.mcpServers ?? {
+        tasks: {
+          type: 'http' as const,
+          url: `${ctx.baseUrl}/api/v1/tasks/tasks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+        context: {
+          type: 'http' as const,
+          url: `${ctx.baseUrl}/api/v1/context/blocks/mcp`,
+          headers: {
+            Authorization: `Bearer ${ctx.accessToken}`,
+            [EXECUTION_ID_HEADER]: ctx.executionId,
+          },
+        },
+      };
+
+    return Object.fromEntries(
+      Object.entries(runtimeMcpServers).map(([serverName, serverConfig]) => [
+        serverName,
+        this.toCopilotMcpServerConfig(serverConfig),
+      ]),
+    );
+  }
+
+  private toCopilotMcpServerConfig(
+    serverConfig: RuntimeMcpServerConfig,
+  ): MCPRemoteServerConfig | MCPLocalServerConfig {
+    if (serverConfig.type === 'http') {
+      return {
+        type: "http",
+        url: serverConfig.url,
+        headers: serverConfig.headers,
+        tools: ["*"],
+      };
+    }
+
+    return {
+      type: "local",
+      command: serverConfig.command,
+      args: serverConfig.args,
+      tools: ["*"],
+    };
   }
 }

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -5,6 +5,19 @@ import { OpencodeAsyncMessageFormatter } from "../formatters/OpencodeMessageForm
 import { EXECUTION_ID_HEADER } from "../helpers/config.js";
 import { AgentModelConfig, AgentRunContext, Model } from "./AgentRunner.js";
 
+type OpenCodeMcpServerConfig =
+  | {
+      type: 'remote';
+      url: string;
+      headers: Record<string, string>;
+      enabled: true;
+    }
+  | {
+      type: 'local';
+      command: string[];
+      enabled: true;
+    };
+
 export class OpencodeAgentRunner extends BaseAgentRunner {
   readonly kind = 'opencode';
 
@@ -224,15 +237,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     executionId: string;
     baseUrl: string;
     accessToken: string;
-  }): Record<
-    string,
-    {
-      type: 'remote';
-      url: string;
-      headers: Record<string, string>;
-      enabled: true;
-    }
-  > {
+  }): Record<string, OpenCodeMcpServerConfig> {
     const runtimeMcpServers =
       this.runtimeMcpServers ?? {
         tasks: {
@@ -253,24 +258,21 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
         },
       };
 
-    const config: Record<
-      string,
-      {
-        type: 'remote';
-        url: string;
-        headers: Record<string, string>;
-        enabled: true;
-      }
-    > = {};
+    const config: Record<string, OpenCodeMcpServerConfig> = {};
     for (const [providedId, server] of Object.entries(runtimeMcpServers)) {
-      if (server.type !== 'http') {
+      if (server.type === 'http') {
+        config[providedId] = {
+          type: 'remote',
+          url: server.url,
+          headers: server.headers,
+          enabled: true,
+        };
         continue;
       }
 
       config[providedId] = {
-        type: 'remote',
-        url: server.url,
-        headers: server.headers,
+        type: 'local',
+        command: [server.command, ...server.args],
         enabled: true,
       };
     }

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -107,26 +107,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
           timeout: 20 * 3600,
           signal: this.abortController.signal,
           config: {
-            mcp: {
-              tasks: {
-                type: "remote",
-                url: `${baseUrl}/api/v1/tasks/tasks/mcp`,
-                headers: {
-                  Authorization: `Bearer ${accessToken}`,
-                  [EXECUTION_ID_HEADER]: executionId,
-                },
-                enabled: true,
-              },
-              context: {
-                type: "remote",
-                url: `${baseUrl}/api/v1/context/blocks/mcp`,
-                headers: {
-                  Authorization: `Bearer ${accessToken}`,
-                  [EXECUTION_ID_HEADER]: executionId,
-                },
-                enabled: true,
-              }
-            }
+            mcp: this.buildMcpConfig({ executionId, baseUrl, accessToken }),
           }
         });
 
@@ -150,6 +131,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
   ): Promise<string> {
     const formatter = new OpencodeAsyncMessageFormatter(ctx.agentSlug);
+    this.runtimeMcpServers = ctx.mcpServers;
 
     // Start client
     await this.initBullshit({
@@ -228,8 +210,73 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
 
     console.log('shutting down Opencode client');
     this.shutdown();
+    this.runtimeMcpServers = undefined;
     console.log('returning final result');
 
     return finalResult;
   }
+
+  private buildMcpConfig({
+    executionId,
+    baseUrl,
+    accessToken,
+  }: {
+    executionId: string;
+    baseUrl: string;
+    accessToken: string;
+  }): Record<
+    string,
+    {
+      type: 'remote';
+      url: string;
+      headers: Record<string, string>;
+      enabled: true;
+    }
+  > {
+    const runtimeMcpServers =
+      this.runtimeMcpServers ?? {
+        tasks: {
+          type: 'http' as const,
+          url: `${baseUrl}/api/v1/tasks/tasks/mcp`,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            [EXECUTION_ID_HEADER]: executionId,
+          },
+        },
+        context: {
+          type: 'http' as const,
+          url: `${baseUrl}/api/v1/context/blocks/mcp`,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            [EXECUTION_ID_HEADER]: executionId,
+          },
+        },
+      };
+
+    const config: Record<
+      string,
+      {
+        type: 'remote';
+        url: string;
+        headers: Record<string, string>;
+        enabled: true;
+      }
+    > = {};
+    for (const [providedId, server] of Object.entries(runtimeMcpServers)) {
+      if (server.type !== 'http') {
+        continue;
+      }
+
+      config[providedId] = {
+        type: 'remote',
+        url: server.url,
+        headers: server.headers,
+        enabled: true,
+      };
+    }
+
+    return config;
+  }
+
+  private runtimeMcpServers?: AgentRunContext['mcpServers'];
 }

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -1,5 +1,5 @@
 import { ApiClient } from '@taico/client/v2';
-import { AgentToolPermissionResponseDto } from '@taico/client/v2';
+import { AgentToolPermissionResponseDto, ServerResponseDto } from '@taico/client/v2';
 import { deriveAllowedToolsFromProvidedIds } from '@taico/shared';
 import { prepareWorkspace } from './helpers/prepareWorkspace.js';
 import { EXECUTION_ID_HEADER } from './helpers/config.js';
@@ -85,8 +85,10 @@ export async function executeTask({
     await workerClient.agent.AgentToolPermissionsController_listAgentToolPermissions({
       actorId: agent.actorId,
     });
+  const serversById = await fetchMcpServersById(workerClient, permissions);
   const runtimeMcpServers = buildRuntimeMcpServers(
     permissions,
+    serversById,
     executionId,
   );
   const allowedTools = deriveAllowedToolsFromProvidedIds(
@@ -174,16 +176,22 @@ export async function executeTask({
 
 function buildRuntimeMcpServers(
   permissions: AgentToolPermissionResponseDto[],
+  serversById: Map<string, ServerResponseDto>,
   executionId: string,
 ): Record<string, RuntimeMcpServerConfig> {
   const mcpServers: Record<string, RuntimeMcpServerConfig> = {};
 
   for (const permission of permissions) {
     const providedId = permission.server.providedId;
-    if (permission.server.type === 'http' && permission.server.url) {
+    const server = serversById.get(permission.server.id);
+    if (!server) {
+      continue;
+    }
+
+    if (server.type === 'http' && server.url) {
       mcpServers[providedId] = {
         type: 'http',
-        url: permission.server.url,
+        url: server.url,
         headers: {
           [EXECUTION_ID_HEADER]: executionId,
         },
@@ -191,16 +199,31 @@ function buildRuntimeMcpServers(
       continue;
     }
 
-    if (permission.server.type === 'stdio' && permission.server.cmd) {
+    if (server.type === 'stdio' && server.cmd) {
       mcpServers[providedId] = {
         type: 'stdio',
-        command: permission.server.cmd,
-        args: permission.server.args ?? [],
+        command: server.cmd,
+        args: server.args ?? [],
       };
     }
   }
 
   return mcpServers;
+}
+
+async function fetchMcpServersById(
+  workerClient: ApiClient,
+  permissions: AgentToolPermissionResponseDto[],
+): Promise<Map<string, ServerResponseDto>> {
+  const serverIds = Array.from(
+    new Set(permissions.map((permission) => permission.server.id)),
+  );
+  const servers = await Promise.all(
+    serverIds.map((serverId) =>
+      workerClient.tools.McpRegistryController_getServer({ serverId }),
+    ),
+  );
+  return new Map(servers.map((server) => [server.id, server]));
 }
 
 function attachRuntimeAuthHeaders(

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -1,8 +1,10 @@
 import { ApiClient } from '@taico/client/v2';
-import { DEFAULT_AGENT_TOKEN_SCOPES } from '@taico/shared';
+import { AgentToolPermissionResponseDto } from '@taico/client/v2';
+import { deriveAllowedToolsFromProvidedIds } from '@taico/shared';
 import { prepareWorkspace } from './helpers/prepareWorkspace.js';
+import { EXECUTION_ID_HEADER } from './helpers/config.js';
 import { BaseAgentRunner } from './runners/BaseAgentRunner.js';
-import { AgentModelConfig } from './runners/AgentRunner.js';
+import { AgentModelConfig, RuntimeMcpServerConfig } from './runners/AgentRunner.js';
 import { ClaudeAgentRunner } from './runners/ClaudeAgentRunner.js';
 import { OpencodeAgentRunner } from './runners/OpenCodeAgentRunner.js';
 import { ADKAgentRunner } from './runners/ADKAgentRunner.js';
@@ -79,14 +81,27 @@ export async function executeTask({
 
   const thread = await workerClient.threads.ThreadsController_getThreadByTaskId({ taskId });
 
+  const permissions =
+    await workerClient.agent.AgentToolPermissionsController_listAgentToolPermissions({
+      actorId: agent.actorId,
+    });
+  const runtimeMcpServers = buildRuntimeMcpServers(
+    permissions,
+    executionId,
+  );
+  const allowedTools = deriveAllowedToolsFromProvidedIds(
+    Object.keys(runtimeMcpServers),
+  );
+
   // Get an access token for the agent
   const agentToken = await workerClient.agentExecutionTokens.AgentExecutionTokensController_requestExecutionToken({
     slug: agent.slug,
     body: {
-      scopes: [...DEFAULT_AGENT_TOKEN_SCOPES],
       expirationSeconds: 60 * 60, // 1 hour? what's a sensible ttl?
     }
   });
+
+  attachRuntimeAuthHeaders(runtimeMcpServers, agentToken.token);
 
   // Create runner
   let runner: BaseAgentRunner | null = null;
@@ -123,6 +138,8 @@ export async function executeTask({
         executionId,
         resume: undefined,
         agentSlug: agent.slug,
+        mcpServers: runtimeMcpServers,
+        allowedTools,
       },
       {
         onHeartbeat: async () => {
@@ -152,5 +169,52 @@ export async function executeTask({
     );
   } catch (error) {
     throw classifyRunnerError(error);
+  }
+}
+
+function buildRuntimeMcpServers(
+  permissions: AgentToolPermissionResponseDto[],
+  executionId: string,
+): Record<string, RuntimeMcpServerConfig> {
+  const mcpServers: Record<string, RuntimeMcpServerConfig> = {};
+
+  for (const permission of permissions) {
+    const providedId = permission.server.providedId;
+    if (permission.server.type === 'http' && permission.server.url) {
+      mcpServers[providedId] = {
+        type: 'http',
+        url: permission.server.url,
+        headers: {
+          [EXECUTION_ID_HEADER]: executionId,
+        },
+      };
+      continue;
+    }
+
+    if (permission.server.type === 'stdio' && permission.server.cmd) {
+      mcpServers[providedId] = {
+        type: 'stdio',
+        command: permission.server.cmd,
+        args: permission.server.args ?? [],
+      };
+    }
+  }
+
+  return mcpServers;
+}
+
+function attachRuntimeAuthHeaders(
+  mcpServers: Record<string, RuntimeMcpServerConfig>,
+  accessToken: string,
+): void {
+  for (const server of Object.values(mcpServers)) {
+    if (server.type !== 'http') {
+      continue;
+    }
+
+    server.headers = {
+      ...server.headers,
+      Authorization: `Bearer ${accessToken}`,
+    };
   }
 }

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -10314,6 +10314,27 @@
               "stdio"
             ],
             "example": "http"
+          },
+          "url": {
+            "type": "string",
+            "description": "HTTP endpoint for servers with http transport",
+            "example": "https://example.com/mcp"
+          },
+          "cmd": {
+            "type": "string",
+            "description": "Command for servers with stdio transport",
+            "example": "npx"
+          },
+          "args": {
+            "description": "Command arguments for servers with stdio transport",
+            "example": [
+              "-y",
+              "@taico/example-mcp"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -10572,7 +10593,7 @@
         "type": "object",
         "properties": {
           "scopes": {
-            "description": "Scopes to grant to the short-lived execution token.",
+            "description": "Scopes to grant to the short-lived execution token. When omitted, scopes are derived from baseline system access plus assigned tool permissions.",
             "example": [
               "tasks:read",
               "tasks:write"
@@ -10589,10 +10610,7 @@
             "minimum": 1,
             "maximum": 3600
           }
-        },
-        "required": [
-          "scopes"
-        ]
+        }
       },
       "AgentExecutionTokenResponseDto": {
         "type": "object",

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -10314,27 +10314,6 @@
               "stdio"
             ],
             "example": "http"
-          },
-          "url": {
-            "type": "string",
-            "description": "HTTP endpoint for servers with http transport",
-            "example": "https://example.com/mcp"
-          },
-          "cmd": {
-            "type": "string",
-            "description": "Command for servers with stdio transport",
-            "example": "npx"
-          },
-          "args": {
-            "description": "Command arguments for servers with stdio transport",
-            "example": [
-              "-y",
-              "@taico/example-mcp"
-            ],
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           }
         },
         "required": [
@@ -10370,13 +10349,6 @@
           "server": {
             "$ref": "#/components/schemas/AgentToolPermissionServerResponseDto"
           },
-          "availableScopes": {
-            "description": "All scopes currently available on this MCP server",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AgentToolPermissionScopeResponseDto"
-            }
-          },
           "grantedScopes": {
             "description": "Subset of scopes granted to this agent for this server",
             "type": "array",
@@ -10392,7 +10364,6 @@
         },
         "required": [
           "server",
-          "availableScopes",
           "grantedScopes",
           "hasAllScopes"
         ]

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -4280,24 +4280,6 @@ export interface components {
              * @enum {string}
              */
             type: "http" | "stdio";
-            /**
-             * @description HTTP endpoint for servers with http transport
-             * @example https://example.com/mcp
-             */
-            url?: string;
-            /**
-             * @description Command for servers with stdio transport
-             * @example npx
-             */
-            cmd?: string;
-            /**
-             * @description Command arguments for servers with stdio transport
-             * @example [
-             *       "-y",
-             *       "@taico/example-mcp"
-             *     ]
-             */
-            args?: string[];
         };
         AgentToolPermissionScopeResponseDto: {
             /**
@@ -4313,8 +4295,6 @@ export interface components {
         };
         AgentToolPermissionResponseDto: {
             server: components["schemas"]["AgentToolPermissionServerResponseDto"];
-            /** @description All scopes currently available on this MCP server */
-            availableScopes: components["schemas"]["AgentToolPermissionScopeResponseDto"][];
             /** @description Subset of scopes granted to this agent for this server */
             grantedScopes: components["schemas"]["AgentToolPermissionScopeResponseDto"][];
             /**

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -4280,6 +4280,24 @@ export interface components {
              * @enum {string}
              */
             type: "http" | "stdio";
+            /**
+             * @description HTTP endpoint for servers with http transport
+             * @example https://example.com/mcp
+             */
+            url?: string;
+            /**
+             * @description Command for servers with stdio transport
+             * @example npx
+             */
+            cmd?: string;
+            /**
+             * @description Command arguments for servers with stdio transport
+             * @example [
+             *       "-y",
+             *       "@taico/example-mcp"
+             *     ]
+             */
+            args?: string[];
         };
         AgentToolPermissionScopeResponseDto: {
             /**
@@ -4444,13 +4462,13 @@ export interface components {
         };
         RequestAgentExecutionTokenDto: {
             /**
-             * @description Scopes to grant to the short-lived execution token.
+             * @description Scopes to grant to the short-lived execution token. When omitted, scopes are derived from baseline system access plus assigned tool permissions.
              * @example [
              *       "tasks:read",
              *       "tasks:write"
              *     ]
              */
-            scopes: string[];
+            scopes?: string[];
             /**
              * @description Lifetime of the short-lived execution token in seconds. Defaults to the server MCP access token duration.
              * @example 600

--- a/packages/client/src/v1/client/models/AgentToolPermissionResponseDto.ts
+++ b/packages/client/src/v1/client/models/AgentToolPermissionResponseDto.ts
@@ -7,10 +7,6 @@ import type { AgentToolPermissionServerResponseDto } from './AgentToolPermission
 export type AgentToolPermissionResponseDto = {
     server: AgentToolPermissionServerResponseDto;
     /**
-     * All scopes currently available on this MCP server
-     */
-    availableScopes: Array<AgentToolPermissionScopeResponseDto>;
-    /**
      * Subset of scopes granted to this agent for this server
      */
     grantedScopes: Array<AgentToolPermissionScopeResponseDto>;

--- a/packages/client/src/v1/client/models/AgentToolPermissionServerResponseDto.ts
+++ b/packages/client/src/v1/client/models/AgentToolPermissionServerResponseDto.ts
@@ -23,6 +23,18 @@ export type AgentToolPermissionServerResponseDto = {
      * MCP server transport type
      */
     type: AgentToolPermissionServerResponseDto.type;
+    /**
+     * HTTP endpoint for servers with http transport
+     */
+    url?: string;
+    /**
+     * Command for servers with stdio transport
+     */
+    cmd?: string;
+    /**
+     * Command arguments for servers with stdio transport
+     */
+    args?: Array<string>;
 };
 export namespace AgentToolPermissionServerResponseDto {
     /**

--- a/packages/client/src/v1/client/models/AgentToolPermissionServerResponseDto.ts
+++ b/packages/client/src/v1/client/models/AgentToolPermissionServerResponseDto.ts
@@ -23,18 +23,6 @@ export type AgentToolPermissionServerResponseDto = {
      * MCP server transport type
      */
     type: AgentToolPermissionServerResponseDto.type;
-    /**
-     * HTTP endpoint for servers with http transport
-     */
-    url?: string;
-    /**
-     * Command for servers with stdio transport
-     */
-    cmd?: string;
-    /**
-     * Command arguments for servers with stdio transport
-     */
-    args?: Array<string>;
 };
 export namespace AgentToolPermissionServerResponseDto {
     /**

--- a/packages/client/src/v1/client/models/RequestAgentExecutionTokenDto.ts
+++ b/packages/client/src/v1/client/models/RequestAgentExecutionTokenDto.ts
@@ -4,9 +4,9 @@
 /* eslint-disable */
 export type RequestAgentExecutionTokenDto = {
     /**
-     * Scopes to grant to the short-lived execution token.
+     * Scopes to grant to the short-lived execution token. When omitted, scopes are derived from baseline system access plus assigned tool permissions.
      */
-    scopes: Array<string>;
+    scopes?: Array<string>;
     /**
      * Lifetime of the short-lived execution token in seconds. Defaults to the server MCP access token duration.
      */

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -696,9 +696,6 @@ export interface AgentToolPermissionServerResponseDto {
   name: string;
   description: string;
   type: 'http' | 'stdio';
-  url?: string;
-  cmd?: string;
-  args?: string[];
 }
 
 export interface AgentToolPermissionScopeResponseDto {
@@ -708,7 +705,6 @@ export interface AgentToolPermissionScopeResponseDto {
 
 export interface AgentToolPermissionResponseDto {
   server: AgentToolPermissionServerResponseDto;
-  availableScopes: AgentToolPermissionScopeResponseDto[];
   grantedScopes: AgentToolPermissionScopeResponseDto[];
   hasAllScopes: boolean;
 }

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -696,6 +696,9 @@ export interface AgentToolPermissionServerResponseDto {
   name: string;
   description: string;
   type: 'http' | 'stdio';
+  url?: string;
+  cmd?: string;
+  args?: string[];
 }
 
 export interface AgentToolPermissionScopeResponseDto {
@@ -746,7 +749,7 @@ export interface IssuedAccessTokenResponseDto {
 }
 
 export interface RequestAgentExecutionTokenDto {
-  scopes: string[];
+  scopes?: string[];
   expirationSeconds?: number;
 }
 

--- a/packages/shared/src/agent-runtime-permissions.ts
+++ b/packages/shared/src/agent-runtime-permissions.ts
@@ -17,11 +17,6 @@ export const DEFAULT_AGENT_ALLOWED_TOOLS = [
   'Edit',
 ] as const;
 
-const BASELINE_SCOPES_BY_PROVIDED_ID: Record<string, readonly string[]> = {
-  tasks: ['tasks:read', 'tasks:write'],
-  context: ['context:read', 'context:write'],
-};
-
 export type AgentRuntimeScopeLike = {
   id: string;
 };
@@ -30,15 +25,8 @@ export type AgentRuntimeToolPermissionLike = {
   server: {
     providedId: string;
   };
-  availableScopes: AgentRuntimeScopeLike[];
   grantedScopes: AgentRuntimeScopeLike[];
 };
-
-export function isBaselineSystemTool(providedId: string): boolean {
-  return BASELINE_SYSTEM_TOOL_PROVIDED_IDS.includes(
-    providedId as (typeof BASELINE_SYSTEM_TOOL_PROVIDED_IDS)[number],
-  );
-}
 
 export function deriveExecutionScopesFromToolPermissions(
   permissions: AgentRuntimeToolPermissionLike[],
@@ -46,18 +34,6 @@ export function deriveExecutionScopesFromToolPermissions(
   const scopes = new Set<string>(BASELINE_AGENT_EXECUTION_SCOPES);
 
   for (const permission of permissions) {
-    const providedId = permission.server.providedId;
-    if (isBaselineSystemTool(providedId)) {
-      const availableScopeIds = permission.availableScopes.map((scope) => scope.id);
-      const fallbackScopes = BASELINE_SCOPES_BY_PROVIDED_ID[providedId] ?? [];
-      const baselineScopes = availableScopeIds.length > 0 ? availableScopeIds : fallbackScopes;
-
-      for (const scopeId of baselineScopes) {
-        scopes.add(scopeId);
-      }
-      continue;
-    }
-
     for (const scope of permission.grantedScopes) {
       scopes.add(scope.id);
     }

--- a/packages/shared/src/agent-runtime-permissions.ts
+++ b/packages/shared/src/agent-runtime-permissions.ts
@@ -1,0 +1,78 @@
+export const BASELINE_SYSTEM_TOOL_PROVIDED_IDS = ['tasks', 'context'] as const;
+
+export const BASELINE_AGENT_EXECUTION_SCOPES = [
+  'meta:read',
+  'mcp:use',
+  'tasks:read',
+  'tasks:write',
+  'context:read',
+  'context:write',
+] as const;
+
+export const DEFAULT_AGENT_ALLOWED_TOOLS = [
+  'SlashCommand',
+  'Bash',
+  'Read',
+  'Write',
+  'Edit',
+] as const;
+
+const BASELINE_SCOPES_BY_PROVIDED_ID: Record<string, readonly string[]> = {
+  tasks: ['tasks:read', 'tasks:write'],
+  context: ['context:read', 'context:write'],
+};
+
+export type AgentRuntimeScopeLike = {
+  id: string;
+};
+
+export type AgentRuntimeToolPermissionLike = {
+  server: {
+    providedId: string;
+  };
+  availableScopes: AgentRuntimeScopeLike[];
+  grantedScopes: AgentRuntimeScopeLike[];
+};
+
+export function isBaselineSystemTool(providedId: string): boolean {
+  return BASELINE_SYSTEM_TOOL_PROVIDED_IDS.includes(
+    providedId as (typeof BASELINE_SYSTEM_TOOL_PROVIDED_IDS)[number],
+  );
+}
+
+export function deriveExecutionScopesFromToolPermissions(
+  permissions: AgentRuntimeToolPermissionLike[],
+): string[] {
+  const scopes = new Set<string>(BASELINE_AGENT_EXECUTION_SCOPES);
+
+  for (const permission of permissions) {
+    const providedId = permission.server.providedId;
+    if (isBaselineSystemTool(providedId)) {
+      const availableScopeIds = permission.availableScopes.map((scope) => scope.id);
+      const fallbackScopes = BASELINE_SCOPES_BY_PROVIDED_ID[providedId] ?? [];
+      const baselineScopes = availableScopeIds.length > 0 ? availableScopeIds : fallbackScopes;
+
+      for (const scopeId of baselineScopes) {
+        scopes.add(scopeId);
+      }
+      continue;
+    }
+
+    for (const scope of permission.grantedScopes) {
+      scopes.add(scope.id);
+    }
+  }
+
+  return [...scopes].sort((a, b) => a.localeCompare(b));
+}
+
+export function deriveAllowedToolsFromProvidedIds(
+  providedIds: string[],
+  alwaysAllowedTools: readonly string[] = DEFAULT_AGENT_ALLOWED_TOOLS,
+): string[] {
+  const tools = new Set<string>(alwaysAllowedTools);
+  for (const providedId of providedIds) {
+    tools.add(`mcp__${providedId}__*`);
+  }
+  return [...tools];
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,3 +57,5 @@ export const DEFAULT_AGENT_TOKEN_SCOPES = [
   'mcp:use',
   'secret:read',
 ] as const;
+
+export * from './agent-runtime-permissions.js';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -39,6 +39,10 @@ export const INTERNAL_WORKER_AUTH_SCOPES: Scope[] = [
     id: 'meta:read',
     description: 'Read meta information (tags, etc.)',
   },
+  {
+    id: 'mcp-registry:read',
+    description: 'Allows workers to read MCP server registry metadata.',
+  },
 ];
 
 export const DEFAULT_AGENT_TOKEN_SCOPES = [


### PR DESCRIPTION
## Summary
- Makes agent tool permissions the runtime source of truth for both MCP mounting and execution token scope derivation.
- Ensures Tasks and Context remain guaranteed baseline structural tools for every agent by injecting implicit baseline permissions in the backend permission listing.
- Updates both backend-worker orchestration and standalone worker paths to consume runtime MCP config from agent tool permissions and remove hardcoded token scope requests.

## What Changed
- Added shared runtime derivation helpers in `@taico/shared` (`agent-runtime-permissions`) for:
  - baseline system tool IDs and baseline execution scopes
  - derived execution JWT scopes from effective tool permissions
  - derived Claude allowed-tool patterns from mounted MCP servers
- Extended agent tool permission response payload to include runtime transport fields (`url`, `cmd`, `args`).
- Updated `AgentToolPermissionsService.listAgentToolPermissions` to include effective baseline Tasks/Context permissions for all agents.
- Updated execution-token API to allow omitted `scopes`; backend now derives scopes from effective permissions + baseline when omitted.
- Updated backend execution orchestrator + runners and standalone worker + runners to mount MCP servers from permissions instead of hardcoded Tasks/Context blocks.

## Validation
- ✅ `npm run build:dev` succeeded
- ⚠️ `npm run dev:1` started backend successfully, but both Vite frontends failed in this environment with `ENOSPC` (file watcher limit)

## Technical Debt / Follow-up
- OpenCode runner currently only mounts HTTP runtime MCP servers; STDIO mounts are ignored in OpenCode path due SDK config constraints and should be addressed once validated end-to-end.