### PR TITLE
Harden Claude tool-call parsing types in mainline

### DIFF
--- a/apps/worker/src/formatters/ClaudeMessageFormatter.ts
+++ b/apps/worker/src/formatters/ClaudeMessageFormatter.ts
@@ -12,6 +12,26 @@ import {
 export class ClaudeMessageFormatter {
   constructor(private agentSlug?: string) {}
 
+  extractToolCallNames(message: SDKMessage): string[] {
+    if (message.type !== 'assistant') {
+      return [];
+    }
+
+    const content = message.message?.content;
+    if (!Array.isArray(content)) {
+      return [];
+    }
+
+    const toolNames: string[] = [];
+    for (const part of content) {
+      if (part.type === 'tool_use' && typeof part.name === 'string') {
+        toolNames.push(part.name);
+      }
+    }
+
+    return toolNames;
+  }
+
   format(message: SDKMessage): string | null {
     switch (message.type) {
       case 'assistant':

--- a/apps/worker/src/runners/ClaudeAgentRunner.ts
+++ b/apps/worker/src/runners/ClaudeAgentRunner.ts
@@ -66,12 +66,9 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
         await setSession(msg.session_id);
       }
 
-      if (msg?.type === 'assistant' && Array.isArray(msg.message?.content)) {
-        for (const part of msg.message.content) {
-          if (part.type === 'tool_use' && typeof part.name === 'string') {
-            await onToolCall?.(part.name);
-          }
-        }
+      const toolCalls = formatter.extractToolCallNames(msg);
+      for (const toolName of toolCalls) {
+        await onToolCall?.(toolName);
       }
 
       // map → string


### PR DESCRIPTION
## Summary
- Lands the already-reviewed Claude parser hardening that is currently only on #834 and not in `main` after #836 merge.
- Replaces brittle runner-side `msg.message` inspection (through SDK `any`) with typed extraction via `ClaudeMessageFormatter.extractToolCallNames()`.
- Keeps tool-call counting behavior unchanged while centralizing message-shape logic in the formatter.

## Technical debt
- None introduced in this follow-up; this is a narrow parity/backport fix.