### PR TITLE
Add blocks import/export archive flow in settings

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -5354,6 +5354,76 @@
         ]
       }
     },
+    "/api/v1/context/blocks/export": {
+      "get": {
+        "operationId": "ContextController_exportBlocks",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Context blocks archive downloaded successfully"
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Export all context blocks as markdown zip",
+        "tags": [
+          "Context"
+        ]
+      }
+    },
+    "/api/v1/context/blocks/import": {
+      "post": {
+        "operationId": "ContextController_importBlocks",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Zip file exported from context blocks"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Context blocks imported successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportBlocksResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No archive file uploaded or invalid file type"
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Import context blocks from markdown zip",
+        "tags": [
+          "Context"
+        ]
+      }
+    },
     "/api/v1/context/blocks/{id}": {
       "get": {
         "operationId": "ContextController_getBlock",
@@ -11176,6 +11246,19 @@
           "children",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "ImportBlocksResponseDto": {
+        "type": "object",
+        "properties": {
+          "importedCount": {
+            "type": "number",
+            "description": "Number of context blocks imported from the archive",
+            "example": 12
+          }
+        },
+        "required": [
+          "importedCount"
         ]
       },
       "UpdateBlockDto": {

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -5360,7 +5360,15 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Context blocks archive downloaded successfully"
+            "description": "Context blocks archive downloaded successfully",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -72,6 +72,7 @@
     "cookie-parser": "^1.4.7",
     "cron-parser": "^5.5.0",
     "fuse.js": "^7.1.0",
+    "jszip": "^3.10.1",
     "ollama": "^0.6.3",
     "openai": "^6.22.0",
     "reflect-metadata": "^0.2.2",

--- a/apps/backend/src/context/context.controller.ts
+++ b/apps/backend/src/context/context.controller.ts
@@ -27,6 +27,7 @@ import {
   ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiProduces,
   ApiTags,
 } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
@@ -148,8 +149,13 @@ export class ContextController {
 
   @Get('export')
   @ApiOperation({ summary: 'Export all context blocks as markdown zip' })
+  @ApiProduces('application/zip')
   @ApiOkResponse({
     description: 'Context blocks archive downloaded successfully',
+    schema: {
+      type: 'string',
+      format: 'binary',
+    },
   })
   async exportBlocks(@Res({ passthrough: true }) res: Response): Promise<StreamableFile> {
     const archive = await this.contextService.exportBlocksAsZip();

--- a/apps/backend/src/context/context.controller.ts
+++ b/apps/backend/src/context/context.controller.ts
@@ -13,11 +13,16 @@ import {
   Query,
   Req,
   Res,
+  StreamableFile,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
+  ApiBody,
   ApiCookieAuth,
+  ApiConsumes,
   ApiCreatedResponse,
   ApiNoContentResponse,
   ApiOkResponse,
@@ -25,6 +30,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { ContextService } from './context.service';
 import { CreateBlockDto } from './dto/create-block.dto';
 import { BlockResponseDto } from './dto/block-response.dto';
@@ -41,6 +47,7 @@ import { ReorderBlockDto } from './dto/reorder-block.dto';
 import { MoveBlockDto } from './dto/move-block.dto';
 import { SearchBlocksQueryDto } from './dto/search-blocks-query.dto';
 import { BlockSearchResultDto } from './dto/block-search-result.dto';
+import { ImportBlocksResponseDto } from './dto/import-blocks-response.dto';
 import {
   BlockResult,
   BlockSummaryResult,
@@ -137,6 +144,75 @@ export class ContextController {
   async getBlockTree(): Promise<BlockTreeResponseDto[]> {
     const result = await this.contextService.getBlockTree();
     return result.map((node) => this.mapToTreeResponse(node));
+  }
+
+  @Get('export')
+  @ApiOperation({ summary: 'Export all context blocks as markdown zip' })
+  @ApiOkResponse({
+    description: 'Context blocks archive downloaded successfully',
+  })
+  async exportBlocks(@Res({ passthrough: true }) res: Response): Promise<StreamableFile> {
+    const archive = await this.contextService.exportBlocksAsZip();
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const fileName = `context-blocks-${timestamp}.zip`;
+
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+    res.setHeader('Content-Length', archive.byteLength.toString());
+
+    return new StreamableFile(archive);
+  }
+
+  @Post('import')
+  @RequireScopes(ContextScopes.WRITE.id)
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: 'Import context blocks from markdown zip' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'Zip file exported from context blocks',
+        },
+      },
+    },
+  })
+  @ApiCreatedResponse({
+    type: ImportBlocksResponseDto,
+    description: 'Context blocks imported successfully',
+  })
+  @ApiBadRequestResponse({
+    description: 'No archive file uploaded or invalid file type',
+  })
+  async importBlocks(
+    @UploadedFile()
+    file:
+      | {
+          buffer: Buffer;
+          originalname: string;
+          mimetype: string;
+        }
+      | undefined,
+    @CurrentUser() user: UserContext,
+  ): Promise<ImportBlocksResponseDto> {
+    if (!file) {
+      throw new BadRequestException('A zip file is required');
+    }
+
+    const lowerName = file.originalname.toLowerCase();
+    const isZipMime =
+      file.mimetype === 'application/zip'
+      || file.mimetype === 'application/x-zip-compressed'
+      || file.mimetype === 'application/octet-stream';
+    if (!lowerName.endsWith('.zip') && !isZipMime) {
+      throw new BadRequestException('Only .zip archives are supported');
+    }
+
+    return this.contextService.importBlocksFromZip(file.buffer, user.actorId);
   }
 
   @Get(':id')

--- a/apps/backend/src/context/context.service.ts
+++ b/apps/backend/src/context/context.service.ts
@@ -27,6 +27,7 @@ import {
   ParentBlockNotFoundError,
   CircularReferenceError,
   BlockIsThreadStateError,
+  InvalidContextArchiveError,
 } from './errors/context.errors';
 import {
   BlockCreatedEvent,
@@ -628,7 +629,12 @@ export class ContextService {
   ): Promise<{ importedCount: number }> {
     this.logger.log({ message: 'Importing context blocks from zip archive' });
 
-    const zip = await JSZip.loadAsync(archiveBuffer);
+    let zip: JSZip;
+    try {
+      zip = await JSZip.loadAsync(archiveBuffer);
+    } catch {
+      throw new InvalidContextArchiveError();
+    }
     const root = this.createArchiveDirectory('');
 
     for (const [rawPath, entry] of Object.entries(zip.files)) {

--- a/apps/backend/src/context/context.service.ts
+++ b/apps/backend/src/context/context.service.ts
@@ -653,13 +653,17 @@ export class ContextService {
         .replace(/^\/+/, '')
         .replace(/\/+$/, '');
 
-      if (!normalizedPath.toLowerCase().endsWith('.md')) {
+      const parts = normalizedPath.split('/').filter(Boolean);
+      if (parts.length === 0 || this.shouldIgnoreArchivePath(parts)) {
         continue;
       }
 
-      const parts = normalizedPath.split('/').filter(Boolean);
       const fileName = parts.pop();
       if (!fileName) {
+        continue;
+      }
+
+      if (!fileName.toLowerCase().endsWith('.md')) {
         continue;
       }
 
@@ -882,6 +886,21 @@ export class ContextService {
   private normalizeImportedTitle(name: string): string {
     const normalized = name.trim();
     return normalized.length > 0 ? normalized : 'untitled';
+  }
+
+  private shouldIgnoreArchivePath(pathParts: string[]): boolean {
+    return pathParts.some((part) => this.isIgnoredArchiveSegment(part));
+  }
+
+  private isIgnoredArchiveSegment(segment: string): boolean {
+    const normalized = segment.trim().toLowerCase();
+    return (
+      normalized.length === 0 ||
+      normalized === '__macosx' ||
+      normalized === '.ds_store' ||
+      normalized === 'thumbs.db' ||
+      normalized.startsWith('._')
+    );
   }
 
   private mapToResult(block: ContextBlockEntity): BlockResult {

--- a/apps/backend/src/context/context.service.ts
+++ b/apps/backend/src/context/context.service.ts
@@ -606,7 +606,13 @@ export class ContextService {
     }
 
     const zip = new JSZip();
-    this.addBlocksToArchive(zip, '', childrenByParentId, ContextService.ROOT_PARENT_KEY);
+    const rootFolderName = this.createArchiveRootFolderName();
+    this.addBlocksToArchive(
+      zip,
+      `${rootFolderName}/`,
+      childrenByParentId,
+      ContextService.ROOT_PARENT_KEY,
+    );
 
     const archive = await zip.generateAsync({
       type: 'nodebuffer',
@@ -671,11 +677,8 @@ export class ContextService {
       currentDirectory.files.set(fileName, content);
     }
 
-    const importedCount = await this.importArchiveDirectory(
-      root,
-      null,
-      createdByActorId,
-    );
+    const importRoot = this.resolveImportRootDirectory(root);
+    const importedCount = await this.importArchiveDirectory(importRoot, null, createdByActorId);
 
     this.logger.log({
       message: 'Imported context blocks from zip archive',
@@ -758,6 +761,34 @@ export class ContextService {
     };
   }
 
+  private createArchiveRootFolderName(): string {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    return `context-blocks-${timestamp}`;
+  }
+
+  private resolveImportRootDirectory(root: ArchiveDirectory): ArchiveDirectory {
+    if (root.files.size > 0 || root.directories.size !== 1) {
+      return root;
+    }
+
+    const [directoryName, directory] = [...root.directories.entries()][0];
+    const normalizedName = directoryName.toLowerCase();
+    const isExpectedArchiveRoot =
+      normalizedName === 'context-blocks' || normalizedName.startsWith('context-blocks-');
+    if (!isExpectedArchiveRoot) {
+      return root;
+    }
+
+    const hasIndexFile = [...directory.files.keys()].some(
+      (fileName) => fileName.toLowerCase() === 'index.md',
+    );
+    if (hasIndexFile) {
+      return root;
+    }
+
+    return directory;
+  }
+
   private async importArchiveDirectory(
     directory: ArchiveDirectory,
     parentId: string | null,
@@ -788,7 +819,7 @@ export class ContextService {
       const indexEntry = [...childDirectory.files.entries()].find(
         ([fileName]) => fileName.toLowerCase() === 'index.md',
       );
-      const content = indexEntry?.[1] ?? '';
+      const content = indexEntry?.[1] ?? '.';
 
       const block = await this.createBlock({
         title: this.normalizeImportedTitle(directoryName),

--- a/apps/backend/src/context/context.service.ts
+++ b/apps/backend/src/context/context.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import JSZip from 'jszip';
 import { ContextBlockEntity } from './block.entity';
 import { MetaService } from '../meta/meta.service';
 import { TagEntity } from '../meta/tag.entity';
@@ -33,9 +34,17 @@ import {
   BlockDeletedEvent,
 } from './events/context.events';
 
+interface ArchiveDirectory {
+  name: string;
+  directories: Map<string, ArchiveDirectory>;
+  files: Map<string, string>;
+}
+
 @Injectable()
 export class ContextService {
   private readonly logger = new Logger(ContextService.name);
+
+  private static readonly ROOT_PARENT_KEY = '__root__';
 
   constructor(
     @InjectRepository(ContextBlockEntity)
@@ -580,6 +589,96 @@ export class ContextService {
     }));
   }
 
+  async exportBlocksAsZip(): Promise<Buffer> {
+    this.logger.log({ message: 'Exporting context blocks to zip archive' });
+
+    const allBlocks = await this.blockRepository.find({
+      order: { order: 'ASC', createdAt: 'ASC' },
+    });
+
+    const childrenByParentId = new Map<string, ContextBlockEntity[]>();
+    for (const block of allBlocks) {
+      const key = block.parentId ?? ContextService.ROOT_PARENT_KEY;
+      const siblings = childrenByParentId.get(key) ?? [];
+      siblings.push(block);
+      childrenByParentId.set(key, siblings);
+    }
+
+    const zip = new JSZip();
+    this.addBlocksToArchive(zip, '', childrenByParentId, ContextService.ROOT_PARENT_KEY);
+
+    const archive = await zip.generateAsync({
+      type: 'nodebuffer',
+      compression: 'DEFLATE',
+      compressionOptions: { level: 9 },
+    });
+
+    this.logger.log({
+      message: 'Exported context blocks to zip archive',
+      bytes: archive.byteLength,
+      blockCount: allBlocks.length,
+    });
+
+    return archive;
+  }
+
+  async importBlocksFromZip(
+    archiveBuffer: Buffer,
+    createdByActorId: string,
+  ): Promise<{ importedCount: number }> {
+    this.logger.log({ message: 'Importing context blocks from zip archive' });
+
+    const zip = await JSZip.loadAsync(archiveBuffer);
+    const root = this.createArchiveDirectory('');
+
+    for (const [rawPath, entry] of Object.entries(zip.files)) {
+      if (entry.dir) {
+        continue;
+      }
+
+      const normalizedPath = rawPath
+        .replace(/\\/g, '/')
+        .replace(/^\/+/, '')
+        .replace(/\/+$/, '');
+
+      if (!normalizedPath.toLowerCase().endsWith('.md')) {
+        continue;
+      }
+
+      const parts = normalizedPath.split('/').filter(Boolean);
+      const fileName = parts.pop();
+      if (!fileName) {
+        continue;
+      }
+
+      let currentDirectory = root;
+      for (const part of parts) {
+        let childDirectory = currentDirectory.directories.get(part);
+        if (!childDirectory) {
+          childDirectory = this.createArchiveDirectory(part);
+          currentDirectory.directories.set(part, childDirectory);
+        }
+        currentDirectory = childDirectory;
+      }
+
+      const content = await entry.async('string');
+      currentDirectory.files.set(fileName, content);
+    }
+
+    const importedCount = await this.importArchiveDirectory(
+      root,
+      null,
+      createdByActorId,
+    );
+
+    this.logger.log({
+      message: 'Imported context blocks from zip archive',
+      importedCount,
+    });
+
+    return { importedCount };
+  }
+
   private async validateNoCircularReference(
     blockId: string,
     newParentId: string,
@@ -612,6 +711,140 @@ export class ContextService {
 
       currentId = current.parentId ?? null;
     }
+  }
+
+  private addBlocksToArchive(
+    zip: JSZip,
+    currentPath: string,
+    childrenByParentId: Map<string, ContextBlockEntity[]>,
+    parentIdKey: string,
+  ): void {
+    const siblings = (childrenByParentId.get(parentIdKey) ?? []).slice();
+    siblings.sort((a, b) => {
+      if (a.order !== b.order) {
+        return a.order - b.order;
+      }
+      return a.createdAt.getTime() - b.createdAt.getTime();
+    });
+
+    const usedNames = new Set<string>();
+    for (const block of siblings) {
+      const sanitizedTitle = this.sanitizeNameForFs(block.title);
+      const uniqueBaseName = this.makeUniqueName(usedNames, sanitizedTitle);
+      const childKey = block.id;
+      const children = childrenByParentId.get(childKey) ?? [];
+
+      if (children.length > 0) {
+        const folderPath = `${currentPath}${uniqueBaseName}/`;
+        zip.file(`${folderPath}index.md`, block.content ?? '');
+        this.addBlocksToArchive(zip, folderPath, childrenByParentId, childKey);
+      } else {
+        zip.file(`${currentPath}${uniqueBaseName}.md`, block.content ?? '');
+      }
+    }
+  }
+
+  private createArchiveDirectory(name: string): ArchiveDirectory {
+    return {
+      name,
+      directories: new Map<string, ArchiveDirectory>(),
+      files: new Map<string, string>(),
+    };
+  }
+
+  private async importArchiveDirectory(
+    directory: ArchiveDirectory,
+    parentId: string | null,
+    createdByActorId: string,
+  ): Promise<number> {
+    let importedCount = 0;
+
+    const leafFiles = [...directory.files.entries()]
+      .filter(([fileName]) => fileName.toLowerCase() !== 'index.md')
+      .sort(([left], [right]) => left.localeCompare(right));
+
+    for (const [fileName, content] of leafFiles) {
+      const title = this.extractTitleFromMarkdownFileName(fileName);
+      await this.createBlock({
+        title,
+        content,
+        createdByActorId,
+        parentId,
+      });
+      importedCount += 1;
+    }
+
+    const childDirectories = [...directory.directories.entries()].sort(
+      ([left], [right]) => left.localeCompare(right),
+    );
+
+    for (const [directoryName, childDirectory] of childDirectories) {
+      const indexEntry = [...childDirectory.files.entries()].find(
+        ([fileName]) => fileName.toLowerCase() === 'index.md',
+      );
+      const content = indexEntry?.[1] ?? '';
+
+      const block = await this.createBlock({
+        title: this.normalizeImportedTitle(directoryName),
+        content,
+        createdByActorId,
+        parentId,
+      });
+      importedCount += 1;
+
+      importedCount += await this.importArchiveDirectory(
+        childDirectory,
+        block.id,
+        createdByActorId,
+      );
+    }
+
+    return importedCount;
+  }
+
+  private sanitizeNameForFs(name: string): string {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return 'untitled';
+    }
+
+    const sanitized = trimmed
+      .replace(/[<>:"/\\|?*\u0000-\u001F]/g, '-')
+      .replace(/\s+/g, ' ')
+      .replace(/[. ]+$/g, '')
+      .trim();
+
+    return sanitized || 'untitled';
+  }
+
+  private makeUniqueName(usedNames: Set<string>, baseName: string): string {
+    if (!usedNames.has(baseName)) {
+      usedNames.add(baseName);
+      return baseName;
+    }
+
+    let suffix = 2;
+    let candidate = `${baseName} (${suffix})`;
+    while (usedNames.has(candidate)) {
+      suffix += 1;
+      candidate = `${baseName} (${suffix})`;
+    }
+    usedNames.add(candidate);
+    return candidate;
+  }
+
+  private extractTitleFromMarkdownFileName(fileName: string): string {
+    if (!fileName.toLowerCase().endsWith('.md')) {
+      return this.normalizeImportedTitle(fileName);
+    }
+
+    const baseName = fileName.slice(0, -3);
+    return this.normalizeImportedTitle(baseName);
+  }
+
+  private normalizeImportedTitle(name: string): string {
+    const normalized = name.trim();
+    return normalized.length > 0 ? normalized : 'untitled';
   }
 
   private mapToResult(block: ContextBlockEntity): BlockResult {

--- a/apps/backend/src/context/dto/import-blocks-response.dto.ts
+++ b/apps/backend/src/context/dto/import-blocks-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ImportBlocksResponseDto {
+  @ApiProperty({
+    description: 'Number of context blocks imported from the archive',
+    example: 12,
+  })
+  importedCount!: number;
+}

--- a/apps/backend/src/context/errors/context.errors.ts
+++ b/apps/backend/src/context/errors/context.errors.ts
@@ -5,6 +5,7 @@ export const ContextErrorCodes = {
   PARENT_BLOCK_NOT_FOUND: ErrorCodes.PARENT_PAGE_NOT_FOUND,
   CIRCULAR_REFERENCE: ErrorCodes.CIRCULAR_REFERENCE,
   BLOCK_IS_THREAD_STATE: ErrorCodes.BLOCK_IS_THREAD_STATE,
+  INVALID_ARCHIVE: ErrorCodes.VALIDATION_FAILED,
 } as const;
 
 type ContextErrorCode =
@@ -55,5 +56,11 @@ export class BlockIsThreadStateError extends ContextDomainError {
       ContextErrorCodes.BLOCK_IS_THREAD_STATE,
       { blockId, threadCount },
     );
+  }
+}
+
+export class InvalidContextArchiveError extends ContextDomainError {
+  constructor() {
+    super('Invalid zip archive.', ContextErrorCodes.INVALID_ARCHIVE);
   }
 }

--- a/apps/ui/src/features/home/HomeRoutes.tsx
+++ b/apps/ui/src/features/home/HomeRoutes.tsx
@@ -7,6 +7,7 @@ import { SettingsAccountPage } from "./SettingsAccountPage";
 import { SettingsAppearancePage } from "./SettingsAppearancePage";
 import { SettingsProjectsPage } from "./SettingsProjectsPage";
 import { SettingsChatPage } from "./SettingsChatPage";
+import { SettingsDataPage } from './SettingsDataPage';
 
 export function HomeRoutes() {
   return (
@@ -19,6 +20,7 @@ export function HomeRoutes() {
           <Route path="/settings/appearance" element={<SettingsAppearancePage />} />
           <Route path="/settings/projects" element={<SettingsProjectsPage />} />
           <Route path="/settings/chat" element={<SettingsChatPage />} />
+          <Route path="/settings/data" element={<SettingsDataPage />} />
         </Route>
       </Routes>
     </HomeProvider>

--- a/apps/ui/src/features/home/SettingsDataPage.css
+++ b/apps/ui/src/features/home/SettingsDataPage.css
@@ -1,0 +1,27 @@
+.settings-data__file-label {
+  font-size: var(--fs-2);
+  color: var(--text);
+  font-weight: var(--fw-medium);
+}
+
+.settings-data__file-input {
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  background: var(--surface);
+  color: var(--text);
+  padding: var(--space-2);
+}
+
+.settings-data__file-input::file-selector-button {
+  margin-right: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  background: var(--card-bg);
+  color: var(--text);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+}
+
+.settings-data__success {
+  color: var(--success);
+}

--- a/apps/ui/src/features/home/SettingsDataPage.tsx
+++ b/apps/ui/src/features/home/SettingsDataPage.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button, Card, Row, Stack, Text } from '../../ui/primitives';
+import { ErrorText } from '../../ui/primitives/ErrorText';
+import { BFF_BASE_URL } from '../../config/api';
+import { useHomeCtx } from './HomeProvider';
+import './SettingsDataPage.css';
+
+type ImportResponse = {
+  importedCount?: number;
+};
+
+export function SettingsDataPage() {
+  const { setSectionTitle } = useHomeCtx();
+  const [isExporting, setIsExporting] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    setSectionTitle('Import / Export');
+  }, [setSectionTitle]);
+
+  const exportUrl = useMemo(() => `${BFF_BASE_URL}/api/v1/context/blocks/export`, []);
+  const importUrl = useMemo(() => `${BFF_BASE_URL}/api/v1/context/blocks/import`, []);
+
+  const handleExportBlocks = async () => {
+    setIsExporting(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const response = await fetch(exportUrl, {
+        method: 'GET',
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to export blocks');
+      }
+
+      const blob = await response.blob();
+      const headerFileName = response.headers
+        .get('content-disposition')
+        ?.match(/filename="?([^";]+)"?/)?.[1];
+      const fileName = headerFileName || 'context-blocks.zip';
+
+      const objectUrl = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = objectUrl;
+      anchor.download = fileName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(objectUrl);
+
+      setSuccess('Blocks export downloaded successfully.');
+    } catch {
+      setError('Failed to export blocks. Please try again.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleImportBlocks = async () => {
+    if (!selectedFile) {
+      setError('Please choose a .zip file first.');
+      setSuccess('');
+      return;
+    }
+
+    setIsImporting(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const formData = new FormData();
+      formData.append('file', selectedFile);
+
+      const response = await fetch(importUrl, {
+        method: 'POST',
+        credentials: 'include',
+        body: formData,
+      });
+
+      const payload = (await response.json().catch(() => ({}))) as ImportResponse;
+      if (!response.ok) {
+        throw new Error('Failed to import blocks');
+      }
+
+      const importedCount = payload.importedCount ?? 0;
+      setSuccess(`Import complete. ${importedCount} block${importedCount === 1 ? '' : 's'} created.`);
+      setSelectedFile(null);
+    } catch {
+      setError('Failed to import blocks. Verify the archive format and try again.');
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  return (
+    <Stack spacing="6">
+      <Text tone="muted">
+        Import and export workspace data. Blocks are available now; task support can be added in this section later.
+      </Text>
+
+      {error ? (
+        <ErrorText size="2" weight="medium">
+          {error}
+        </ErrorText>
+      ) : null}
+
+      {success ? (
+        <Text size="2" className="settings-data__success">
+          {success}
+        </Text>
+      ) : null}
+
+      <Card padding="5">
+        <Stack spacing="4">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">Export Blocks</Text>
+            <Text tone="muted">Download all context blocks as a nested markdown zip archive.</Text>
+          </Stack>
+          <Row justify="end">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleExportBlocks}
+              disabled={isExporting}
+            >
+              {isExporting ? 'Exporting...' : 'Export Blocks'}
+            </Button>
+          </Row>
+        </Stack>
+      </Card>
+
+      <Card padding="5">
+        <Stack spacing="4">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">Import Blocks</Text>
+            <Text tone="muted">Upload a blocks archive to create context blocks in this workspace.</Text>
+          </Stack>
+
+          <label htmlFor="blocks-import-file" className="settings-data__file-label">
+            Select archive (.zip)
+          </label>
+          <input
+            id="blocks-import-file"
+            type="file"
+            accept=".zip,application/zip"
+            onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+            className="settings-data__file-input"
+          />
+          <Text size="1" tone="muted">
+            {selectedFile ? `Selected: ${selectedFile.name}` : 'No file selected'}
+          </Text>
+
+          <Row justify="end">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleImportBlocks}
+              disabled={isImporting}
+            >
+              {isImporting ? 'Importing...' : 'Import Blocks'}
+            </Button>
+          </Row>
+        </Stack>
+      </Card>
+    </Stack>
+  );
+}

--- a/apps/ui/src/features/home/SettingsPage.tsx
+++ b/apps/ui/src/features/home/SettingsPage.tsx
@@ -50,6 +50,13 @@ export function SettingsPage() {
         aliases: ['chat', 'openai', 'providers', 'chat providers'],
         onSelect: () => navigate('/settings/chat'),
       },
+      {
+        id: 'settings-data',
+        label: 'Import / Export',
+        description: 'Import and export workspace data',
+        aliases: ['data', 'export', 'import', 'backup', 'restore'],
+        onSelect: () => navigate('/settings/data'),
+      },
     ];
 
     return registerCommands(commands);
@@ -132,6 +139,25 @@ export function SettingsPage() {
               onClick={() => navigate('/settings/chat')}
             >
               Configure Chat
+            </Button>
+          </Row>
+        </Stack>
+      </Card>
+
+      <Card padding="5">
+        <Stack spacing="3">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">Import / Export</Text>
+            <Text tone="muted">Back up and restore workspace data</Text>
+          </Stack>
+          <Row justify="space-between" align="center">
+            <Text size="2" tone="muted">Export blocks and import archive files</Text>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => navigate('/settings/data')}
+            >
+              Manage Data
             </Button>
           </Row>
         </Stack>

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "cookie-parser": "^1.4.7",
         "cron-parser": "^5.5.0",
         "fuse.js": "^7.1.0",
+        "jszip": "^3.10.1",
         "ollama": "^0.6.3",
         "openai": "^6.22.0",
         "reflect-metadata": "^0.2.2",
@@ -7953,6 +7954,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -10719,6 +10726,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -12458,6 +12471,54 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -12518,6 +12579,15 @@
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
       "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
       "license": "MIT"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -14863,6 +14933,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -15322,6 +15398,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -16307,6 +16389,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -5354,6 +5354,76 @@
         ]
       }
     },
+    "/api/v1/context/blocks/export": {
+      "get": {
+        "operationId": "ContextController_exportBlocks",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Context blocks archive downloaded successfully"
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Export all context blocks as markdown zip",
+        "tags": [
+          "Context"
+        ]
+      }
+    },
+    "/api/v1/context/blocks/import": {
+      "post": {
+        "operationId": "ContextController_importBlocks",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Zip file exported from context blocks"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Context blocks imported successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportBlocksResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No archive file uploaded or invalid file type"
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Import context blocks from markdown zip",
+        "tags": [
+          "Context"
+        ]
+      }
+    },
     "/api/v1/context/blocks/{id}": {
       "get": {
         "operationId": "ContextController_getBlock",
@@ -11176,6 +11246,19 @@
           "children",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "ImportBlocksResponseDto": {
+        "type": "object",
+        "properties": {
+          "importedCount": {
+            "type": "number",
+            "description": "Number of context blocks imported from the archive",
+            "example": 12
+          }
+        },
+        "required": [
+          "importedCount"
         ]
       },
       "UpdateBlockDto": {

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -5360,7 +5360,15 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Context blocks archive downloaded successfully"
+            "description": "Context blocks archive downloaded successfully",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -9315,7 +9315,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/zip": string;
+                };
             };
         };
     };

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -1509,6 +1509,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/context/blocks/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Export all context blocks as markdown zip */
+        get: operations["ContextController_exportBlocks"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/context/blocks/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Import context blocks from markdown zip */
+        post: operations["ContextController_importBlocks"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/context/blocks/{id}": {
         parameters: {
             query?: never;
@@ -4915,6 +4949,13 @@ export interface components {
              * @example 2025-01-02T15:30:00.000Z
              */
             updatedAt: string;
+        };
+        ImportBlocksResponseDto: {
+            /**
+             * @description Number of context blocks imported from the archive
+             * @example 12
+             */
+            importedCount: number;
         };
         UpdateBlockDto: {
             /**
@@ -9257,6 +9298,61 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["BlockTreeResponseDto"][];
                 };
+            };
+        };
+    };
+    ContextController_exportBlocks: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Context blocks archive downloaded successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ContextController_importBlocks: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description Zip file exported from context blocks
+                     */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Context blocks imported successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportBlocksResponseDto"];
+                };
+            };
+            /** @description No archive file uploaded or invalid file type */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/client/src/v1/client/index.ts
+++ b/packages/client/src/v1/client/index.ts
@@ -69,6 +69,7 @@ export type { FlowClientDto } from './models/FlowClientDto.js';
 export type { FlowServerDto } from './models/FlowServerDto.js';
 export { GetConsentMetadataResponseDto } from './models/GetConsentMetadataResponseDto.js';
 export { GlobalSearchResultDto } from './models/GlobalSearchResultDto.js';
+export type { ImportBlocksResponseDto } from './models/ImportBlocksResponseDto.js';
 export type { InputRequestResponseDto } from './models/InputRequestResponseDto.js';
 export { IntrospectTokenRequestDto } from './models/IntrospectTokenRequestDto.js';
 export { IntrospectTokenResponseDto } from './models/IntrospectTokenResponseDto.js';

--- a/packages/client/src/v1/client/models/ImportBlocksResponseDto.ts
+++ b/packages/client/src/v1/client/models/ImportBlocksResponseDto.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ImportBlocksResponseDto = {
+    /**
+     * Number of context blocks imported from the archive
+     */
+    importedCount: number;
+};
+

--- a/packages/client/src/v1/client/services/ContextService.ts
+++ b/packages/client/src/v1/client/services/ContextService.ts
@@ -9,6 +9,7 @@ import type { BlockSearchResultDto } from '../models/BlockSearchResultDto.js';
 import type { BlockTreeResponseDto } from '../models/BlockTreeResponseDto.js';
 import type { CreateBlockDto } from '../models/CreateBlockDto.js';
 import type { CreateTagDto } from '../models/CreateTagDto.js';
+import type { ImportBlocksResponseDto } from '../models/ImportBlocksResponseDto.js';
 import type { MoveBlockDto } from '../models/MoveBlockDto.js';
 import type { ReorderBlockDto } from '../models/ReorderBlockDto.js';
 import type { UpdateBlockDto } from '../models/UpdateBlockDto.js';
@@ -88,6 +89,42 @@ export class ContextService {
         return __request(config, {
             method: 'GET',
             url: '/api/v1/context/blocks/tree',
+        });
+    }
+    /**
+     * Export all context blocks as markdown zip
+     * @returns any Context blocks archive downloaded successfully
+     * @throws ApiError
+     */
+    public static contextControllerExportBlocks(config: OpenAPIConfig = OpenAPI): CancelablePromise<any> {
+        return __request(config, {
+            method: 'GET',
+            url: '/api/v1/context/blocks/export',
+        });
+    }
+    /**
+     * Import context blocks from markdown zip
+     * @param formData
+     * @returns ImportBlocksResponseDto Context blocks imported successfully
+     * @throws ApiError
+     */
+    public static contextControllerImportBlocks(
+        formData: {
+            /**
+             * Zip file exported from context blocks
+             */
+            file: Blob;
+        },
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<ImportBlocksResponseDto> {
+        return __request(config, {
+            method: 'POST',
+            url: '/api/v1/context/blocks/import',
+            formData: formData,
+            mediaType: 'multipart/form-data',
+            errors: {
+                400: `No archive file uploaded or invalid file type`,
+            },
         });
     }
     /**

--- a/packages/client/src/v1/client/services/ContextService.ts
+++ b/packages/client/src/v1/client/services/ContextService.ts
@@ -93,10 +93,10 @@ export class ContextService {
     }
     /**
      * Export all context blocks as markdown zip
-     * @returns any Context blocks archive downloaded successfully
+     * @returns binary Context blocks archive downloaded successfully
      * @throws ApiError
      */
-    public static contextControllerExportBlocks(config: OpenAPIConfig = OpenAPI): CancelablePromise<any> {
+    public static contextControllerExportBlocks(config: OpenAPIConfig = OpenAPI): CancelablePromise<Blob> {
         return __request(config, {
             method: 'GET',
             url: '/api/v1/context/blocks/export',

--- a/packages/client/src/v2/agent-resource.ts
+++ b/packages/client/src/v2/agent-resource.ts
@@ -28,7 +28,7 @@ export class AgentResource extends BaseClient {
 
   /** Delete an agent */
   async AgentsController_deleteAgent(params: { actorId: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/agents/${params.actorId}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/agents/${params.actorId}`, { responseType: 'void', signal: params?.signal });
   }
 
   /** List tool permissions for an agent */
@@ -43,7 +43,7 @@ export class AgentResource extends BaseClient {
 
   /** Delete an agent tool permission assignment */
   async AgentToolPermissionsController_deleteAgentToolPermission(params: { actorId: string; serverId: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/agents/${params.actorId}/tool-permissions/${params.serverId}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/agents/${params.actorId}/tool-permissions/${params.serverId}`, { responseType: 'void', signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/authorization-server-resource.ts
+++ b/packages/client/src/v2/authorization-server-resource.ts
@@ -23,12 +23,12 @@ export class AuthorizationServerResource extends BaseClient {
 
   /** OAuth 2.0 Authorization Endpoint */
   async AuthorizationController_authorize(params: { serverIdentifier: string; version: string; response_type: 'code'; scope?: string; client_id: string; code_challenge: string; code_challenge_method: string; redirect_uri: string; state: string; resource?: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('GET', `/api/v1/auth/authorize/mcp/${params.serverIdentifier}/${params.version}`, { params: { response_type: params.response_type, scope: params.scope, client_id: params.client_id, code_challenge: params.code_challenge, code_challenge_method: params.code_challenge_method, redirect_uri: params.redirect_uri, state: params.state, resource: params.resource }, signal: params?.signal });
+    return this.request('GET', `/api/v1/auth/authorize/mcp/${params.serverIdentifier}/${params.version}`, { params: { response_type: params.response_type, scope: params.scope, client_id: params.client_id, code_challenge: params.code_challenge, code_challenge_method: params.code_challenge_method, redirect_uri: params.redirect_uri, state: params.state, resource: params.resource }, responseType: 'void', signal: params?.signal });
   }
 
   /** OAuth 2.0 Authorization Consent Handler */
   async AuthorizationController_authorizeConsent(params: { serverIdentifier: string; version: string; body: ConsentDecisionDto; signal?: AbortSignal }): Promise<void> {
-    return this.request('POST', `/api/v1/auth/authorize/mcp/${params.serverIdentifier}/${params.version}`, { body: params.body, signal: params?.signal });
+    return this.request('POST', `/api/v1/auth/authorize/mcp/${params.serverIdentifier}/${params.version}`, { body: params.body, responseType: 'void', signal: params?.signal });
   }
 
   /** Get metadata for the consent screen from flow ID */
@@ -53,7 +53,7 @@ export class AuthorizationServerResource extends BaseClient {
 
   /** OAuth 2.0 Callback Endpoint for Downstream Systems */
   async AuthorizationController_callback(params: { code: string; state: string; error?: string; scope?: string; error_description?: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('GET', '/api/v1/auth/callback', { params: { code: params.code, state: params.state, error: params.error, scope: params.scope, error_description: params.error_description }, signal: params?.signal });
+    return this.request('GET', '/api/v1/auth/callback', { params: { code: params.code, state: params.state, error: params.error, scope: params.scope, error_description: params.error_description }, responseType: 'void', signal: params?.signal });
   }
 
   /** List All Available Scopes */

--- a/packages/client/src/v2/base-client.ts
+++ b/packages/client/src/v2/base-client.ts
@@ -176,15 +176,15 @@ export class BaseClient {
     // Add auth headers
     Object.assign(headers, await this.buildAuthHeaders());
 
-    let requestBody: BodyInit | undefined;
+    let requestBody: any;
     if (options?.body !== undefined) {
       const bodyType = options.bodyType ?? 'json';
 
       if (bodyType === 'form-data') {
-        requestBody = options.body as BodyInit;
+        requestBody = options.body;
         this.removeHeader(headers, 'Content-Type');
       } else if (bodyType === 'raw') {
-        requestBody = options.body as BodyInit;
+        requestBody = options.body;
       } else {
         if (!this.hasHeader(headers, 'Content-Type')) {
           headers['Content-Type'] = 'application/json';

--- a/packages/client/src/v2/base-client.ts
+++ b/packages/client/src/v2/base-client.ts
@@ -60,9 +60,34 @@ export class ApiError extends Error {
 export class BaseClient {
   constructor(protected config: ClientConfig) {}
 
-  private async parseResponseBody(response: Response): Promise<unknown> {
+  private async parseResponseBody(
+    response: Response,
+    responseType: 'auto' | 'json' | 'text' | 'arrayBuffer' | 'void' = 'auto'
+  ): Promise<unknown> {
+    if (responseType === 'void') {
+      return undefined;
+    }
+
     if (response.status === 204 || response.headers.get('content-length') === '0') {
       return undefined;
+    }
+
+    if (responseType === 'json') {
+      try {
+        return await response.json();
+      } catch {
+        return undefined;
+      }
+    }
+
+    if (responseType === 'text') {
+      const text = await response.text();
+      return text.length > 0 ? text : undefined;
+    }
+
+    if (responseType === 'arrayBuffer') {
+      const arrayBuffer = await response.arrayBuffer();
+      return arrayBuffer.byteLength > 0 ? arrayBuffer : undefined;
     }
 
     const contentType = response.headers.get('content-type');
@@ -76,6 +101,20 @@ export class BaseClient {
 
     const text = await response.text();
     return text.length > 0 ? text : undefined;
+  }
+
+  private hasHeader(headers: Record<string, string>, headerName: string): boolean {
+    const target = headerName.toLowerCase();
+    return Object.keys(headers).some((key) => key.toLowerCase() === target);
+  }
+
+  private removeHeader(headers: Record<string, string>, headerName: string): void {
+    const target = headerName.toLowerCase();
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === target) {
+        delete headers[key];
+      }
+    }
   }
 
   private async buildAuthHeaders(): Promise<Record<string, string>> {
@@ -96,6 +135,8 @@ export class BaseClient {
     options?: {
       params?: Record<string, any>;
       body?: any;
+      bodyType?: 'json' | 'form-data' | 'raw';
+      responseType?: 'auto' | 'json' | 'text' | 'arrayBuffer' | 'void';
       headers?: Record<string, string>;
       signal?: AbortSignal;
     }
@@ -135,25 +176,37 @@ export class BaseClient {
     // Add auth headers
     Object.assign(headers, await this.buildAuthHeaders());
 
-    // Add content type for body requests
-    if (options?.body && !headers['Content-Type']) {
-      headers['Content-Type'] = 'application/json';
+    let requestBody: BodyInit | undefined;
+    if (options?.body !== undefined) {
+      const bodyType = options.bodyType ?? 'json';
+
+      if (bodyType === 'form-data') {
+        requestBody = options.body as BodyInit;
+        this.removeHeader(headers, 'Content-Type');
+      } else if (bodyType === 'raw') {
+        requestBody = options.body as BodyInit;
+      } else {
+        if (!this.hasHeader(headers, 'Content-Type')) {
+          headers['Content-Type'] = 'application/json';
+        }
+        requestBody = JSON.stringify(options.body);
+      }
     }
 
     const response = await fetch(url.toString(), {
       method,
       headers,
-      body: options?.body ? JSON.stringify(options.body) : undefined,
+      body: requestBody,
       signal: options?.signal,
       credentials: this.config.credentials,
     });
 
     if (!response.ok) {
-      const errorBody = await this.parseResponseBody(response);
+      const errorBody = await this.parseResponseBody(response, 'auto');
       throw new ApiError(response, errorBody);
     }
 
-    return await this.parseResponseBody(response) as T;
+    return await this.parseResponseBody(response, options?.responseType ?? 'auto') as T;
   }
 
   protected async *streamEvents<T = any>(

--- a/packages/client/src/v2/chat-providers-resource.ts
+++ b/packages/client/src/v2/chat-providers-resource.ts
@@ -28,7 +28,7 @@ export class ChatProvidersResource extends BaseClient {
 
   /** Delete a chat provider */
   async ChatProvidersController_deleteChatProvider(params: { id: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/chat-providers/${params.id}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/chat-providers/${params.id}`, { responseType: 'void', signal: params?.signal });
   }
 
   /** Set the active chat provider */
@@ -38,7 +38,7 @@ export class ChatProvidersResource extends BaseClient {
 
   /** Deactivate the active chat provider */
   async ChatProvidersController_deactivateActiveChatProvider(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('POST', '/api/v1/chat-providers/deactivate', { signal: params?.signal });
+    return this.request('POST', '/api/v1/chat-providers/deactivate', { responseType: 'void', signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/context-resource.ts
+++ b/packages/client/src/v2/context-resource.ts
@@ -27,13 +27,13 @@ export class ContextResource extends BaseClient {
   }
 
   /** Export all context blocks as markdown zip */
-  async ContextController_exportBlocks(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('GET', '/api/v1/context/blocks/export', { signal: params?.signal });
+  async ContextController_exportBlocks(params?: { signal?: AbortSignal }): Promise<ArrayBuffer> {
+    return this.request('GET', '/api/v1/context/blocks/export', { responseType: 'arrayBuffer', signal: params?.signal });
   }
 
   /** Import context blocks from markdown zip */
-  async ContextController_importBlocks(params: { body: { file: string }; signal?: AbortSignal }): Promise<ImportBlocksResponseDto> {
-    return this.request('POST', '/api/v1/context/blocks/import', { body: params.body, signal: params?.signal });
+  async ContextController_importBlocks(params: { body: FormData; signal?: AbortSignal }): Promise<ImportBlocksResponseDto> {
+    return this.request('POST', '/api/v1/context/blocks/import', { body: params.body, bodyType: 'form-data', signal: params?.signal });
   }
 
   /** Fetch a wiki page by ID */
@@ -48,7 +48,7 @@ export class ContextResource extends BaseClient {
 
   /** Delete a wiki page */
   async ContextController_deleteBlock(params: { id: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/context/blocks/${params.id}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/context/blocks/${params.id}`, { responseType: 'void', signal: params?.signal });
   }
 
   /** Append content to an existing wiki page */
@@ -77,31 +77,31 @@ export class ContextResource extends BaseClient {
   }
 
   async ContextController_handleMcp_get(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('GET', '/api/v1/context/blocks/mcp', { signal: params?.signal });
+    return this.request('GET', '/api/v1/context/blocks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async ContextController_handleMcp_post(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('POST', '/api/v1/context/blocks/mcp', { signal: params?.signal });
+    return this.request('POST', '/api/v1/context/blocks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async ContextController_handleMcp_put(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('PUT', '/api/v1/context/blocks/mcp', { signal: params?.signal });
+    return this.request('PUT', '/api/v1/context/blocks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async ContextController_handleMcp_delete(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', '/api/v1/context/blocks/mcp', { signal: params?.signal });
+    return this.request('DELETE', '/api/v1/context/blocks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async ContextController_handleMcp_patch(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('PATCH', '/api/v1/context/blocks/mcp', { signal: params?.signal });
+    return this.request('PATCH', '/api/v1/context/blocks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async ContextController_handleMcp_options(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('OPTIONS', '/api/v1/context/blocks/mcp', { signal: params?.signal });
+    return this.request('OPTIONS', '/api/v1/context/blocks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async ContextController_handleMcp_head(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('HEAD', '/api/v1/context/blocks/mcp', { signal: params?.signal });
+    return this.request('HEAD', '/api/v1/context/blocks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/context-resource.ts
+++ b/packages/client/src/v2/context-resource.ts
@@ -1,5 +1,5 @@
 import { BaseClient, ClientConfig } from './base-client.js';
-import type { AppendBlockDto, BlockListResponseDto, BlockResponseDto, BlockSearchResultDto, BlockTreeResponseDto, CreateBlockDto, CreateTagDto, MoveBlockDto, ReorderBlockDto, UpdateBlockDto } from './types.js';
+import type { AppendBlockDto, BlockListResponseDto, BlockResponseDto, BlockSearchResultDto, BlockTreeResponseDto, CreateBlockDto, CreateTagDto, ImportBlocksResponseDto, MoveBlockDto, ReorderBlockDto, UpdateBlockDto } from './types.js';
 
 export class ContextResource extends BaseClient {
   constructor(config: ClientConfig) {
@@ -24,6 +24,16 @@ export class ContextResource extends BaseClient {
   /** Get page hierarchy tree */
   async ContextController_getBlockTree(params?: { signal?: AbortSignal }): Promise<BlockTreeResponseDto[]> {
     return this.request('GET', '/api/v1/context/blocks/tree', { signal: params?.signal });
+  }
+
+  /** Export all context blocks as markdown zip */
+  async ContextController_exportBlocks(params?: { signal?: AbortSignal }): Promise<void> {
+    return this.request('GET', '/api/v1/context/blocks/export', { signal: params?.signal });
+  }
+
+  /** Import context blocks from markdown zip */
+  async ContextController_importBlocks(params: { body: { file: string }; signal?: AbortSignal }): Promise<ImportBlocksResponseDto> {
+    return this.request('POST', '/api/v1/context/blocks/import', { body: params.body, signal: params?.signal });
   }
 
   /** Fetch a wiki page by ID */

--- a/packages/client/src/v2/executions-resource.ts
+++ b/packages/client/src/v2/executions-resource.ts
@@ -28,12 +28,12 @@ export class ExecutionsResource extends BaseClient {
 
   /** Attach the runner session id to an active execution */
   async ActiveTaskExecutionController_updateRunnerSessionId(params: { executionId: string; body: UpdateRunnerSessionIdDto; signal?: AbortSignal }): Promise<void> {
-    return this.request('PATCH', `/api/v1/executions/active/${params.executionId}/session`, { body: params.body, signal: params?.signal });
+    return this.request('PATCH', `/api/v1/executions/active/${params.executionId}/session`, { body: params.body, responseType: 'void', signal: params?.signal });
   }
 
   /** Increment tool call count for an active execution */
   async ActiveTaskExecutionController_incrementToolCallCount(params: { executionId: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('PATCH', `/api/v1/executions/active/${params.executionId}/tool-calls/increment`, { signal: params?.signal });
+    return this.request('PATCH', `/api/v1/executions/active/${params.executionId}/tool-calls/increment`, { responseType: 'void', signal: params?.signal });
   }
 
   /** List task execution history */

--- a/packages/client/src/v2/meta---projects-resource.ts
+++ b/packages/client/src/v2/meta---projects-resource.ts
@@ -38,7 +38,7 @@ export class MetaProjectsResource extends BaseClient {
 
   /** Delete a project */
   async ProjectsController_deleteProject(params: { projectId: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/meta/projects/${params.projectId}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/meta/projects/${params.projectId}`, { responseType: 'void', signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/meta-resource.ts
+++ b/packages/client/src/v2/meta-resource.ts
@@ -23,7 +23,7 @@ export class MetaResource extends BaseClient {
 
   /** Delete a tag from the system */
   async MetaController_deleteTag(params: { tagId: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/meta/tags/${params.tagId}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/meta/tags/${params.tagId}`, { responseType: 'void', signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/scheduled-tasks-resource.ts
+++ b/packages/client/src/v2/scheduled-tasks-resource.ts
@@ -28,7 +28,7 @@ export class ScheduledTasksResource extends BaseClient {
 
   /** Delete a scheduled task */
   async ScheduledTasksController_deleteScheduledTask(params: { id: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/scheduled-tasks/${params.id}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/scheduled-tasks/${params.id}`, { responseType: 'void', signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/secrets-resource.ts
+++ b/packages/client/src/v2/secrets-resource.ts
@@ -28,7 +28,7 @@ export class SecretsResource extends BaseClient {
 
   /** Delete a secret */
   async SecretsController_deleteSecret(params: { id: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/secrets/${params.id}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/secrets/${params.id}`, { responseType: 'void', signal: params?.signal });
   }
 
   /** Get decrypted secret value */

--- a/packages/client/src/v2/task-blueprints-resource.ts
+++ b/packages/client/src/v2/task-blueprints-resource.ts
@@ -28,7 +28,7 @@ export class TaskBlueprintsResource extends BaseClient {
 
   /** Delete a task blueprint */
   async TaskBlueprintsController_deleteTaskBlueprint(params: { id: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/task-blueprints/${params.id}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/task-blueprints/${params.id}`, { responseType: 'void', signal: params?.signal });
   }
 
   /** Create a task from a blueprint */

--- a/packages/client/src/v2/task-resource.ts
+++ b/packages/client/src/v2/task-resource.ts
@@ -23,7 +23,7 @@ export class TaskResource extends BaseClient {
 
   /** Delete a task */
   async TasksController_deleteTask(params: { id: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/tasks/tasks/${params.id}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/tasks/tasks/${params.id}`, { responseType: 'void', signal: params?.signal });
   }
 
   /** Get a task by ID */
@@ -82,31 +82,31 @@ export class TaskResource extends BaseClient {
   }
 
   async TasksController_handleMcp_get(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('GET', '/api/v1/tasks/tasks/mcp', { signal: params?.signal });
+    return this.request('GET', '/api/v1/tasks/tasks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async TasksController_handleMcp_post(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('POST', '/api/v1/tasks/tasks/mcp', { signal: params?.signal });
+    return this.request('POST', '/api/v1/tasks/tasks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async TasksController_handleMcp_put(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('PUT', '/api/v1/tasks/tasks/mcp', { signal: params?.signal });
+    return this.request('PUT', '/api/v1/tasks/tasks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async TasksController_handleMcp_delete(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', '/api/v1/tasks/tasks/mcp', { signal: params?.signal });
+    return this.request('DELETE', '/api/v1/tasks/tasks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async TasksController_handleMcp_patch(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('PATCH', '/api/v1/tasks/tasks/mcp', { signal: params?.signal });
+    return this.request('PATCH', '/api/v1/tasks/tasks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async TasksController_handleMcp_options(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('OPTIONS', '/api/v1/tasks/tasks/mcp', { signal: params?.signal });
+    return this.request('OPTIONS', '/api/v1/tasks/tasks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
   async TasksController_handleMcp_head(params?: { signal?: AbortSignal }): Promise<void> {
-    return this.request('HEAD', '/api/v1/tasks/tasks/mcp', { signal: params?.signal });
+    return this.request('HEAD', '/api/v1/tasks/tasks/mcp', { responseType: 'void', signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/threads-resource.ts
+++ b/packages/client/src/v2/threads-resource.ts
@@ -28,7 +28,7 @@ export class ThreadsResource extends BaseClient {
 
   /** Delete a thread */
   async ThreadsController_deleteThread(params: { id: string; signal?: AbortSignal }): Promise<void> {
-    return this.request('DELETE', `/api/v1/threads/${params.id}`, { signal: params?.signal });
+    return this.request('DELETE', `/api/v1/threads/${params.id}`, { responseType: 'void', signal: params?.signal });
   }
 
   /** Get a thread by task ID */

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -874,6 +874,10 @@ export interface BlockTreeResponseDto {
   updatedAt: string;
 }
 
+export interface ImportBlocksResponseDto {
+  importedCount: number;
+}
+
 export interface UpdateBlockDto {
   title?: string;
   content?: string;

--- a/packages/openapi-sdkgen/src/generator.ts
+++ b/packages/openapi-sdkgen/src/generator.ts
@@ -71,7 +71,7 @@ function schemaToTypeScript(schema: SchemaInfo): string {
 
   switch (schema.type) {
     case 'string':
-      baseType = 'string';
+      baseType = schema.format === 'binary' ? 'Blob' : 'string';
       break;
     case 'number':
     case 'integer':
@@ -172,9 +172,34 @@ export class ApiError extends Error {
 export class BaseClient {
   constructor(protected config: ClientConfig) {}
 
-  private async parseResponseBody(response: Response): Promise<unknown> {
+  private async parseResponseBody(
+    response: Response,
+    responseType: 'auto' | 'json' | 'text' | 'arrayBuffer' | 'void' = 'auto'
+  ): Promise<unknown> {
+    if (responseType === 'void') {
+      return undefined;
+    }
+
     if (response.status === 204 || response.headers.get('content-length') === '0') {
       return undefined;
+    }
+
+    if (responseType === 'json') {
+      try {
+        return await response.json();
+      } catch {
+        return undefined;
+      }
+    }
+
+    if (responseType === 'text') {
+      const text = await response.text();
+      return text.length > 0 ? text : undefined;
+    }
+
+    if (responseType === 'arrayBuffer') {
+      const arrayBuffer = await response.arrayBuffer();
+      return arrayBuffer.byteLength > 0 ? arrayBuffer : undefined;
     }
 
     const contentType = response.headers.get('content-type');
@@ -188,6 +213,20 @@ export class BaseClient {
 
     const text = await response.text();
     return text.length > 0 ? text : undefined;
+  }
+
+  private hasHeader(headers: Record<string, string>, headerName: string): boolean {
+    const target = headerName.toLowerCase();
+    return Object.keys(headers).some((key) => key.toLowerCase() === target);
+  }
+
+  private removeHeader(headers: Record<string, string>, headerName: string): void {
+    const target = headerName.toLowerCase();
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === target) {
+        delete headers[key];
+      }
+    }
   }
 
   private async buildAuthHeaders(): Promise<Record<string, string>> {
@@ -208,6 +247,8 @@ export class BaseClient {
     options?: {
       params?: Record<string, any>;
       body?: any;
+      bodyType?: 'json' | 'form-data' | 'raw';
+      responseType?: 'auto' | 'json' | 'text' | 'arrayBuffer' | 'void';
       headers?: Record<string, string>;
       signal?: AbortSignal;
     }
@@ -247,25 +288,37 @@ export class BaseClient {
     // Add auth headers
     Object.assign(headers, await this.buildAuthHeaders());
 
-    // Add content type for body requests
-    if (options?.body && !headers['Content-Type']) {
-      headers['Content-Type'] = 'application/json';
+    let requestBody: BodyInit | undefined;
+    if (options?.body !== undefined) {
+      const bodyType = options.bodyType ?? 'json';
+
+      if (bodyType === 'form-data') {
+        requestBody = options.body as BodyInit;
+        this.removeHeader(headers, 'Content-Type');
+      } else if (bodyType === 'raw') {
+        requestBody = options.body as BodyInit;
+      } else {
+        if (!this.hasHeader(headers, 'Content-Type')) {
+          headers['Content-Type'] = 'application/json';
+        }
+        requestBody = JSON.stringify(options.body);
+      }
     }
 
     const response = await fetch(url.toString(), {
       method,
       headers,
-      body: options?.body ? JSON.stringify(options.body) : undefined,
+      body: requestBody,
       signal: options?.signal,
       credentials: this.config.credentials,
     });
 
     if (!response.ok) {
-      const errorBody = await this.parseResponseBody(response);
+      const errorBody = await this.parseResponseBody(response, 'auto');
       throw new ApiError(response, errorBody);
     }
 
-    return await this.parseResponseBody(response) as T;
+    return await this.parseResponseBody(response, options?.responseType ?? 'auto') as T;
   }
 
   protected async *streamEvents<T = any>(
@@ -434,12 +487,13 @@ function generateOperation(op: Operation): string {
 
   // Determine if this is a streaming endpoint by checking response content-type
   const isStreaming = isStreamingEndpoint(op);
+  const responseMode = inferResponseMode(op);
 
   // Build method signature
   // Use operationId directly as method name (already in desired format from OpenAPI)
   const methodName = op.operationId;
   const { params, isParamsOptional } = buildMethodParams(op);
-  const returnType = inferReturnType(op, isStreaming);
+  const returnType = inferReturnType(op, isStreaming, responseMode);
 
   // Add JSDoc comment
   if (op.summary) {
@@ -511,6 +565,16 @@ function generateOperation(op: Operation): string {
 
   if (op.requestBody) {
     requestOptions.push(`body: ${paramsPrefix}body`);
+    const requestBodyContentType = getPreferredRequestBodyContentType(op);
+    if (requestBodyContentType === 'multipart/form-data') {
+      requestOptions.push(`bodyType: 'form-data'`);
+    } else if (requestBodyContentType && requestBodyContentType !== 'application/json') {
+      requestOptions.push(`bodyType: 'raw'`);
+    }
+  }
+
+  if (responseMode !== 'auto') {
+    requestOptions.push(`responseType: '${responseMode}'`);
   }
 
   if (params.includes('signal')) {
@@ -568,12 +632,20 @@ function buildMethodParams(op: Operation): { params: string; isParamsOptional: b
     }
 
     if (op.requestBody) {
-      // Try to get the body schema from any content type (prefer application/json)
-      const bodySchema = op.requestBody.content.get('application/json') ||
-                         Array.from(op.requestBody.content.values())[0];
+      const requestBodyContentType = getPreferredRequestBodyContentType(op);
+      const bodySchema =
+        (requestBodyContentType
+          ? op.requestBody.content.get(requestBodyContentType)
+          : undefined)
+        || op.requestBody.content.get('application/json')
+        || Array.from(op.requestBody.content.values())[0];
       if (bodySchema) {
         const optional = !op.requestBody.required;
-        paramFields.push(`body${optional ? '?' : ''}: ${schemaToTypeScript(bodySchema.schema)}`);
+        const bodyType =
+          requestBodyContentType === 'multipart/form-data'
+            ? 'FormData'
+            : schemaToTypeScript(bodySchema.schema);
+        paramFields.push(`body${optional ? '?' : ''}: ${bodyType}`);
       }
     }
 
@@ -596,11 +668,23 @@ function buildMethodParams(op: Operation): { params: string; isParamsOptional: b
   return { params: params.join(', '), isParamsOptional };
 }
 
-function inferReturnType(op: Operation, isStreaming: boolean): string {
+function inferReturnType(
+  op: Operation,
+  isStreaming: boolean,
+  responseMode: 'auto' | 'json' | 'text' | 'arrayBuffer' | 'void'
+): string {
   const successResponse = op.responses.get(200) || op.responses.get(201);
 
   if (!successResponse?.content) {
     return isStreaming ? 'AsyncIterable<any>' : 'Promise<void>';
+  }
+
+  if (responseMode === 'arrayBuffer') {
+    return isStreaming ? 'AsyncIterable<any>' : 'Promise<ArrayBuffer>';
+  }
+
+  if (responseMode === 'text') {
+    return isStreaming ? 'AsyncIterable<any>' : 'Promise<string>';
   }
 
   const jsonContent = successResponse.content.get('application/json');
@@ -615,6 +699,56 @@ function inferReturnType(op: Operation, isStreaming: boolean): string {
   }
 
   return `Promise<${tsType}>`;
+}
+
+function getPreferredRequestBodyContentType(op: Operation): string | undefined {
+  if (!op.requestBody) {
+    return undefined;
+  }
+
+  if (op.requestBody.content.has('application/json')) {
+    return 'application/json';
+  }
+
+  if (op.requestBody.content.has('multipart/form-data')) {
+    return 'multipart/form-data';
+  }
+
+  if (op.requestBody.content.has('application/x-www-form-urlencoded')) {
+    return 'application/x-www-form-urlencoded';
+  }
+
+  return op.requestBody.content.keys().next().value;
+}
+
+function inferResponseMode(op: Operation): 'auto' | 'json' | 'text' | 'arrayBuffer' | 'void' {
+  const successResponse = op.responses.get(200) || op.responses.get(201);
+  if (!successResponse?.content) {
+    return 'void';
+  }
+
+  for (const contentType of successResponse.content.keys()) {
+    const lowered = contentType.toLowerCase();
+    if (lowered.includes('application/json')) {
+      return 'auto';
+    }
+  }
+
+  for (const contentType of successResponse.content.keys()) {
+    const lowered = contentType.toLowerCase();
+    if (lowered.startsWith('text/')) {
+      return 'text';
+    }
+  }
+
+  for (const contentType of successResponse.content.keys()) {
+    const lowered = contentType.toLowerCase();
+    if (lowered.includes('zip') || lowered.includes('octet-stream')) {
+      return 'arrayBuffer';
+    }
+  }
+
+  return 'auto';
 }
 
 function generateMainClient(spec: ParsedSpec): string {

--- a/packages/openapi-sdkgen/src/generator.ts
+++ b/packages/openapi-sdkgen/src/generator.ts
@@ -288,15 +288,15 @@ export class BaseClient {
     // Add auth headers
     Object.assign(headers, await this.buildAuthHeaders());
 
-    let requestBody: BodyInit | undefined;
+    let requestBody: any;
     if (options?.body !== undefined) {
       const bodyType = options.bodyType ?? 'json';
 
       if (bodyType === 'form-data') {
-        requestBody = options.body as BodyInit;
+        requestBody = options.body;
         this.removeHeader(headers, 'Content-Type');
       } else if (bodyType === 'raw') {
-        requestBody = options.body as BodyInit;
+        requestBody = options.body;
       } else {
         if (!this.hasHeader(headers, 'Content-Type')) {
           headers['Content-Type'] = 'application/json';
@@ -573,7 +573,7 @@ function generateOperation(op: Operation): string {
     }
   }
 
-  if (responseMode !== 'auto') {
+  if (!isStreaming && responseMode !== 'auto') {
     requestOptions.push(`responseType: '${responseMode}'`);
   }
 

--- a/packages/openapi-sdkgen/test/api/src/files.controller.ts
+++ b/packages/openapi-sdkgen/test/api/src/files.controller.ts
@@ -11,6 +11,7 @@ import {
   UploadedFile,
   UploadedFiles,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiOperation, ApiResponse, ApiConsumes, ApiBody, ApiProperty } from '@nestjs/swagger';
 
 export class FileUploadResponseDto {
@@ -98,7 +99,8 @@ export class FilesController {
   })
   @ApiResponse({ status: 201, type: FileUploadResponseDto })
   @HttpCode(HttpStatus.CREATED)
-  uploadSingleFile(@Body() body: any): FileUploadResponseDto {
+  @UseInterceptors(FileInterceptor('file'))
+  uploadSingleFile(@UploadedFile() _file: any): FileUploadResponseDto {
     // Mock response - in real implementation would use multer or similar
     return {
       filename: 'uploaded-file.txt',
@@ -166,7 +168,11 @@ export class FilesController {
   })
   @ApiResponse({ status: 201, type: FileWithMetadataResponseDto })
   @HttpCode(HttpStatus.CREATED)
-  uploadFileWithMetadata(@Body() body: any): FileWithMetadataResponseDto {
+  @UseInterceptors(FileInterceptor('file'))
+  uploadFileWithMetadata(
+    @UploadedFile() _file: any,
+    @Body() body: any,
+  ): FileWithMetadataResponseDto {
     // Mock response
     return {
       filename: 'document.pdf',

--- a/packages/openapi-sdkgen/test/client/test-sdk.ts
+++ b/packages/openapi-sdkgen/test/client/test-sdk.ts
@@ -297,17 +297,21 @@ async function main() {
 
     // Test 33: Files - uploads and downloads
     console.log('\n✓ Test 33: Files - representative upload/download endpoints');
+    const singleFileBody = new FormData();
+    singleFileBody.append('file', 'mock-file-content');
     const uploadedFile = await client.files.FilesController_uploadSingleFile({
-      body: { file: 'mock-file-content' },
+      body: singleFileBody,
       signal: undefined,
     });
+
+    const fileWithMetadataBody = new FormData();
+    fileWithMetadataBody.append('file', 'mock-file-binary');
+    fileWithMetadataBody.append('title', 'SDK test file');
+    fileWithMetadataBody.append('description', 'Uploaded from generated client test');
+    fileWithMetadataBody.append('tags', 'sdk');
+    fileWithMetadataBody.append('tags', 'openapi');
     const uploadWithMetadata = await client.files.FilesController_uploadFileWithMetadata({
-      body: {
-        file: 'mock-file-binary',
-        title: 'SDK test file',
-        description: 'Uploaded from generated client test',
-        tags: ['sdk', 'openapi'],
-      },
+      body: fileWithMetadataBody,
       signal: undefined,
     });
     const fileInfo = await client.files.FilesController_getFileInfo({


### PR DESCRIPTION
## Summary
- add backend `context/blocks/export` and `context/blocks/import` endpoints to export all context blocks as a nested markdown ZIP archive and import that archive back into blocks
- implement archive mapping for nested blocks (`<folder>/index.md` for parent content, child files/folders for descendants), including filename sanitization and collision handling
- add new Settings Import/Export page in the UI with controls to download block exports and upload `.zip` archives for block imports
- regenerate OpenAPI/client artifacts so frontend and SDK consumers can use the new import/export API surface

## Technical Debt
- import currently sorts sibling entries by filename/folder name and does not preserve original custom `order` values from source blocks beyond deterministic creation order