### PR TITLE
Show task run failure details and agent slugs in runs UI

### DIFF
--- a/apps/ui2/src/features/executions/ExecutionsPage.css
+++ b/apps/ui2/src/features/executions/ExecutionsPage.css
@@ -233,6 +233,15 @@
   gap: var(--space-1);
 }
 
+.executions-actor-cell {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.executions-actor-slug {
+  color: var(--text-muted);
+}
+
 .executions-task-cell--clickable {
   background: none;
   border: none;

--- a/apps/ui2/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui2/src/features/executions/ExecutionsPage.tsx
@@ -2,6 +2,7 @@ import { Fragment, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
 import { Button, Card, Text } from "../../ui/primitives";
+import { useActorsCtx } from "../actors";
 import { useExecutions } from "./useExecutions";
 import type {
   TaskExecutionQueueEntryResponseDto,
@@ -12,6 +13,7 @@ import "./ExecutionsPage.css";
 
 export function ExecutionsPage() {
   const navigate = useNavigate();
+  const { actors } = useActorsCtx();
   const {
     queue,
     active,
@@ -132,20 +134,28 @@ export function ExecutionsPage() {
             table={
               <ExecutionTable
                 columns={["State", "Task", "Worker", "Agent", "Claimed", "Latest heartbeat", "Before claim"]}
-                rows={active.map((entry) => ({
-                  key: entry.id,
-                  cells: [
+                rows={active.map((entry) => {
+                  const actor = actors.find((candidate) => candidate.id === entry.agentActorId);
+
+                  return {
+                    key: entry.id,
+                    cells: [
                     <StatusPill key="state" tone="warning">Active</StatusPill>,
                     <TaskCell key="task" taskId={entry.taskId} taskName={entry.taskName} onClick={() => navigate(`/tasks/task/${entry.taskId}`)} />,
                     <CodeCell key="worker" value={entry.workerClientId} />,
-                    <CodeCell key="agent" value={entry.agentActorId} />,
+                    <ActorCell
+                      key="agent"
+                      actorId={entry.agentActorId}
+                      actorName={actor?.displayName}
+                      actorSlug={actor?.slug}
+                    />,
                     <TimeCell key="claimed" value={entry.claimedAt} />,
                     <TimeCell key="heartbeat" value={entry.lastHeartbeatAt} />,
                     <StatusPill key="before" tone={taskStatusTone(entry.taskStatusBeforeClaim)}>
                       {entry.taskStatusBeforeClaim}
                     </StatusPill>,
-                  ],
-                  mobile: (
+                    ],
+                    mobile: (
                     <ExecutionMobileCard
                       key={`active-mobile-${entry.id}`}
                       tone="warning"
@@ -155,13 +165,14 @@ export function ExecutionsPage() {
                         { label: "Claimed", value: formatDateTime(entry.claimedAt) },
                         { label: "Latest heartbeat", value: formatDateTime(entry.lastHeartbeatAt) },
                         { label: "Worker", value: shortId(entry.workerClientId), mono: true },
-                        { label: "Agent", value: shortId(entry.agentActorId), mono: true },
+                        { label: "Agent", value: actor?.slug ? `@${actor.slug}` : shortId(entry.agentActorId), mono: true },
                         { label: "Before claim", value: entry.taskStatusBeforeClaim },
                       ]}
                       onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
                     />
-                  ),
-                }))}
+                    ),
+                  };
+                })}
               />
             }
           />
@@ -173,17 +184,20 @@ export function ExecutionsPage() {
             emptyMessage="No historical executions yet."
             table={
               <ExecutionTable
-                columns={["Result", "Task", "Transitioned", "Task status", "Worker", "Error"]}
-                rows={history.map((entry) => ({
-                  key: entry.id,
-                  expandedContent:
+                columns={["Result", "Task", "Transitioned", "Task status", "Agent", "Worker", "Error"]}
+                rows={history.map((entry) => {
+                  const actor = actors.find((candidate) => candidate.id === entry.agentActorId);
+
+                  return {
+                    key: entry.id,
+                    expandedContent:
                     entry.errorMessage && expandedHistoryIds.has(entry.id) ? (
                       <ExecutionErrorMessage
                         status={entry.status}
                         message={entry.errorMessage}
                       />
                     ) : null,
-                  cells: [
+                    cells: [
                     <StatusPill key="result" tone={entry.status === "SUCCEEDED" ? "success" : "danger"}>
                       {entry.status}
                     </StatusPill>,
@@ -192,6 +206,12 @@ export function ExecutionsPage() {
                     <StatusPill key="task-status" tone={taskStatusTone(entry.taskStatus)}>
                       {entry.taskStatus ?? "Unknown"}
                     </StatusPill>,
+                    <ActorCell
+                      key="agent"
+                      actorId={entry.agentActorId}
+                      actorName={actor?.displayName}
+                      actorSlug={actor?.slug}
+                    />,
                     <CodeCell key="worker" value={entry.workerClientId} />,
                     <ErrorCell
                       key="error"
@@ -200,8 +220,8 @@ export function ExecutionsPage() {
                       expanded={expandedHistoryIds.has(entry.id)}
                       onToggle={() => toggleHistoryMessage(entry.id)}
                     />,
-                  ],
-                  mobile: (
+                    ],
+                    mobile: (
                     <ExecutionMobileCard
                       key={`history-mobile-${entry.id}`}
                       tone={entry.status === "SUCCEEDED" ? "success" : "danger"}
@@ -210,6 +230,7 @@ export function ExecutionsPage() {
                       lines={[
                         { label: "Transitioned", value: formatDateTime(entry.transitionedAt) },
                         { label: "Task status", value: entry.taskStatus ?? "Unknown" },
+                        { label: "Agent", value: actor?.slug ? `@${actor.slug}` : shortId(entry.agentActorId), mono: true },
                         { label: "Worker", value: shortId(entry.workerClientId), mono: true },
                         { label: "Error", value: entry.errorCode ?? "None" },
                         ...(entry.errorMessage
@@ -218,8 +239,9 @@ export function ExecutionsPage() {
                       ]}
                       onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
                     />
-                  ),
-                }))}
+                    ),
+                  };
+                })}
               />
             }
           />
@@ -384,6 +406,25 @@ function CodeCell({ value }: { value: string }) {
     <Text as="span" size="1" style="mono" className="executions-code-copy">
       {shortId(value)}
     </Text>
+  );
+}
+
+function ActorCell({
+  actorId,
+  actorName,
+  actorSlug,
+}: {
+  actorId: string;
+  actorName?: string;
+  actorSlug?: string;
+}) {
+  return (
+    <div className="executions-actor-cell">
+      <Text as="div" size="2" weight="semibold">{actorName ?? shortId(actorId)}</Text>
+      <Text as="div" size="1" tone="muted" style="mono" className="executions-actor-slug">
+        {actorSlug ? `@${actorSlug}` : shortId(actorId)}
+      </Text>
+    </div>
   );
 }
 

--- a/apps/ui2/src/features/tasks/TaskDetailPage.css
+++ b/apps/ui2/src/features/tasks/TaskDetailPage.css
@@ -190,6 +190,50 @@
   padding: 0 var(--space-3) var(--space-3);
 }
 
+.task-detail-page__execution-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.task-detail-page__execution-error-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: 1px solid color-mix(in srgb, var(--danger) 30%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--danger) 10%, var(--surface));
+  color: var(--danger);
+  font-size: var(--fs-1);
+  font-weight: var(--fw-bold);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.task-detail-page__execution-error-toggle:hover {
+  background: color-mix(in srgb, var(--danger) 16%, var(--surface));
+}
+
+.task-detail-page__execution-error-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--danger) 45%, transparent);
+  outline-offset: 2px;
+}
+
+.task-detail-page__execution-error-detail {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--r-2);
+  background: color-mix(in srgb, var(--danger) 5%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--danger) 12%, var(--border-subtle));
+}
+
+.task-detail-page__execution-error-code {
+  color: var(--danger);
+}
+
 @keyframes task-detail-activity-in {
   from {
     opacity: 0;

--- a/apps/ui2/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui2/src/features/tasks/TaskDetailPage.tsx
@@ -56,6 +56,8 @@ type TaskExecutionListItem = {
   status: 'ACTIVE' | TaskExecutionHistoryResponseDto['status'];
   source: 'active' | 'history';
   timestamp: string;
+  errorCode: TaskExecutionHistoryResponseDto['errorCode'] | null;
+  errorMessage: string | null;
 };
 
 export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask = false, activityByTaskId = {}, handlers, allTasks }: TaskDetailViewProps) {
@@ -257,11 +259,24 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
   const [executions, setExecutions] = useState<TaskExecutionListItem[]>([]);
   const [isLoadingExecutions, setIsLoadingExecutions] = useState(false);
   const [executionsError, setExecutionsError] = useState<string | null>(null);
+  const [expandedExecutionErrorIds, setExpandedExecutionErrorIds] = useState<Set<string>>(new Set());
 
   const [showNewCommentPop, setShowNewCommentPop] = useState(false);
   const [showAssignPop, setShowAssignPop] = useState(false);
   const [showTagPop, setShowTagPop] = useState(false);
   const [respondingToInputRequest, setRespondingToInputRequest] = useState<InputRequestResponseDto | null>(null);
+
+  const toggleExecutionErrorDetails = useCallback((executionId: string) => {
+    setExpandedExecutionErrorIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(executionId)) {
+        next.delete(executionId);
+      } else {
+        next.add(executionId);
+      }
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -406,6 +421,8 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
           status: 'ACTIVE',
           source: 'active',
           timestamp: entry.claimedAt,
+          errorCode: null,
+          errorMessage: null,
         }));
 
       const taskHistoryItems = historyExecutions
@@ -417,6 +434,8 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
           status: entry.status,
           source: 'history',
           timestamp: entry.transitionedAt,
+          errorCode: entry.errorCode,
+          errorMessage: entry.errorMessage,
         }));
 
       const sorted = [...taskActiveItems, ...taskHistoryItems].sort(
@@ -439,9 +458,11 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
     if (!task) {
       setExecutions([]);
       setExecutionsError(null);
+      setExpandedExecutionErrorIds(new Set());
       return;
     }
 
+    setExpandedExecutionErrorIds(new Set());
     void loadExecutionsForTask(task.id);
   }, [task, loadExecutionsForTask]);
 
@@ -808,6 +829,9 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
           const actorName = actor?.displayName ?? shortId(execution.agentActorId);
           const actorSlug = actor?.slug;
           const statusTag = getExecutionStatusTag(execution.status);
+          const hasFailureDetails =
+            execution.status === 'FAILED' && Boolean(execution.errorCode || execution.errorMessage);
+          const isFailureDetailsExpanded = expandedExecutionErrorIds.has(execution.id);
           const sourceTag: DataRowTag = {
             label: execution.source === 'active' ? 'active' : 'history',
             color: 'gray',
@@ -830,8 +854,36 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
                   </Text>
                 </div>
                 <Text as='span' tone='muted' size='2'>
-                  run #{shortId(execution.executionId)}
+                  <span className='task-detail-page__execution-meta'>
+                    run #{shortId(execution.executionId)}
+                    {hasFailureDetails ? (
+                      <button
+                        type='button'
+                        className='task-detail-page__execution-error-toggle'
+                        onClick={() => toggleExecutionErrorDetails(execution.id)}
+                        aria-label={isFailureDetailsExpanded ? 'Hide failure details' : 'Show failure details'}
+                        aria-expanded={isFailureDetailsExpanded}
+                        title={isFailureDetailsExpanded ? 'Hide failure details' : 'Show failure details'}
+                      >
+                        i
+                      </button>
+                    ) : null}
+                  </span>
                 </Text>
+                {hasFailureDetails && isFailureDetailsExpanded ? (
+                  <div className='task-detail-page__execution-error-detail'>
+                    {execution.errorCode ? (
+                      <Text as='span' size='1' style='mono' className='task-detail-page__execution-error-code'>
+                        {execution.errorCode}
+                      </Text>
+                    ) : null}
+                    {execution.errorMessage ? (
+                      <Text as='span' size='2' wrap>
+                        {execution.errorMessage}
+                      </Text>
+                    ) : null}
+                  </div>
+                ) : null}
               </Stack>
             </DataRow>
           );


### PR DESCRIPTION
## Summary
- add optional failure-detail disclosure to Task Detail run rows, shown only for failed history executions that include `errorCode` or `errorMessage`
- include agent identity (name + `@slug` fallback) in Runs page active/history tables and mobile cards for faster attribution
- keep existing run history error expansion behavior and align new UI patterns across Task Detail and Runs views

## Validation
- `npm run build:dev`
- `npm run dev:1`

## Technical debt
- actor lookups in `ExecutionsPage` currently call `actors.find(...)` per row; we can optimize with a memoized actor map if execution lists grow substantially