### PR TITLE
Define per-tool JWT claim model and scope mapping primitives

### DIFF
--- a/apps/backend/src/auth/core/types/access-token-claims.type.ts
+++ b/apps/backend/src/auth/core/types/access-token-claims.type.ts
@@ -83,4 +83,19 @@ export interface AccessTokenClaims {
    * Used for audit trail when a human issues a token for an agent.
    */
   issued_by?: string;
+
+  /**
+   * Token kind discriminator. Omitted for legacy/non tool-specific access tokens.
+   */
+  token_kind?: 'tool';
+
+  /**
+   * MCP server providedId this token is constrained to when token_kind is `tool`.
+   */
+  tool_id?: string;
+
+  /**
+   * Tool-local scopes authorized for this token when token_kind is `tool`.
+   */
+  tool_scopes?: string[];
 }

--- a/packages/shared/src/agent-runtime-permissions.ts
+++ b/packages/shared/src/agent-runtime-permissions.ts
@@ -28,6 +28,18 @@ export type AgentRuntimeToolPermissionLike = {
   grantedScopes: AgentRuntimeScopeLike[];
 };
 
+export const PER_TOOL_EXECUTION_TOKEN_KIND = 'tool';
+
+export type PerToolExecutionTokenKind = typeof PER_TOOL_EXECUTION_TOKEN_KIND;
+
+export type PerToolExecutionTokenClaims = {
+  token_kind: PerToolExecutionTokenKind;
+  tool_id: string;
+  tool_scopes: string[];
+};
+
+export type PerToolExecutionScopeMap = Record<string, string[]>;
+
 export function deriveExecutionScopesFromToolPermissions(
   permissions: AgentRuntimeToolPermissionLike[],
 ): string[] {
@@ -40,6 +52,38 @@ export function deriveExecutionScopesFromToolPermissions(
   }
 
   return [...scopes].sort((a, b) => a.localeCompare(b));
+}
+
+export function derivePerToolExecutionScopesFromToolPermissions(
+  permissions: AgentRuntimeToolPermissionLike[],
+): PerToolExecutionScopeMap {
+  const perToolScopes = new Map<string, Set<string>>();
+
+  for (const permission of permissions) {
+    const providedId = permission.server.providedId;
+    if (!providedId) {
+      continue;
+    }
+
+    const scopeSet =
+      perToolScopes.get(providedId) ??
+      new Set<string>(BASELINE_AGENT_EXECUTION_SCOPES);
+
+    for (const scope of permission.grantedScopes) {
+      scopeSet.add(scope.id);
+    }
+
+    perToolScopes.set(providedId, scopeSet);
+  }
+
+  const result: PerToolExecutionScopeMap = {};
+  for (const [providedId, scopes] of [...perToolScopes.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    result[providedId] = [...scopes].sort((a, b) => a.localeCompare(b));
+  }
+
+  return result;
 }
 
 export function deriveAllowedToolsFromProvidedIds(


### PR DESCRIPTION
## Summary
- add a backwards-compatible per-tool JWT claim model (`token_kind`, `tool_id`, `tool_scopes`) to backend access-token claim typing so legacy tokens remain valid
- add shared per-tool scope mapping primitives to derive deterministic tool-specific execution scopes from agent tool permissions
- keep baseline execution scopes included per tool map entry to support existing runtime expectations

## Validation
- `npm run build:dev`
- `npm run dev:1` (validated backend + both UIs boot and initialize)

## Technical debt / follow-ups
- this PR defines primitives only; token issuance and worker attachment still need to consume these new per-tool claim and scope mapping helpers in follow-up tasks