### PR TITLE
Filter tasks with pending input requests from execution queue

### DIFF
--- a/apps/backend/src/executions-v2/readiness/readiness-candidate.repository.ts
+++ b/apps/backend/src/executions-v2/readiness/readiness-candidate.repository.ts
@@ -52,6 +52,14 @@ export class ReadinessCandidateRepository {
             AND prerequisite.deleted_at IS NULL
             AND prerequisite.status != :doneStatus
         )`,
+      )
+      .andWhere(
+        `NOT EXISTS (
+          SELECT 1
+          FROM task_input_requests input_request
+          WHERE input_request.task_id = task.id
+            AND input_request.resolved_at IS NULL
+        )`,
       );
   }
 


### PR DESCRIPTION
## Summary

This PR implements filtering of tasks with unanswered input requests from the execution queue. When a task has a pending question that hasn't been answered, it is now excluded from being eligible for agent execution.

## Changes

- Modified `ReadinessCandidateRepository.applyCandidateFilters()` to add a new filter condition
- Added a subquery to check for pending input requests (where `resolved_at IS NULL`)
- Tasks with unanswered questions will no longer appear in the execution queue

## Technical Details

The filter uses a `NOT EXISTS` subquery to check the `task_input_requests` table for any unresolved requests associated with the task. This follows the same pattern as the existing dependency check.

## Testing

- ✅ Build verified with `npm run build:dev`
- ✅ Backend starts successfully
- The change is a pure database filter addition with no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)