### PR TITLE
Add Taico landing page for soft launch

### DIFF
--- a/apps/ui/src/app/App.tsx
+++ b/apps/ui/src/app/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, LoginPage, OnboardingPage, WalkthroughPage, ProtectedRout
 import { OnboardingChecker } from '../auth/OnboardingChecker';
 import { BetaShell } from './shells/BetaShell';
 import { HomeRoutes } from '../features/home/HomeRoutes';
+import { LandingPage } from '../features/home/LandingPage';
 import { BASE_PATH } from '../shared/const/base';
 import './App.css';
 import { TasksRoutes } from '../features/tasks/TasksRoutes';
@@ -52,6 +53,7 @@ export function App() {
             <ActorsProvider>
               <CommandPaletteProvider>
                 <Routes>
+                  <Route path="/" element={<LandingPage />} />
                   <Route path="/onboarding" element={<OnboardingPage />} />
                   <Route path="/login" element={
                     <OnboardingChecker>

--- a/apps/ui/src/auth/ProtectedRoute.tsx
+++ b/apps/ui/src/auth/ProtectedRoute.tsx
@@ -7,7 +7,7 @@ interface ProtectedRouteProps {
 
 /**
  * ProtectedRoute component
- * Redirects to /login if user is not authenticated
+ * Redirects to landing page if user is not authenticated
  * Preserves the original destination to redirect back after login
  */
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
@@ -19,9 +19,9 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
     return null;
   }
 
-  // Redirect to login if not authenticated
+  // Redirect to landing page if not authenticated
   if (!isAuthenticated) {
-    return <Navigate to="/login" state={{ from: location }} replace />;
+    return <Navigate to="/" state={{ from: location }} replace />;
   }
 
   // User is authenticated, render the protected content

--- a/apps/ui/src/features/home/LandingPage.css
+++ b/apps/ui/src/features/home/LandingPage.css
@@ -1,0 +1,123 @@
+.landing-page {
+  min-height: 100vh;
+  background: var(--app-surface);
+  padding: var(--space-6) var(--space-4);
+  overflow-y: auto;
+}
+
+.landing-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.landing-hero {
+  text-align: center;
+  padding: var(--space-7) 0;
+}
+
+.landing-title {
+  font-size: var(--fs-6);
+  color: var(--text);
+  letter-spacing: -0.5px;
+}
+
+.landing-subtitle {
+  max-width: 700px;
+  line-height: var(--lh-relaxed);
+}
+
+.landing-task-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+}
+
+.landing-task-item {
+  /* TaskCard already has proper styling */
+}
+
+.landing-features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+}
+
+.landing-feature-card {
+  padding: var(--space-5);
+  border: 1px solid var(--border-subtle);
+  background: var(--card-bg);
+  border-radius: var(--r-3);
+  transition: all 0.2s ease;
+}
+
+.landing-feature-card:hover {
+  border-color: var(--border);
+  box-shadow: var(--shadow-2);
+}
+
+.landing-flexibility-card {
+  padding: var(--space-5);
+  border: 1px solid var(--border-subtle);
+  background: var(--card-bg);
+  border-radius: var(--r-3);
+}
+
+.landing-setup-card {
+  padding: var(--space-5);
+  border: 1px solid var(--border-subtle);
+  background: var(--card-bg);
+  border-radius: var(--r-3);
+}
+
+.landing-code-block {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  padding: var(--space-4);
+  overflow-x: auto;
+}
+
+.landing-code-block pre {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2);
+  line-height: var(--lh-relaxed);
+  color: var(--text);
+}
+
+.landing-code-block code {
+  font-family: var(--font-mono);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .landing-page {
+    padding: var(--space-4) var(--space-3);
+  }
+
+  .landing-hero {
+    padding: var(--space-5) 0;
+  }
+
+  .landing-title {
+    font-size: var(--fs-5);
+  }
+
+  .landing-subtitle {
+    font-size: var(--fs-3);
+  }
+
+  .landing-task-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-features-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-code-block {
+    font-size: var(--fs-1);
+  }
+}

--- a/apps/ui/src/features/home/LandingPage.tsx
+++ b/apps/ui/src/features/home/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation, type Location } from "react-router-dom";
 import { Button, Card, Stack, Text, Row } from "../../ui/primitives";
 import { TaskCard } from "../tasks/TaskCard";
 import { Task } from "../tasks/types";
@@ -139,6 +139,10 @@ const mockTasks: Task[] = [
 
 export function LandingPage() {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  // Preserve the 'from' location if redirected from a protected route
+  const from = (location.state as { from?: Location })?.from;
 
   return (
     <div className="landing-page">
@@ -288,7 +292,7 @@ npx @taico/worker@0.2.8 --serverurl http://localhost:$PORT`}</code></pre>
                   </Button>
                   <Button
                     variant="secondary"
-                    onClick={() => navigate('/login')}
+                    onClick={() => navigate('/login', { state: { from } })}
                   >
                     Sign In
                   </Button>

--- a/apps/ui/src/features/home/LandingPage.tsx
+++ b/apps/ui/src/features/home/LandingPage.tsx
@@ -1,0 +1,303 @@
+import { useNavigate } from "react-router-dom";
+import { Button, Card, Stack, Text, Row } from "../../ui/primitives";
+import { TaskCard } from "../tasks/TaskCard";
+import { Task } from "../tasks/types";
+import "./LandingPage.css";
+
+// Mock tasks for demonstration
+const mockTasks: Task[] = [
+  {
+    id: "demo-task-1",
+    name: "Review API design",
+    description: "Review the new REST API endpoints for the user management system",
+    status: "NOT_STARTED",
+    assignee: "user-mike",
+    assigneeActor: {
+      id: "user-mike",
+      type: "human",
+      slug: "mike",
+      displayName: "Mike",
+      avatarUrl: null,
+      introduction: null,
+    },
+    createdByActor: {
+      id: "user-creator",
+      type: "human",
+      slug: "fran",
+      displayName: "Francisco",
+      avatarUrl: null,
+      introduction: null,
+    },
+    tags: [
+      { id: "tag-1", name: "project:store", color: "#98D8C8" }
+    ],
+    comments: [],
+    artefacts: [],
+    inputRequests: [],
+    sessionId: null,
+    dependsOnIds: [],
+    createdAt: new Date(Date.now() - 86400000).toISOString(),
+    updatedAt: new Date(Date.now() - 86400000).toISOString(),
+  },
+  {
+    id: "demo-task-2",
+    name: "Implement user authentication",
+    description: "Add JWT-based authentication to the backend API",
+    status: "FOR_REVIEW",
+    assignee: "agent-codex",
+    assigneeActor: {
+      id: "agent-codex",
+      type: "agent",
+      slug: "codex",
+      displayName: "Codex",
+      avatarUrl: "/icons/OpenAI-black-monoblossom.svg",
+      introduction: null,
+    },
+    createdByActor: {
+      id: "user-creator",
+      type: "human",
+      slug: "fran",
+      displayName: "Francisco",
+      avatarUrl: null,
+      introduction: null,
+    },
+    tags: [
+      { id: "tag-2", name: "review ✅", color: "#4CAF50" },
+      { id: "tag-3", name: "code", color: "#2196F3" },
+      { id: "tag-4", name: "project:store", color: "#98D8C8" }
+    ],
+    comments: [
+      {
+        id: "comment-1",
+        taskId: "demo-task-2",
+        commenterName: "Codex",
+        commenterActor: {
+          id: "agent-codex",
+          type: "agent",
+          slug: "codex",
+          displayName: "Codex",
+          avatarUrl: "/icons/OpenAI-black-monoblossom.svg",
+          introduction: null,
+        },
+        content: "Implementation complete, ready for review",
+        createdAt: new Date(Date.now() - 3600000).toISOString(),
+      }
+    ],
+    artefacts: [],
+    inputRequests: [],
+    sessionId: null,
+    dependsOnIds: [],
+    createdAt: new Date(Date.now() - 172800000).toISOString(),
+    updatedAt: new Date(Date.now() - 3600000).toISOString(),
+  },
+  {
+    id: "demo-task-3",
+    name: "Database schema help needed",
+    description: "Need help deciding between SQL and NoSQL for our analytics data",
+    status: "IN_PROGRESS",
+    assignee: "user-mike",
+    assigneeActor: {
+      id: "user-mike",
+      type: "human",
+      slug: "mike",
+      displayName: "Mike",
+      avatarUrl: null,
+      introduction: null,
+    },
+    createdByActor: {
+      id: "user-creator",
+      type: "human",
+      slug: "fran",
+      displayName: "Francisco",
+      avatarUrl: null,
+      introduction: null,
+    },
+    tags: [
+      { id: "tag-5", name: "architecture", color: "#FF9800" }
+    ],
+    comments: [],
+    artefacts: [],
+    inputRequests: [
+      {
+        id: "input-1",
+        taskId: "demo-task-3",
+        askedByActorId: "agent-codex",
+        assignedToActorId: "user-mike",
+        question: "What's the expected data volume? This will help determine the best approach.",
+        answer: null,
+        resolvedAt: null,
+        createdAt: new Date(Date.now() - 7200000).toISOString(),
+        updatedAt: new Date(Date.now() - 7200000).toISOString(),
+      }
+    ],
+    sessionId: null,
+    dependsOnIds: [],
+    createdAt: new Date(Date.now() - 259200000).toISOString(),
+    updatedAt: new Date(Date.now() - 7200000).toISOString(),
+  },
+];
+
+export function LandingPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="landing-page">
+      <div className="landing-container">
+        <Stack spacing="8">
+          {/* Hero Section */}
+          <Stack spacing="4" align="center" className="landing-hero">
+            <Text size="6" weight="bold" className="landing-title">
+              Taico
+            </Text>
+            <Text size="4" tone="muted" className="landing-subtitle">
+              Where people and agents collaborate in threads, using shared context to get work done
+            </Text>
+          </Stack>
+
+          {/* Task Board Demo */}
+          <Stack spacing="4">
+            <Stack spacing="2">
+              <Text size="5" weight="semibold">
+                Tasks
+              </Text>
+              <Text size="3" tone="muted">
+                Units of work that can be assigned to humans or AI agents. Track progress, add comments, and collaborate seamlessly.
+              </Text>
+            </Stack>
+
+            <div className="landing-task-grid">
+              {mockTasks.map((task) => (
+                <div key={task.id} className="landing-task-item">
+                  <TaskCard task={task} />
+                </div>
+              ))}
+            </div>
+          </Stack>
+
+          {/* Features Grid */}
+          <div className="landing-features-grid">
+            <Card className="landing-feature-card">
+              <Stack spacing="3">
+                <Text size="4" weight="semibold">
+                  📝 Context Blocks
+                </Text>
+                <Text size="2" tone="muted">
+                  Shared knowledge and documentation that can be attached to tasks and threads. Keep important information accessible and reusable.
+                </Text>
+              </Stack>
+            </Card>
+
+            <Card className="landing-feature-card">
+              <Stack spacing="3">
+                <Text size="4" weight="semibold">
+                  💬 Threads
+                </Text>
+                <Text size="2" tone="muted">
+                  Rooms for coordinating related work. Organize multiple tasks, conversations, and context all in one place.
+                </Text>
+              </Stack>
+            </Card>
+
+            <Card className="landing-feature-card">
+              <Stack spacing="3">
+                <Text size="4" weight="semibold">
+                  🤖 Agents
+                </Text>
+                <Text size="2" tone="muted">
+                  AI assistants that can take on tasks, ask questions, and collaborate with you. Assign work to agents just like you would to teammates.
+                </Text>
+              </Stack>
+            </Card>
+          </div>
+
+          {/* Flexibility Section */}
+          <Card className="landing-flexibility-card">
+            <Stack spacing="3">
+              <Text size="4" weight="semibold">
+                Use it your way
+              </Text>
+              <Text size="2" tone="muted">
+                Taico adapts to your workflow. Use it as a personal todo app, a note-taking system with context,
+                a chat interface with AI, or a full collaboration platform. Create tasks for AI, have AI create tasks
+                for you, or use it purely for organizing your thoughts. When the moment is right, everything comes
+                together because all the pieces are in the same place.
+              </Text>
+            </Stack>
+          </Card>
+
+          {/* Getting Started */}
+          <Stack spacing="4">
+            <Stack spacing="2">
+              <Text size="5" weight="semibold">
+                Getting Started
+              </Text>
+              <Text size="3" tone="muted">
+                Taico is currently designed for self-hosted deployment on your own laptop as a personal tool.
+                Multi-tenant SaaS is coming in the future.
+              </Text>
+            </Stack>
+
+            <Card className="landing-setup-card">
+              <Stack spacing="4">
+                <Stack spacing="2">
+                  <Text size="3" weight="semibold">
+                    1. Start the Taico server
+                  </Text>
+                  <div className="landing-code-block">
+                    <pre><code>{`IMAGE=ghcr.io/galarzafrancisco/ai-monorepo:main-409e79f
+PORT=1234
+DATABASE_PATH=$(pwd)/data
+
+docker run --name taico --restart unless-stopped -d \\
+  -p $PORT:$PORT \\
+  -e NODE_ENV=production \\
+  -e PORT=$PORT \\
+  -e ISSUER_URL=http://localhost:$PORT \\
+  -e SECRETS_ENABLED="true" \\
+  -e ALLOW_PLAINTEXT_SECRETS_INSECURE="true" \\
+  -e DATABASE_PATH=/app/data/database.sqlite \\
+  -v $DATABASE_PATH:/app/data \\
+  $IMAGE
+
+# Access at http://localhost:1234`}</code></pre>
+                  </div>
+                </Stack>
+
+                <Stack spacing="2">
+                  <Text size="3" weight="semibold">
+                    2. Start the worker (for AI agent support)
+                  </Text>
+                  <div className="landing-code-block">
+                    <pre><code>{`PORT=1234
+
+# Optional: For Google models via ADK
+# export GOOGLE_CLOUD_PROJECT=""
+# export GOOGLE_CLOUD_LOCATION=""
+# export GOOGLE_GENAI_USE_VERTEXAI="True"
+
+npx @taico/worker@0.2.8 --serverurl http://localhost:$PORT`}</code></pre>
+                  </div>
+                </Stack>
+
+                <Row spacing="3">
+                  <Button
+                    variant="primary"
+                    onClick={() => window.open('https://github.com/galarzafrancisco/taico', '_blank')}
+                  >
+                    View on GitHub
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => navigate('/login')}
+                  >
+                    Sign In
+                  </Button>
+                </Row>
+              </Stack>
+            </Card>
+          </Stack>
+        </Stack>
+      </div>
+    </div>
+  );
+}

--- a/helpers/start-server.sh
+++ b/helpers/start-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE=ghcr.io/galarzafrancisco/ai-monorepo:main-7ae9270
+IMAGE=ghcr.io/galarzafrancisco/ai-monorepo:main-409e79f
 
 PORT=1234                    # Port where the server will be accessible
 CONTAINER_NAME=taico         # Name for the Docker container

--- a/helpers/start-worker.sh
+++ b/helpers/start-worker.sh
@@ -8,5 +8,5 @@ export GOOGLE_CLOUD_PROJECT=""
 export GOOGLE_CLOUD_LOCATION=""
 export GOOGLE_GENAI_USE_VERTEXAI="True"
 
-npx @taico/worker --serverurl http://localhost:$PORT
+npx @taico/worker@0.2.8 --serverurl http://localhost:$PORT
 


### PR DESCRIPTION
## Summary

Created a comprehensive landing page for Taico's soft launch that introduces the product to new users before authentication. The landing page is now the first thing visitors see at taico.app.

## Changes

### Landing Page Features
- **Hero Section**: Clear value proposition with the tagline "Where people and agents collaborate in threads, using shared context to get work done"
- **Interactive Task Demo**: Shows 3 example tasks using the actual TaskCard component:
  - Task assigned to @mike (NOT_STARTED) with `project:store` tag
  - Task assigned to @codex with OpenAI avatar (FOR_REVIEW) with `review ✅`, `code`, and `project:store` tags, plus a comment
  - Task with an open question indicator (✋) showing the input request feature
- **Feature Cards**: Explains Tasks, Context Blocks, Threads, and Agents with emoji icons
- **Flexibility Section**: Describes various use cases (todo app, notes, chat, full workflow)
- **Getting Started**: Docker commands for self-hosted deployment

### Routing Changes
- Landing page at `/` (public, no auth required)
- Protected routes now redirect to `/` instead of `/login`
- Login still accessible at `/login`

### Helper Scripts
- Updated `helpers/start-server.sh` to use image `ghcr.io/galarzafrancisco/ai-monorepo:main-409e79f`
- Updated `helpers/start-worker.sh` to use `@taico/worker@0.2.8`

## Design Principles

- **Minimalist**: Consistent with existing app aesthetic
- **Theme-Aware**: All styles use CSS tokens from `tokens.css`
- **Responsive**: Mobile-friendly with proper breakpoints
- **Component Reuse**: Uses existing UI primitives (Card, Stack, Button, TaskCard)

## Test Plan

- [x] Build works: `npm run build:dev`
- [x] Dev server starts: `npm run dev:2`
- [x] Landing page accessible at root path
- [x] Task cards render correctly with proper styling
- [x] Routing preserves protected route behavior
- [x] Docker commands in Getting Started section are accurate

## Technical Notes

- Mock tasks use proper `TaskResponseDto` types from the API client
- TaskCard component handles the demo tasks naturally without modifications
- No breaking changes to existing authentication flows
- GitHub link in Getting Started may need to be updated if the repo URL changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)