### PR TITLE
Add download as markdown button to context block detail page

### DIFF
--- a/apps/ui2/src/features/context/ContextBlockDetailPage.tsx
+++ b/apps/ui2/src/features/context/ContextBlockDetailPage.tsx
@@ -90,6 +90,35 @@ export function ContextBlockDetailPage() {
     }
   }, [isDeleted, navigate]);
 
+  // Handle markdown download
+  const handleDownload = () => {
+    if (!block) return;
+
+    // Sanitize the title to create a safe filename
+    const sanitizedTitle = block.title
+      .replace(/[^a-z0-9]/gi, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+      .toLowerCase();
+
+    const filename = `${sanitizedTitle || 'context-block'}.md`;
+
+    // Create blob with markdown content
+    const blob = new Blob([block.content], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+
+    // Create temporary link and trigger download
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+
+    // Cleanup
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   const breadcrumbs = useMemo(() => {
     if (!block) {
       return [];
@@ -209,6 +238,13 @@ export function ContextBlockDetailPage() {
           onClick={() => navigate(`/context/block/${block.id}/edit`)}
         >
           Edit
+        </Button>
+        <Button
+          size='lg'
+          variant='secondary'
+          onClick={handleDownload}
+        >
+          Download as Markdown
         </Button>
         {threadId && (
           <Button


### PR DESCRIPTION
## Summary

Added a "Download as Markdown" button to the context block detail view that allows users to download block content as a `.md` file.

## Changes

- Added `handleDownload` function to `ContextBlockDetailPage.tsx` that:
  - Sanitizes the block title to create a safe filename (removes special chars, replaces with hyphens)
  - Creates a Blob with markdown content type
  - Triggers browser download with `.md` extension
  - Properly cleans up temporary URLs after download
- Added "Download as Markdown" button next to the Edit button in the action buttons section

## Technical Details

The implementation uses the browser's native download API with proper cleanup:
1. Sanitizes title using regex to remove special characters
2. Falls back to `context-block.md` for empty titles
3. Creates a temporary object URL for the blob
4. Triggers download via programmatically created link element
5. Cleans up DOM and revokes object URL to prevent memory leaks

## Testing

✅ Build completed successfully (`npm run build:dev`)
✅ Backend compiled with 0 errors
✅ No TypeScript errors

## Related

Closes task: 103d2780-96ef-4a66-a4b9-2e1ae8e847bd

🤖 Generated with Claude Code