### PR TITLE
Enrich execution telemetry and surface it in Runs + Task Detail

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -5998,6 +5998,78 @@
         ]
       }
     },
+    "/api/v1/executions-v2/active/{executionId}/session": {
+      "patch": {
+        "description": "Stores the runtime session identifier emitted by the agent harness so it can be propagated to execution history.",
+        "operationId": "ActiveTaskExecutionController_updateRunnerSessionId",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to update",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRunnerSessionIdDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Attach the runner session id to an active execution",
+        "tags": [
+          "Executions V2"
+        ]
+      }
+    },
+    "/api/v1/executions-v2/active/{executionId}/tool-calls/increment": {
+      "patch": {
+        "description": "Atomically increments the active execution tool-call counter without touching other mutable execution fields.",
+        "operationId": "ActiveTaskExecutionController_incrementToolCallCount",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to update",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Increment tool call count for an active execution",
+        "tags": [
+          "Executions V2"
+        ]
+      }
+    },
     "/api/v1/executions-v2/history": {
       "get": {
         "description": "Returns the persisted execution history rows in the v2 execution system.",
@@ -11367,6 +11439,17 @@
             "example": "2026-04-03T08:25:10.000Z",
             "nullable": true
           },
+          "runnerSessionId": {
+            "type": "string",
+            "description": "Agent runtime session identifier associated with this execution",
+            "example": "session_01JZ0SMM85FBFA8Y82M8VREY2A",
+            "nullable": true
+          },
+          "toolCallCount": {
+            "type": "number",
+            "description": "Number of tool calls made during this execution so far",
+            "example": 7
+          },
           "taskStatusBeforeClaim": {
             "type": "string",
             "description": "Task status before the task was claimed",
@@ -11408,6 +11491,8 @@
           "taskStatus",
           "claimedAt",
           "lastHeartbeatAt",
+          "runnerSessionId",
+          "toolCallCount",
           "taskStatusBeforeClaim",
           "taskTagsBeforeClaim",
           "workerClientId",
@@ -11501,6 +11586,17 @@
             "description": "OAuth client id of the worker that executed the task",
             "example": "24f52f295c990c1d6cdc6034fa3d1900"
           },
+          "runnerSessionId": {
+            "type": "string",
+            "description": "Agent runtime session identifier associated with this execution",
+            "example": "session_01JZ0SMM85FBFA8Y82M8VREY2A",
+            "nullable": true
+          },
+          "toolCallCount": {
+            "type": "number",
+            "description": "Number of tool calls made during the execution",
+            "example": 12
+          },
           "status": {
             "type": "string",
             "description": "Terminal execution status",
@@ -11536,9 +11632,25 @@
           "transitionedAt",
           "agentActorId",
           "workerClientId",
+          "runnerSessionId",
+          "toolCallCount",
           "status",
           "errorCode",
           "errorMessage"
+        ]
+      },
+      "UpdateRunnerSessionIdDto": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Agent runtime session identifier for this execution",
+            "example": "session_01JZ0SMM85FBFA8Y82M8VREY2A",
+            "maxLength": 255
+          }
+        },
+        "required": [
+          "sessionId"
         ]
       },
       "CreateTaskBlueprintDto": {

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -38,6 +38,7 @@ import { AddExecutionsV2Tables1741700000000 } from './migrations/1741700000000-A
 import { AddLastHeartbeatAtToActiveExecutionsV21741800000000 } from './migrations/1741800000000-AddLastHeartbeatAtToActiveExecutionsV2';
 import { AddErrorMessageToTaskExecutionHistoryV21741900000000 } from './migrations/1741900000000-AddErrorMessageToTaskExecutionHistoryV2';
 import { AddAgentToolPermissions1742000000000 } from './migrations/1742000000000-AddAgentToolPermissions';
+import { AddExecutionEnrichmentFieldsV21742100000000 } from './migrations/1742100000000-AddExecutionEnrichmentFieldsV2';
 import { SecretsModule } from './secrets/secrets.module';
 import { ChatProvidersModule } from './chat-providers/chat-providers.module';
 import { ExecutionsModule } from './executions/executions.module';
@@ -73,6 +74,7 @@ import { GlobalSearchModule } from './global-search/global-search.module';
         AddLastHeartbeatAtToActiveExecutionsV21741800000000,
         AddErrorMessageToTaskExecutionHistoryV21741900000000,
         AddAgentToolPermissions1742000000000,
+        AddExecutionEnrichmentFieldsV21742100000000,
       ],
     }),
     EventEmitterModule.forRoot(),

--- a/apps/backend/src/executions-v2/active/active-task-execution.controller.ts
+++ b/apps/backend/src/executions-v2/active/active-task-execution.controller.ts
@@ -1,10 +1,11 @@
 import {
   Body,
-  ConflictException,
   Controller,
   Get,
+  HttpCode,
   NotFoundException,
   Param,
+  Patch,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -27,6 +28,7 @@ import { ActiveTaskExecutionNotFoundError } from '../errors/executions-v2.errors
 import { ActiveTaskExecutionService } from './active-task-execution.service';
 import { ActiveTaskExecutionResponseDto } from './dto/http/active-task-execution-response.dto';
 import { StopActiveTaskExecutionDto } from './dto/http/stop-active-task-execution.dto';
+import { UpdateRunnerSessionIdDto } from './dto/http/update-runner-session-id.dto';
 import { TaskExecutionHistoryResponseDto } from '../history/dto/http/task-execution-history-response.dto';
 
 @ApiTags('Executions V2')
@@ -77,6 +79,58 @@ export class ActiveTaskExecutionController {
       });
 
       return TaskExecutionHistoryResponseDto.fromEntity(historyEntry);
+    } catch (error) {
+      if (error instanceof ActiveTaskExecutionNotFoundError) {
+        throw new NotFoundException(error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  @Patch(':executionId/session')
+  @HttpCode(204)
+  @RequireScopes(WorkersScopes.CONNECT.id)
+  @ApiOperation({
+    summary: 'Attach the runner session id to an active execution',
+    description:
+      'Stores the runtime session identifier emitted by the agent harness so it can be propagated to execution history.',
+  })
+  @ApiParam({ name: 'executionId', description: 'Execution ID to update' })
+  async updateRunnerSessionId(
+    @Param('executionId') executionId: string,
+    @Body() dto: UpdateRunnerSessionIdDto,
+  ): Promise<void> {
+    try {
+      await this.activeTaskExecutionService.updateRunnerSessionId({
+        executionId,
+        runnerSessionId: dto.sessionId,
+      });
+    } catch (error) {
+      if (error instanceof ActiveTaskExecutionNotFoundError) {
+        throw new NotFoundException(error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  @Patch(':executionId/tool-calls/increment')
+  @HttpCode(204)
+  @RequireScopes(WorkersScopes.CONNECT.id)
+  @ApiOperation({
+    summary: 'Increment tool call count for an active execution',
+    description:
+      'Atomically increments the active execution tool-call counter without touching other mutable execution fields.',
+  })
+  @ApiParam({ name: 'executionId', description: 'Execution ID to update' })
+  async incrementToolCallCount(
+    @Param('executionId') executionId: string,
+  ): Promise<void> {
+    try {
+      await this.activeTaskExecutionService.incrementToolCallCount({
+        executionId,
+      });
     } catch (error) {
       if (error instanceof ActiveTaskExecutionNotFoundError) {
         throw new NotFoundException(error.message);

--- a/apps/backend/src/executions-v2/active/active-task-execution.entity.ts
+++ b/apps/backend/src/executions-v2/active/active-task-execution.entity.ts
@@ -63,6 +63,12 @@ export class ActiveTaskExecutionEntity {
   @Column({ type: 'datetime', name: 'last_heartbeat_at', nullable: true })
   lastHeartbeatAt!: Date | null;
 
+  @Column({ type: 'text', name: 'runner_session_id', nullable: true })
+  runnerSessionId!: string | null;
+
+  @Column({ type: 'integer', name: 'tool_call_count', default: 0 })
+  toolCallCount!: number;
+
   @VersionColumn({ name: 'row_version' })
   rowVersion!: number;
 

--- a/apps/backend/src/executions-v2/active/active-task-execution.service.ts
+++ b/apps/backend/src/executions-v2/active/active-task-execution.service.ts
@@ -34,6 +34,15 @@ export type StopTaskExecutionInput = {
   errorMessage?: string | null;
 };
 
+export type UpdateRunnerSessionIdInput = {
+  executionId: string;
+  runnerSessionId: string;
+};
+
+export type IncrementToolCallCountInput = {
+  executionId: string;
+};
+
 @Injectable()
 export class ActiveTaskExecutionService {
   constructor(
@@ -101,6 +110,8 @@ export class ActiveTaskExecutionService {
         agentActorId: assigneeActorId,
         workerClientId: input.workerClientId,
         lastHeartbeatAt: null,
+        runnerSessionId: null,
+        toolCallCount: 0,
       });
 
       const savedExecution = await manager.save(activeExecution);
@@ -150,6 +161,8 @@ export class ActiveTaskExecutionService {
         transitionedAt: new Date(),
         agentActorId: activeExecution.agentActorId,
         workerClientId: input.workerClientId,
+        runnerSessionId: activeExecution.runnerSessionId,
+        toolCallCount: activeExecution.toolCallCount,
         status: input.status,
         errorCode: input.errorCode ?? null,
         errorMessage: input.errorMessage ?? null,
@@ -191,5 +204,49 @@ export class ActiveTaskExecutionService {
     });
 
     return historyEntry;
+  }
+
+  async updateRunnerSessionId(input: UpdateRunnerSessionIdInput): Promise<void> {
+    const result = await this.activeTaskExecutionRepository
+      .createQueryBuilder()
+      .update(ActiveTaskExecutionEntity)
+      .set({
+        runnerSessionId: input.runnerSessionId,
+        rowVersion: () => 'row_version + 1',
+        updatedAt: () => 'CURRENT_TIMESTAMP',
+      })
+      .where('id = :executionId', { executionId: input.executionId })
+      .andWhere('runner_session_id IS NULL')
+      .execute();
+
+    if ((result.affected ?? 0) > 0) {
+      return;
+    }
+
+    const existing = await this.activeTaskExecutionRepository.findOne({
+      where: { id: input.executionId },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      throw new ActiveTaskExecutionNotFoundError(input.executionId);
+    }
+  }
+
+  async incrementToolCallCount(input: IncrementToolCallCountInput): Promise<void> {
+    const result = await this.activeTaskExecutionRepository
+      .createQueryBuilder()
+      .update(ActiveTaskExecutionEntity)
+      .set({
+        toolCallCount: () => 'tool_call_count + 1',
+        rowVersion: () => 'row_version + 1',
+        updatedAt: () => 'CURRENT_TIMESTAMP',
+      })
+      .where('id = :executionId', { executionId: input.executionId })
+      .execute();
+
+    if ((result.affected ?? 0) === 0) {
+      throw new ActiveTaskExecutionNotFoundError(input.executionId);
+    }
   }
 }

--- a/apps/backend/src/executions-v2/active/dto/http/active-task-execution-response.dto.ts
+++ b/apps/backend/src/executions-v2/active/dto/http/active-task-execution-response.dto.ts
@@ -71,6 +71,20 @@ export class ActiveTaskExecutionResponseDto {
   lastHeartbeatAt!: string | null;
 
   @ApiProperty({
+    type: String,
+    description: 'Agent runtime session identifier associated with this execution',
+    example: 'session_01JZ0SMM85FBFA8Y82M8VREY2A',
+    nullable: true,
+  })
+  runnerSessionId!: string | null;
+
+  @ApiProperty({
+    description: 'Number of tool calls made during this execution so far',
+    example: 7,
+  })
+  toolCallCount!: number;
+
+  @ApiProperty({
     description: 'Task status before the task was claimed',
     enum: TaskStatus,
   })
@@ -112,6 +126,8 @@ export class ActiveTaskExecutionResponseDto {
       taskStatus: entity.task?.status ?? null,
       claimedAt: entity.claimedAt.toISOString(),
       lastHeartbeatAt: entity.lastHeartbeatAt?.toISOString() ?? null,
+      runnerSessionId: entity.runnerSessionId,
+      toolCallCount: entity.toolCallCount,
       taskStatusBeforeClaim: entity.taskStatusBeforeClaim,
       taskTagsBeforeClaim: entity.taskTagsBeforeClaim.map((tag) =>
         ActiveTaskExecutionTagSnapshotResponseDto.fromSnapshot(tag),

--- a/apps/backend/src/executions-v2/active/dto/http/update-runner-session-id.dto.ts
+++ b/apps/backend/src/executions-v2/active/dto/http/update-runner-session-id.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MaxLength } from 'class-validator';
+
+export class UpdateRunnerSessionIdDto {
+  @ApiProperty({
+    description: 'Agent runtime session identifier for this execution',
+    example: 'session_01JZ0SMM85FBFA8Y82M8VREY2A',
+    maxLength: 255,
+  })
+  @IsString()
+  @MaxLength(255)
+  sessionId!: string;
+}

--- a/apps/backend/src/executions-v2/history/dto/http/task-execution-history-response.dto.ts
+++ b/apps/backend/src/executions-v2/history/dto/http/task-execution-history-response.dto.ts
@@ -57,6 +57,20 @@ export class TaskExecutionHistoryResponseDto {
   workerClientId!: string;
 
   @ApiProperty({
+    type: String,
+    description: 'Agent runtime session identifier associated with this execution',
+    example: 'session_01JZ0SMM85FBFA8Y82M8VREY2A',
+    nullable: true,
+  })
+  runnerSessionId!: string | null;
+
+  @ApiProperty({
+    description: 'Number of tool calls made during the execution',
+    example: 12,
+  })
+  toolCallCount!: number;
+
+  @ApiProperty({
     description: 'Terminal execution status',
     enum: TaskExecutionHistoryStatus,
   })
@@ -89,6 +103,8 @@ export class TaskExecutionHistoryResponseDto {
       transitionedAt: entity.transitionedAt.toISOString(),
       agentActorId: entity.agentActorId,
       workerClientId: entity.workerClientId,
+      runnerSessionId: entity.runnerSessionId,
+      toolCallCount: entity.toolCallCount,
       status: entity.status,
       errorCode: entity.errorCode,
       errorMessage: entity.errorMessage,

--- a/apps/backend/src/executions-v2/history/task-execution-history.entity.ts
+++ b/apps/backend/src/executions-v2/history/task-execution-history.entity.ts
@@ -42,6 +42,12 @@ export class TaskExecutionHistoryEntity {
   @Column({ type: 'text', name: 'worker_client_id' })
   workerClientId!: string;
 
+  @Column({ type: 'text', name: 'runner_session_id', nullable: true })
+  runnerSessionId!: string | null;
+
+  @Column({ type: 'integer', name: 'tool_call_count', default: 0 })
+  toolCallCount!: number;
+
   @Column({
     type: 'text',
     enum: TaskExecutionHistoryStatus,

--- a/apps/backend/src/migrations/1742100000000-AddExecutionEnrichmentFieldsV2.ts
+++ b/apps/backend/src/migrations/1742100000000-AddExecutionEnrichmentFieldsV2.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddExecutionEnrichmentFieldsV21742100000000
+  implements MigrationInterface
+{
+  name = 'AddExecutionEnrichmentFieldsV21742100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE active_task_executions_v2
+      ADD COLUMN runner_session_id text
+    `);
+    await queryRunner.query(`
+      ALTER TABLE active_task_executions_v2
+      ADD COLUMN tool_call_count integer NOT NULL DEFAULT 0
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE task_execution_history_v2
+      ADD COLUMN runner_session_id text
+    `);
+    await queryRunner.query(`
+      ALTER TABLE task_execution_history_v2
+      ADD COLUMN tool_call_count integer NOT NULL DEFAULT 0
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE task_execution_history_v2
+      DROP COLUMN tool_call_count
+    `);
+    await queryRunner.query(`
+      ALTER TABLE task_execution_history_v2
+      DROP COLUMN runner_session_id
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE active_task_executions_v2
+      DROP COLUMN tool_call_count
+    `);
+    await queryRunner.query(`
+      ALTER TABLE active_task_executions_v2
+      DROP COLUMN runner_session_id
+    `);
+  }
+}

--- a/apps/ui2/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui2/src/features/executions/ExecutionsPage.tsx
@@ -133,7 +133,7 @@ export function ExecutionsPage() {
             emptyMessage="No active executions right now."
             table={
               <ExecutionTable
-                columns={["State", "Task", "Worker", "Agent", "Claimed", "Latest heartbeat", "Before claim"]}
+                columns={["State", "Task", "Worker", "Agent", "Session", "Tools", "Claimed", "Latest heartbeat", "Before claim"]}
                 rows={active.map((entry) => {
                   const actor = actors.find((candidate) => candidate.id === entry.agentActorId);
 
@@ -149,6 +149,8 @@ export function ExecutionsPage() {
                       actorName={actor?.displayName}
                       actorSlug={actor?.slug}
                     />,
+                    <SessionCell key="session" value={entry.runnerSessionId} />,
+                    <ToolCountCell key="tool-count" value={entry.toolCallCount} />,
                     <TimeCell key="claimed" value={entry.claimedAt} />,
                     <TimeCell key="heartbeat" value={entry.lastHeartbeatAt} />,
                     <StatusPill key="before" tone={taskStatusTone(entry.taskStatusBeforeClaim)}>
@@ -166,6 +168,8 @@ export function ExecutionsPage() {
                         { label: "Latest heartbeat", value: formatDateTime(entry.lastHeartbeatAt) },
                         { label: "Worker", value: shortId(entry.workerClientId), mono: true },
                         { label: "Agent", value: actor?.slug ? `@${actor.slug}` : shortId(entry.agentActorId), mono: true },
+                        { label: "Session", value: formatSession(entry.runnerSessionId), mono: true },
+                        { label: "Tool calls", value: String(entry.toolCallCount) },
                         { label: "Before claim", value: entry.taskStatusBeforeClaim },
                       ]}
                       onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
@@ -184,7 +188,7 @@ export function ExecutionsPage() {
             emptyMessage="No historical executions yet."
             table={
               <ExecutionTable
-                columns={["Result", "Task", "Transitioned", "Task status", "Agent", "Worker", "Error"]}
+                columns={["Result", "Task", "Transitioned", "Task status", "Agent", "Worker", "Session", "Tools", "Error"]}
                 rows={history.map((entry) => {
                   const actor = actors.find((candidate) => candidate.id === entry.agentActorId);
 
@@ -213,6 +217,8 @@ export function ExecutionsPage() {
                       actorSlug={actor?.slug}
                     />,
                     <CodeCell key="worker" value={entry.workerClientId} />,
+                    <SessionCell key="session" value={entry.runnerSessionId} />,
+                    <ToolCountCell key="tool-count" value={entry.toolCallCount} />,
                     <ErrorCell
                       key="error"
                       errorCode={entry.errorCode}
@@ -232,6 +238,8 @@ export function ExecutionsPage() {
                         { label: "Task status", value: entry.taskStatus ?? "Unknown" },
                         { label: "Agent", value: actor?.slug ? `@${actor.slug}` : shortId(entry.agentActorId), mono: true },
                         { label: "Worker", value: shortId(entry.workerClientId), mono: true },
+                        { label: "Session", value: formatSession(entry.runnerSessionId), mono: true },
+                        { label: "Tool calls", value: String(entry.toolCallCount) },
                         { label: "Error", value: entry.errorCode ?? "None" },
                         ...(entry.errorMessage
                           ? [{ label: "Message", value: entry.errorMessage }]
@@ -498,6 +506,22 @@ function TimeCell({ value }: { value: string | null }) {
   );
 }
 
+function SessionCell({ value }: { value: string | null }) {
+  return (
+    <Text as="span" size="1" style="mono" className="executions-code-copy">
+      {formatSession(value)}
+    </Text>
+  );
+}
+
+function ToolCountCell({ value }: { value: number }) {
+  return (
+    <Text as="span" size="2" weight="semibold">
+      {value}
+    </Text>
+  );
+}
+
 function ExecutionMobileCard({
   title,
   badge,
@@ -610,4 +634,12 @@ function formatRelativeTime(value: string) {
 
 function shortId(value: string) {
   return value.length > 12 ? `${value.slice(0, 8)}…${value.slice(-4)}` : value;
+}
+
+function formatSession(value: string | null): string {
+  if (!value) {
+    return 'pending';
+  }
+
+  return shortId(value);
 }

--- a/apps/ui2/src/features/executions/useExecutions.ts
+++ b/apps/ui2/src/features/executions/useExecutions.ts
@@ -1,4 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { io } from 'socket.io-client';
+import { TaskActivityWireEvent, TaskWireEvents } from '@taico/events';
+import { getUIWebSocketUrl } from '../../config/api';
 import { ExecutionsService } from './api';
 import type {
   ActiveTaskExecutionResponseDto,
@@ -7,6 +10,7 @@ import type {
 } from './types';
 
 const EXECUTIONS_POLL_INTERVAL_MS = 5000;
+const SOCKET_URL = getUIWebSocketUrl('/tasks');
 
 export const useExecutions = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -68,6 +72,31 @@ export const useExecutions = () => {
     }, EXECUTIONS_POLL_INTERVAL_MS);
 
     return () => window.clearInterval(timer);
+  }, [loadExecutions]);
+
+  useEffect(() => {
+    const nextSocket = io(SOCKET_URL, {
+      transports: ['websocket', 'polling'],
+      withCredentials: true,
+    });
+
+    nextSocket.on('connect', () => {
+      nextSocket.emit('tasks.subscribe', {}, () => {
+        // no-op ack; polling remains fallback
+      });
+    });
+
+    nextSocket.on(TaskWireEvents.TASK_ACTIVITY, (evt: TaskActivityWireEvent) => {
+      if (!evt.kind.startsWith('execution.')) {
+        return;
+      }
+
+      void loadExecutions({ silent: true });
+    });
+
+    return () => {
+      nextSocket.close();
+    };
   }, [loadExecutions]);
 
   return {

--- a/apps/ui2/src/features/tasks/TaskDetailPage.css
+++ b/apps/ui2/src/features/tasks/TaskDetailPage.css
@@ -196,6 +196,17 @@
   gap: var(--space-2);
 }
 
+.task-detail-page__execution-stats {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+}
+
+.task-detail-page__execution-stats-separator {
+  color: var(--border);
+}
+
 .task-detail-page__execution-error-toggle {
   display: inline-flex;
   align-items: center;

--- a/apps/ui2/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui2/src/features/tasks/TaskDetailPage.tsx
@@ -56,6 +56,8 @@ type TaskExecutionListItem = {
   status: 'ACTIVE' | TaskExecutionHistoryResponseDto['status'];
   source: 'active' | 'history';
   timestamp: string;
+  runnerSessionId: string | null;
+  toolCallCount: number;
   errorCode: TaskExecutionHistoryResponseDto['errorCode'] | null;
   errorMessage: string | null;
 };
@@ -421,6 +423,8 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
           status: 'ACTIVE',
           source: 'active',
           timestamp: entry.claimedAt,
+          runnerSessionId: entry.runnerSessionId,
+          toolCallCount: entry.toolCallCount,
           errorCode: null,
           errorMessage: null,
         }));
@@ -434,6 +438,8 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
           status: entry.status,
           source: 'history',
           timestamp: entry.transitionedAt,
+          runnerSessionId: entry.runnerSessionId,
+          toolCallCount: entry.toolCallCount,
           errorCode: entry.errorCode,
           errorMessage: entry.errorMessage,
         }));
@@ -868,6 +874,13 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
                         i
                       </button>
                     ) : null}
+                  </span>
+                </Text>
+                <Text as='span' size='1' tone='muted'>
+                  <span className='task-detail-page__execution-stats'>
+                    tools: {execution.toolCallCount}
+                    <span className='task-detail-page__execution-stats-separator'>|</span>
+                    session: {execution.runnerSessionId ? shortId(execution.runnerSessionId) : 'pending'}
                   </span>
                 </Text>
                 {hasFailureDetails && isFailureDetailsExpanded ? (

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -82,6 +82,7 @@ export class ADKAgentRunner extends BaseAgentRunner {
     emit: (msg: string) => Promise<void>,
     setSession: (id: string) => Promise<void>,
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
+    onToolCall?: (toolName: string) => void | Promise<void>,
   ): Promise<string> {
     const formatter = new ADKMessageFormatter(ctx.agentSlug);
 
@@ -93,6 +94,7 @@ export class ADKAgentRunner extends BaseAgentRunner {
       sessionId: 'session-123',
       userId: 'user-123',
     });
+    await setSession(session.id);
 
     const mcpServers =
       ctx.mcpServers ?? {
@@ -150,6 +152,14 @@ export class ADKAgentRunner extends BaseAgentRunner {
     });
 
     for await (const msg of stream) {
+      if (msg.content?.parts) {
+        for (const part of msg.content.parts) {
+          if (part.functionCall?.name) {
+            await onToolCall?.(part.functionCall.name);
+          }
+        }
+      }
+
       // map → string
       const messages = formatter.format(msg);
       messages.forEach(async (message) => {

--- a/apps/worker/src/runners/AgentRunner.ts
+++ b/apps/worker/src/runners/AgentRunner.ts
@@ -67,6 +67,9 @@ export type AgentRunCallbacks = {
   /** Called for every human-readable event */
   onEvent?: (message: string) => void | Promise<void>;
 
+  /** Called whenever the runner initiates a tool call */
+  onToolCall?: (toolName: string) => void | Promise<void>;
+
   /** Called when an error occurs (e.g., quota limit, API errors) */
   onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>;
 };

--- a/apps/worker/src/runners/BaseAgentRunner.ts
+++ b/apps/worker/src/runners/BaseAgentRunner.ts
@@ -36,9 +36,15 @@ export abstract class BaseAgentRunner implements AgentRunner {
     };
 
     const onError = cb.onError;
+    const onToolCall = async (toolName: string) => {
+      if (!cb.onToolCall) {
+        return;
+      }
+      await cb.onToolCall(toolName);
+    };
 
     try {
-      result = await this.runInternal(ctx, emit, setSession, onError);
+      result = await this.runInternal(ctx, emit, setSession, onError, onToolCall);
     } catch (err: any) {
       await emit(`❌ Agent error: ${err?.message ?? String(err)}`);
       throw err;
@@ -58,5 +64,6 @@ export abstract class BaseAgentRunner implements AgentRunner {
     emit: (msg: string) => Promise<void>,
     setSession: (id: string) => Promise<void>,
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
+    onToolCall?: (toolName: string) => void | Promise<void>,
   ): Promise<string>;
 }

--- a/apps/worker/src/runners/ClaudeAgentRunner.ts
+++ b/apps/worker/src/runners/ClaudeAgentRunner.ts
@@ -18,6 +18,7 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
     emit: (msg: string) => Promise<void>,
     setSession: (id: string) => Promise<void>,
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
+    onToolCall?: (toolName: string) => void | Promise<void>,
   ): Promise<string> {
     const formatter = new ClaudeMessageFormatter(ctx.agentSlug);
 
@@ -63,6 +64,14 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
         typeof msg.session_id === 'string'
       ) {
         await setSession(msg.session_id);
+      }
+
+      if (msg?.type === 'assistant' && Array.isArray(msg.message?.content)) {
+        for (const part of msg.message.content) {
+          if (part.type === 'tool_use' && typeof part.name === 'string') {
+            await onToolCall?.(part.name);
+          }
+        }
       }
 
       // map → string

--- a/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
@@ -22,6 +22,7 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
     emit: (msg: string) => Promise<void>,
     setSession: (id: string) => Promise<void>,
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
+    onToolCall?: (toolName: string) => void | Promise<void>,
   ): Promise<string> {
     const agentLabel = ctx.agentSlug ? `@${ctx.agentSlug}` : 'Assistant';
 
@@ -66,6 +67,7 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
           void emit(`💬 ${agentLabel}: ${message.data.content}`);
         });
         session.on('tool.execution_start', (toolCall) => {
+          void onToolCall?.(toolCall.data.toolName);
           void emit(`🔧 ${agentLabel} Tool call: ${toolCall.data.toolName}`);
         });
         session.on('tool.execution_complete', () => {

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -142,6 +142,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     emit: (msg: string) => Promise<void>,
     setSession: (id: string) => Promise<void>,
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
+    onToolCall?: (toolName: string) => void | Promise<void>,
   ): Promise<string> {
     const formatter = new OpencodeAsyncMessageFormatter(ctx.agentSlug);
     this.runtimeMcpServers = ctx.mcpServers;
@@ -173,6 +174,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
       this.shutdown();
       throw new Error("Failed to create Opencode session");
     }
+    await setSession(session.id);
     console.log(`created session ${session.id} in ${session.directory}`);
     // Session is created in the right dir ✅
 
@@ -209,6 +211,14 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
         if (event.type == 'session.idle') {
           console.log('session.idle');
           break;
+        }
+
+        if (
+          event.type === 'message.part.updated' &&
+          !event.properties.delta &&
+          event.properties.part.type === 'tool'
+        ) {
+          await onToolCall?.(event.properties.part.tool);
         }
 
         const message = formatter.format(event);

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -160,6 +160,29 @@ export async function executeTask({
         },
         onSession: (runnerSessionId: string) => {
           latestRunnerSessionId = runnerSessionId;
+          return workerClient.executionsV2
+            .ActiveTaskExecutionController_updateRunnerSessionId({
+              executionId,
+              body: {
+                sessionId: runnerSessionId,
+              },
+            })
+            .catch((error) => {
+              console.warn(
+                `[worker] failed to persist runner session id for execution ${executionId}: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            });
+        },
+        onToolCall: (toolName: string) => {
+          return workerClient.executionsV2
+            .ActiveTaskExecutionController_incrementToolCallCount({
+              executionId,
+            })
+            .catch((error) => {
+              console.warn(
+                `[worker] failed to increment tool call count for execution ${executionId} (tool=${toolName}): ${error instanceof Error ? error.message : String(error)}`,
+              );
+            });
         },
         onError: (error: { message: string; rawMessage?: any }) => {
           console.log('Error detected');

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -5998,6 +5998,78 @@
         ]
       }
     },
+    "/api/v1/executions-v2/active/{executionId}/session": {
+      "patch": {
+        "description": "Stores the runtime session identifier emitted by the agent harness so it can be propagated to execution history.",
+        "operationId": "ActiveTaskExecutionController_updateRunnerSessionId",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to update",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRunnerSessionIdDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Attach the runner session id to an active execution",
+        "tags": [
+          "Executions V2"
+        ]
+      }
+    },
+    "/api/v1/executions-v2/active/{executionId}/tool-calls/increment": {
+      "patch": {
+        "description": "Atomically increments the active execution tool-call counter without touching other mutable execution fields.",
+        "operationId": "ActiveTaskExecutionController_incrementToolCallCount",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to update",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Increment tool call count for an active execution",
+        "tags": [
+          "Executions V2"
+        ]
+      }
+    },
     "/api/v1/executions-v2/history": {
       "get": {
         "description": "Returns the persisted execution history rows in the v2 execution system.",
@@ -11367,6 +11439,17 @@
             "example": "2026-04-03T08:25:10.000Z",
             "nullable": true
           },
+          "runnerSessionId": {
+            "type": "string",
+            "description": "Agent runtime session identifier associated with this execution",
+            "example": "session_01JZ0SMM85FBFA8Y82M8VREY2A",
+            "nullable": true
+          },
+          "toolCallCount": {
+            "type": "number",
+            "description": "Number of tool calls made during this execution so far",
+            "example": 7
+          },
           "taskStatusBeforeClaim": {
             "type": "string",
             "description": "Task status before the task was claimed",
@@ -11408,6 +11491,8 @@
           "taskStatus",
           "claimedAt",
           "lastHeartbeatAt",
+          "runnerSessionId",
+          "toolCallCount",
           "taskStatusBeforeClaim",
           "taskTagsBeforeClaim",
           "workerClientId",
@@ -11501,6 +11586,17 @@
             "description": "OAuth client id of the worker that executed the task",
             "example": "24f52f295c990c1d6cdc6034fa3d1900"
           },
+          "runnerSessionId": {
+            "type": "string",
+            "description": "Agent runtime session identifier associated with this execution",
+            "example": "session_01JZ0SMM85FBFA8Y82M8VREY2A",
+            "nullable": true
+          },
+          "toolCallCount": {
+            "type": "number",
+            "description": "Number of tool calls made during the execution",
+            "example": 12
+          },
           "status": {
             "type": "string",
             "description": "Terminal execution status",
@@ -11536,9 +11632,25 @@
           "transitionedAt",
           "agentActorId",
           "workerClientId",
+          "runnerSessionId",
+          "toolCallCount",
           "status",
           "errorCode",
           "errorMessage"
+        ]
+      },
+      "UpdateRunnerSessionIdDto": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Agent runtime session identifier for this execution",
+            "example": "session_01JZ0SMM85FBFA8Y82M8VREY2A",
+            "maxLength": 255
+          }
+        },
+        "required": [
+          "sessionId"
         ]
       },
       "CreateTaskBlueprintDto": {

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -1709,6 +1709,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/executions-v2/active/{executionId}/session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Attach the runner session id to an active execution
+         * @description Stores the runtime session identifier emitted by the agent harness so it can be propagated to execution history.
+         */
+        patch: operations["ActiveTaskExecutionController_updateRunnerSessionId"];
+        trace?: never;
+    };
+    "/api/v1/executions-v2/active/{executionId}/tool-calls/increment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Increment tool call count for an active execution
+         * @description Atomically increments the active execution tool-call counter without touching other mutable execution fields.
+         */
+        patch: operations["ActiveTaskExecutionController_incrementToolCallCount"];
+        trace?: never;
+    };
     "/api/v1/executions-v2/history": {
         parameters: {
             query?: never;
@@ -5008,6 +5048,16 @@ export interface components {
              */
             lastHeartbeatAt: string | null;
             /**
+             * @description Agent runtime session identifier associated with this execution
+             * @example session_01JZ0SMM85FBFA8Y82M8VREY2A
+             */
+            runnerSessionId: string | null;
+            /**
+             * @description Number of tool calls made during this execution so far
+             * @example 7
+             */
+            toolCallCount: number;
+            /**
              * @description Task status before the task was claimed
              * @enum {string}
              */
@@ -5091,6 +5141,16 @@ export interface components {
              */
             workerClientId: string;
             /**
+             * @description Agent runtime session identifier associated with this execution
+             * @example session_01JZ0SMM85FBFA8Y82M8VREY2A
+             */
+            runnerSessionId: string | null;
+            /**
+             * @description Number of tool calls made during the execution
+             * @example 12
+             */
+            toolCallCount: number;
+            /**
              * @description Terminal execution status
              * @enum {string}
              */
@@ -5105,6 +5165,13 @@ export interface components {
              * @example ADK runner failed: 429 quota exceeded.
              */
             errorMessage: string | null;
+        };
+        UpdateRunnerSessionIdDto: {
+            /**
+             * @description Agent runtime session identifier for this execution
+             * @example session_01JZ0SMM85FBFA8Y82M8VREY2A
+             */
+            sessionId: string;
         };
         CreateTaskBlueprintDto: {
             /**
@@ -9765,6 +9832,50 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["TaskExecutionHistoryResponseDto"];
                 };
+            };
+        };
+    };
+    ActiveTaskExecutionController_updateRunnerSessionId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Execution ID to update */
+                executionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateRunnerSessionIdDto"];
+            };
+        };
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ActiveTaskExecutionController_incrementToolCallCount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Execution ID to update */
+                executionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/client/src/v1/client/index.ts
+++ b/packages/client/src/v1/client/index.ts
@@ -130,6 +130,7 @@ export type { UpdateAgentRunDto } from './models/UpdateAgentRunDto.js';
 export type { UpdateBlockDto } from './models/UpdateBlockDto.js';
 export type { UpdateChatProviderDto } from './models/UpdateChatProviderDto.js';
 export type { UpdateConnectionDto } from './models/UpdateConnectionDto.js';
+export type { UpdateRunnerSessionIdDto } from './models/UpdateRunnerSessionIdDto.js';
 export type { UpdateScheduledTaskDto } from './models/UpdateScheduledTaskDto.js';
 export type { UpdateSecretDto } from './models/UpdateSecretDto.js';
 export { UpdateServerDto } from './models/UpdateServerDto.js';

--- a/packages/client/src/v1/client/models/ActiveTaskExecutionResponseDto.ts
+++ b/packages/client/src/v1/client/models/ActiveTaskExecutionResponseDto.ts
@@ -29,6 +29,14 @@ export type ActiveTaskExecutionResponseDto = {
      */
     lastHeartbeatAt: string | null;
     /**
+     * Agent runtime session identifier associated with this execution
+     */
+    runnerSessionId: string | null;
+    /**
+     * Number of tool calls made during this execution so far
+     */
+    toolCallCount: number;
+    /**
      * Task status before the task was claimed
      */
     taskStatusBeforeClaim: ActiveTaskExecutionResponseDto.taskStatusBeforeClaim;

--- a/packages/client/src/v1/client/models/TaskExecutionHistoryResponseDto.ts
+++ b/packages/client/src/v1/client/models/TaskExecutionHistoryResponseDto.ts
@@ -36,6 +36,14 @@ export type TaskExecutionHistoryResponseDto = {
      */
     workerClientId: string;
     /**
+     * Agent runtime session identifier associated with this execution
+     */
+    runnerSessionId: string | null;
+    /**
+     * Number of tool calls made during the execution
+     */
+    toolCallCount: number;
+    /**
      * Terminal execution status
      */
     status: TaskExecutionHistoryResponseDto.status;

--- a/packages/client/src/v1/client/models/UpdateRunnerSessionIdDto.ts
+++ b/packages/client/src/v1/client/models/UpdateRunnerSessionIdDto.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UpdateRunnerSessionIdDto = {
+    /**
+     * Agent runtime session identifier for this execution
+     */
+    sessionId: string;
+};
+

--- a/packages/client/src/v1/client/services/ExecutionsV2Service.ts
+++ b/packages/client/src/v1/client/services/ExecutionsV2Service.ts
@@ -6,6 +6,7 @@ import type { ActiveTaskExecutionResponseDto } from '../models/ActiveTaskExecuti
 import type { StopActiveTaskExecutionDto } from '../models/StopActiveTaskExecutionDto.js';
 import type { TaskExecutionHistoryResponseDto } from '../models/TaskExecutionHistoryResponseDto.js';
 import type { TaskExecutionQueueEntryResponseDto } from '../models/TaskExecutionQueueEntryResponseDto.js';
+import type { UpdateRunnerSessionIdDto } from '../models/UpdateRunnerSessionIdDto.js';
 import type { CancelablePromise } from '../core/CancelablePromise.js';
 import { OpenAPI } from '../core/OpenAPI.js';
 import type { OpenAPIConfig } from '../core/OpenAPI.js';
@@ -75,6 +76,48 @@ export class ExecutionsV2Service {
             },
             body: requestBody,
             mediaType: 'application/json',
+        });
+    }
+    /**
+     * Attach the runner session id to an active execution
+     * Stores the runtime session identifier emitted by the agent harness so it can be propagated to execution history.
+     * @param executionId Execution ID to update
+     * @param requestBody
+     * @returns void
+     * @throws ApiError
+     */
+    public static activeTaskExecutionControllerUpdateRunnerSessionId(
+        executionId: string,
+        requestBody: UpdateRunnerSessionIdDto,
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<void> {
+        return __request(config, {
+            method: 'PATCH',
+            url: '/api/v1/executions-v2/active/{executionId}/session',
+            path: {
+                'executionId': executionId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Increment tool call count for an active execution
+     * Atomically increments the active execution tool-call counter without touching other mutable execution fields.
+     * @param executionId Execution ID to update
+     * @returns void
+     * @throws ApiError
+     */
+    public static activeTaskExecutionControllerIncrementToolCallCount(
+        executionId: string,
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<void> {
+        return __request(config, {
+            method: 'PATCH',
+            url: '/api/v1/executions-v2/active/{executionId}/tool-calls/increment',
+            path: {
+                'executionId': executionId,
+            },
         });
     }
     /**

--- a/packages/client/src/v2/executions-v2-resource.ts
+++ b/packages/client/src/v2/executions-v2-resource.ts
@@ -1,5 +1,5 @@
 import { BaseClient, ClientConfig } from './base-client.js';
-import type { ActiveTaskExecutionResponseDto, StopActiveTaskExecutionDto, TaskExecutionHistoryResponseDto, TaskExecutionQueueEntryResponseDto } from './types.js';
+import type { ActiveTaskExecutionResponseDto, StopActiveTaskExecutionDto, TaskExecutionHistoryResponseDto, TaskExecutionQueueEntryResponseDto, UpdateRunnerSessionIdDto } from './types.js';
 
 export class ExecutionsV2Resource extends BaseClient {
   constructor(config: ClientConfig) {
@@ -24,6 +24,16 @@ export class ExecutionsV2Resource extends BaseClient {
   /** Stop an active task execution and move it to history */
   async ActiveTaskExecutionController_stopTaskExecution(params: { executionId: string; body: StopActiveTaskExecutionDto; signal?: AbortSignal }): Promise<TaskExecutionHistoryResponseDto> {
     return this.request('POST', `/api/v1/executions-v2/active/${params.executionId}/stop`, { body: params.body, signal: params?.signal });
+  }
+
+  /** Attach the runner session id to an active execution */
+  async ActiveTaskExecutionController_updateRunnerSessionId(params: { executionId: string; body: UpdateRunnerSessionIdDto; signal?: AbortSignal }): Promise<void> {
+    return this.request('PATCH', `/api/v1/executions-v2/active/${params.executionId}/session`, { body: params.body, signal: params?.signal });
+  }
+
+  /** Increment tool call count for an active execution */
+  async ActiveTaskExecutionController_incrementToolCallCount(params: { executionId: string; signal?: AbortSignal }): Promise<void> {
+    return this.request('PATCH', `/api/v1/executions-v2/active/${params.executionId}/tool-calls/increment`, { signal: params?.signal });
   }
 
   /** List task execution history */

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -912,6 +912,8 @@ export interface ActiveTaskExecutionResponseDto {
   taskStatus: 'NOT_STARTED' | 'IN_PROGRESS' | 'FOR_REVIEW' | 'DONE';
   claimedAt: string;
   lastHeartbeatAt: string | null;
+  runnerSessionId: string | null;
+  toolCallCount: number;
   taskStatusBeforeClaim: 'NOT_STARTED' | 'IN_PROGRESS' | 'FOR_REVIEW' | 'DONE';
   taskTagsBeforeClaim: ActiveTaskExecutionTagSnapshotResponseDto[];
   workerClientId: string;
@@ -934,9 +936,15 @@ export interface TaskExecutionHistoryResponseDto {
   transitionedAt: string;
   agentActorId: string;
   workerClientId: string;
+  runnerSessionId: string | null;
+  toolCallCount: number;
   status: 'SUCCEEDED' | 'FAILED' | 'STALE' | 'CANCELLED';
   errorCode: 'OUT_OF_QUOTA' | 'UNKNOWN';
   errorMessage: string | null;
+}
+
+export interface UpdateRunnerSessionIdDto {
+  sessionId: string;
 }
 
 export interface CreateTaskBlueprintDto {


### PR DESCRIPTION
## Summary
- carry execution enrichment data through v2 execution records (`runnerSessionId`, atomic `toolCallCount`) and expose worker update endpoints for session assignment + tool-call increments
- surface the new fields in `ui2` Runs and Task Detail views for active and historical runs (desktop + mobile)
- add realtime refresh in Runs by listening to `task.activity` execution events, with existing polling retained as fallback

## Validation
- npm run build:dev
- npm run dev:1

## Technical Debt
- Runs realtime currently reuses the tasks websocket stream and does full list reloads on execution activity; a dedicated executions-v2 websocket event for targeted row updates would reduce reload churn.