### PR TITLE
Add Workers settings UI (configure + list)

### DIFF
--- a/apps/backend/src/executions/workers.scopes.ts
+++ b/apps/backend/src/executions/workers.scopes.ts
@@ -1,6 +1,14 @@
 import { Scope } from 'src/auth/core/types/scope.type';
 
 export const WorkersScopes = {
+  READ: {
+    id: 'workers:read',
+    description: 'Read workers',
+  },
+  WRITE: {
+    id: 'workers:write',
+    description: 'Manage workers',
+  },
   CONNECT: {
     id: 'workers:connect',
     description:

--- a/apps/backend/src/workers/events/workers.events.ts
+++ b/apps/backend/src/workers/events/workers.events.ts
@@ -1,0 +1,30 @@
+import { WorkerEntity } from '../worker.entity';
+
+/**
+ * Domain events for the Workers domain.
+ * These events decouple the service layer from transport concerns (WebSocket, HTTP, etc.)
+ *
+ * Each event uses a Symbol as its internal identifier to ensure type-safe,
+ * non-string-based event emission within the domain layer.
+ */
+
+export type EventActor = {
+  id: string;
+};
+
+export abstract class WorkerDomainEvent<TPayload = unknown> {
+  readonly occurredAt: Date = new Date();
+
+  constructor(
+    public readonly actor: EventActor,
+    public readonly payload: TPayload,
+  ) {}
+}
+
+export class WorkerSeenEvent extends WorkerDomainEvent<WorkerEntity> {
+  static readonly INTERNAL = Symbol('workers.WorkerSeenEvent');
+
+  constructor(actor: EventActor, worker: WorkerEntity) {
+    super(actor, worker);
+  }
+}

--- a/apps/backend/src/workers/workers.controller.ts
+++ b/apps/backend/src/workers/workers.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { WorkersService } from './workers.service';
+import { WorkerResponseDto } from './dto/http/worker-response.dto';
+import { AccessTokenGuard } from 'src/auth/guards/guards/access-token.guard';
+import { ScopesGuard } from 'src/auth/guards/guards/scopes.guard';
+import { RequireScopes } from 'src/auth/guards/decorators/require-scopes.decorator';
+import { WorkersScopes } from 'src/executions/workers.scopes';
+
+@ApiTags('workers')
+@UseGuards(AccessTokenGuard, ScopesGuard)
+@Controller('workers')
+export class WorkersController {
+  constructor(private readonly workersService: WorkersService) {}
+
+  @Get()
+  @RequireScopes(WorkersScopes.READ.id)
+  @ApiOperation({ summary: 'List all workers' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of all registered workers',
+    type: [WorkerResponseDto],
+  })
+  async listWorkers(): Promise<WorkerResponseDto[]> {
+    const workers = await this.workersService.findAll();
+    return workers.map((worker) => WorkerResponseDto.fromEntity(worker));
+  }
+}

--- a/apps/backend/src/workers/workers.gateway.ts
+++ b/apps/backend/src/workers/workers.gateway.ts
@@ -1,0 +1,75 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { Logger, UseGuards } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { WorkerSeenEvent } from './events/workers.events';
+import { WorkerWireEvents } from '@taico/events';
+import type { WorkerSeenWireEvent } from '@taico/events';
+import { WorkerResponseDto } from './dto/http/worker-response.dto';
+import { WsAccessTokenGuard } from 'src/auth/guards/guards/ws-access-token-guard';
+import { WsScopesGuard } from 'src/auth/guards/guards/ws-scopes.guard';
+import { RequireScopes } from 'src/auth/guards/decorators/require-scopes.decorator';
+import { WorkersScopes } from 'src/executions/workers.scopes';
+
+const WORKERS_ROOM = 'workers';
+
+/**
+ * WebSocket gateway for Workers domain.
+ *
+ * Acts as a transport adapter that:
+ * 1. Listens to internal domain events (Symbol-based)
+ * 2. Maps domain entities to DTOs
+ * 3. Emits stable wire events to clients
+ *
+ * This decouples the service layer from transport concerns,
+ * similar to how HTTP controllers map entities to response DTOs.
+ */
+@UseGuards(WsAccessTokenGuard, WsScopesGuard)
+@RequireScopes(WorkersScopes.READ.id)
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+  },
+  namespace: '/workers',
+})
+export class WorkersGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
+  @WebSocketServer()
+  server!: Server;
+
+  private logger = new Logger(WorkersGateway.name);
+
+  afterInit() {
+    this.logger.log('Workers WebSocket Gateway initialized');
+  }
+
+  handleConnection(client: Socket) {
+    this.logger.log(`Client connected to workers namespace: ${client.id}`);
+    client.join(WORKERS_ROOM);
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.log(`Client disconnected from workers namespace: ${client.id}`);
+  }
+
+  @OnEvent(WorkerSeenEvent.INTERNAL)
+  handleWorkerSeen(event: WorkerSeenEvent) {
+    const dto = WorkerResponseDto.fromEntity(event.payload);
+    const wireEvent: WorkerSeenWireEvent = {
+      worker: dto,
+      occurredAt: event.occurredAt.toISOString(),
+    };
+
+    this.server.to(WORKERS_ROOM).emit(WorkerWireEvents.WORKER_SEEN, wireEvent);
+    this.logger.log(
+      `Emitted ${WorkerWireEvents.WORKER_SEEN} for worker ${dto.id}`,
+    );
+  }
+}

--- a/apps/backend/src/workers/workers.module.ts
+++ b/apps/backend/src/workers/workers.module.ts
@@ -2,10 +2,17 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { WorkerEntity } from './worker.entity';
 import { WorkersService } from './workers.service';
+import { WorkersController } from './workers.controller';
+import { WorkersGateway } from './workers.gateway';
+import { AuthGuardsModule } from '../auth/guards/auth-guards.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([WorkerEntity])],
-  providers: [WorkersService],
+  imports: [
+    TypeOrmModule.forFeature([WorkerEntity]),
+    AuthGuardsModule,
+  ],
+  controllers: [WorkersController],
+  providers: [WorkersService, WorkersGateway],
   exports: [WorkersService],
 })
 export class WorkersModule {}

--- a/apps/backend/src/workers/workers.service.ts
+++ b/apps/backend/src/workers/workers.service.ts
@@ -1,15 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { WorkerEntity } from './worker.entity';
 import { RecordWorkerSeenInput } from './dto/service/workers.service.types';
+import { WorkerSeenEvent } from './events/workers.events';
 
 @Injectable()
 export class WorkersService {
   constructor(
     @InjectRepository(WorkerEntity)
     private readonly workersRepository: Repository<WorkerEntity>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
+
+  async findAll(): Promise<WorkerEntity[]> {
+    return this.workersRepository.find({
+      order: {
+        lastSeenAt: 'DESC',
+      },
+    });
+  }
 
   async recordWorkerSeen(input: RecordWorkerSeenInput): Promise<WorkerEntity> {
     const worker = await this.workersRepository.findOne({
@@ -18,22 +29,35 @@ export class WorkersService {
 
     const nextSeenAt = input.seenAt ?? new Date();
 
+    let savedWorker: WorkerEntity;
+
     if (!worker) {
-      return this.workersRepository.save(
+      savedWorker = await this.workersRepository.save(
         this.workersRepository.create({
           oauthClientId: input.oauthClientId,
           lastSeenAt: nextSeenAt,
           harnesses: input.harnesses ?? [],
         }),
       );
+    } else {
+      worker.lastSeenAt = nextSeenAt;
+
+      if (input.harnesses) {
+        worker.harnesses = input.harnesses;
+      }
+
+      savedWorker = await this.workersRepository.save(worker);
     }
 
-    worker.lastSeenAt = nextSeenAt;
+    // Emit event for realtime updates
+    this.eventEmitter.emit(
+      WorkerSeenEvent.INTERNAL,
+      new WorkerSeenEvent(
+        { id: savedWorker.oauthClientId },
+        savedWorker,
+      ),
+    );
 
-    if (input.harnesses) {
-      worker.harnesses = input.harnesses;
-    }
-
-    return this.workersRepository.save(worker);
+    return savedWorker;
   }
 }

--- a/apps/ui/src/config/api.ts
+++ b/apps/ui/src/config/api.ts
@@ -46,3 +46,10 @@ export const BFF_BASE_URL = getBFFBaseUrl();
  */
 OpenAPI.BASE = BFF_BASE_URL;
 OpenAPI.CREDENTIALS = 'include';
+
+/**
+ * API configuration object for use in fetch calls and WebSocket connections
+ */
+export const apiConfig = {
+  apiUrl: BFF_BASE_URL,
+};

--- a/apps/ui/src/features/home/HomeRoutes.tsx
+++ b/apps/ui/src/features/home/HomeRoutes.tsx
@@ -8,6 +8,7 @@ import { SettingsAppearancePage } from "./SettingsAppearancePage";
 import { SettingsProjectsPage } from "./SettingsProjectsPage";
 import { SettingsChatPage } from "./SettingsChatPage";
 import { SettingsDataPage } from './SettingsDataPage';
+import { SettingsWorkersPage } from './SettingsWorkersPage';
 
 export function HomeRoutes() {
   return (
@@ -20,6 +21,7 @@ export function HomeRoutes() {
           <Route path="/settings/appearance" element={<SettingsAppearancePage />} />
           <Route path="/settings/projects" element={<SettingsProjectsPage />} />
           <Route path="/settings/chat" element={<SettingsChatPage />} />
+          <Route path="/settings/workers" element={<SettingsWorkersPage />} />
           <Route path="/settings/data" element={<SettingsDataPage />} />
         </Route>
       </Routes>

--- a/apps/ui/src/features/home/SettingsPage.tsx
+++ b/apps/ui/src/features/home/SettingsPage.tsx
@@ -51,6 +51,13 @@ export function SettingsPage() {
         onSelect: () => navigate('/settings/chat'),
       },
       {
+        id: 'settings-workers',
+        label: 'Workers Settings',
+        description: 'Configure and manage background workers',
+        aliases: ['workers', 'background', 'execution'],
+        onSelect: () => navigate('/settings/workers'),
+      },
+      {
         id: 'settings-data',
         label: 'Import / Export',
         description: 'Import and export workspace data',
@@ -139,6 +146,25 @@ export function SettingsPage() {
               onClick={() => navigate('/settings/chat')}
             >
               Configure Chat
+            </Button>
+          </Row>
+        </Stack>
+      </Card>
+
+      <Card padding="5">
+        <Stack spacing="3">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">Workers</Text>
+            <Text tone="muted">Configure and manage background workers</Text>
+          </Stack>
+          <Row justify="space-between" align="center">
+            <Text size="2" tone="muted">Set up workers for task execution</Text>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => navigate('/settings/workers')}
+            >
+              Manage Workers
             </Button>
           </Row>
         </Stack>

--- a/apps/ui/src/features/home/SettingsWorkersPage.css
+++ b/apps/ui/src/features/home/SettingsWorkersPage.css
@@ -1,0 +1,85 @@
+.settings-workers__error-card {
+  background-color: var(--color-background-error, #fee);
+  border: 1px solid var(--color-border-error, #fcc);
+}
+
+.settings-workers__command-container {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.75rem;
+  background-color: var(--color-surface-secondary, #f5f5f5);
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-border, #e0e0e0);
+}
+
+.settings-workers__command {
+  flex: 1;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 0.875rem;
+  color: var(--color-text-primary, #1a1a1a);
+  word-break: break-all;
+}
+
+.settings-workers__copy-button {
+  padding: 0.375rem 0.75rem;
+  background-color: var(--color-primary, #007bff);
+  color: white;
+  border: none;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.2s;
+}
+
+.settings-workers__copy-button:hover {
+  background-color: var(--color-primary-hover, #0056b3);
+}
+
+.settings-workers__copy-button:active {
+  transform: scale(0.98);
+}
+
+.settings-workers__title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.settings-workers__status-indicator {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.settings-workers__status-indicator--connected {
+  background-color: #d1fae5;
+  color: #065f46;
+}
+
+.settings-workers__status-indicator--disconnected {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.settings-workers__harnesses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.settings-workers__harness-badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  background-color: var(--color-surface-tertiary, #e5e5e5);
+  border: 1px solid var(--color-border, #d0d0d0);
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  color: var(--color-text-secondary, #666);
+}

--- a/apps/ui/src/features/home/SettingsWorkersPage.tsx
+++ b/apps/ui/src/features/home/SettingsWorkersPage.tsx
@@ -1,0 +1,147 @@
+import { Stack, Text, Card, Row } from '../../ui/primitives';
+import { useHomeCtx } from './HomeProvider';
+import { useEffect } from 'react';
+import { useWorkers } from '../workers/useWorkers';
+import './SettingsWorkersPage.css';
+
+export function SettingsWorkersPage() {
+  const { setSectionTitle } = useHomeCtx();
+  const { workers, isLoading, error } = useWorkers();
+
+  useEffect(() => {
+    setSectionTitle('Workers Settings');
+  }, []);
+
+  // Get the server URL from the current window location
+  const serverUrl = `${window.location.protocol}//${window.location.host}`;
+  const workerCommand = `npx -y @taico/worker --serverurl ${serverUrl}`;
+
+  // Check if a worker is connected (last seen within 5 minutes)
+  const isWorkerConnected = (lastSeenAt: string) => {
+    const lastSeen = new Date(lastSeenAt);
+    const now = new Date();
+    const diffMs = now.getTime() - lastSeen.getTime();
+    const fiveMinutesMs = 5 * 60 * 1000;
+    return diffMs <= fiveMinutesMs;
+  };
+
+  if (isLoading) {
+    return (
+      <Stack spacing="6">
+        <Text>Loading...</Text>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing="6">
+      <Text tone="muted">
+        Workers execute tasks in the background. Configure workers to enable automated task execution.
+      </Text>
+
+      {error && (
+        <Card padding="5" className="settings-workers__error-card">
+          <Text tone="danger">Error: {error}</Text>
+        </Card>
+      )}
+
+      {/* Configuration Instructions */}
+      <Card padding="5">
+        <Stack spacing="4">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">
+              Configure a New Worker
+            </Text>
+            <Text tone="muted">
+              Run this command in your terminal to start a new worker:
+            </Text>
+          </Stack>
+
+          <div className="settings-workers__command-container">
+            <code className="settings-workers__command">{workerCommand}</code>
+            <button
+              className="settings-workers__copy-button"
+              onClick={() => {
+                navigator.clipboard.writeText(workerCommand);
+              }}
+              title="Copy to clipboard"
+            >
+              Copy
+            </button>
+          </div>
+
+          <Text size="1" tone="muted">
+            The worker will automatically register and appear in the list below when it connects.
+          </Text>
+        </Stack>
+      </Card>
+
+      {/* Workers List */}
+      <Stack spacing="3">
+        <Text size="4" weight="semibold">
+          Registered Workers ({workers.length})
+        </Text>
+
+        {workers.length === 0 ? (
+          <Card padding="5">
+            <Text tone="muted">
+              No workers registered yet. Run the command above to start your first worker.
+            </Text>
+          </Card>
+        ) : (
+          workers.map((worker) => {
+            const isConnected = isWorkerConnected(worker.lastSeenAt);
+            const lastSeenDate = new Date(worker.lastSeenAt);
+            const lastSeenStr = lastSeenDate.toLocaleString();
+
+            return (
+              <Card key={worker.id} padding="5">
+                <Stack spacing="3">
+                  <Row justify="space-between" align="center">
+                    <Stack spacing="1">
+                      <div className="settings-workers__title-row">
+                        <Text size="3" weight="semibold">
+                          Worker
+                        </Text>
+                        <span
+                          className={`settings-workers__status-indicator ${
+                            isConnected
+                              ? 'settings-workers__status-indicator--connected'
+                              : 'settings-workers__status-indicator--disconnected'
+                          }`}
+                        >
+                          {isConnected ? 'Connected' : 'Disconnected'}
+                        </span>
+                      </div>
+                      <Text size="1" tone="muted">
+                        ID: {worker.id}
+                      </Text>
+                      <Text size="1" tone="muted">
+                        Last seen: {lastSeenStr}
+                      </Text>
+                    </Stack>
+                  </Row>
+
+                  {worker.harnesses && worker.harnesses.length > 0 && (
+                    <Stack spacing="1">
+                      <Text size="2" weight="medium">
+                        Harnesses:
+                      </Text>
+                      <div className="settings-workers__harnesses">
+                        {worker.harnesses.map((harness) => (
+                          <span key={harness} className="settings-workers__harness-badge">
+                            {harness}
+                          </span>
+                        ))}
+                      </div>
+                    </Stack>
+                  )}
+                </Stack>
+              </Card>
+            );
+          })
+        )}
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/ui/src/features/home/SettingsWorkersPage.tsx
+++ b/apps/ui/src/features/home/SettingsWorkersPage.tsx
@@ -41,7 +41,7 @@ export function SettingsWorkersPage() {
 
       {error && (
         <Card padding="5" className="settings-workers__error-card">
-          <Text tone="danger">Error: {error}</Text>
+          <Text>Error: {error}</Text>
         </Card>
       )}
 

--- a/apps/ui/src/features/workers/useWorkers.ts
+++ b/apps/ui/src/features/workers/useWorkers.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+import type { WorkerSeenWireEvent } from '@taico/events';
+import { WorkerWireEvents } from '@taico/events';
+import { apiConfig } from '../../config/api';
+
+export interface Worker {
+  id: string;
+  oauthClientId: string;
+  lastSeenAt: string;
+  harnesses: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function useWorkers() {
+  const [workers, setWorkers] = useState<Worker[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let socket: Socket | null = null;
+    let isMounted = true;
+
+    // Fetch initial workers list
+    const fetchWorkers = async () => {
+      try {
+        const response = await fetch(`${apiConfig.apiUrl}/workers`, {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch workers: ${response.statusText}`);
+        }
+
+        const data = await response.json();
+
+        if (isMounted) {
+          setWorkers(data);
+          setError(null);
+        }
+      } catch (err) {
+        console.error('Error fetching workers:', err);
+        if (isMounted) {
+          setError(err instanceof Error ? err.message : 'Failed to load workers');
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    // Connect to WebSocket for realtime updates
+    const connectWebSocket = () => {
+      const wsUrl = apiConfig.apiUrl.replace(/^http/, 'ws');
+
+      socket = io(`${wsUrl}/workers`, {
+        withCredentials: true,
+        transports: ['websocket', 'polling'],
+      });
+
+      socket.on('connect', () => {
+        console.log('Connected to workers WebSocket');
+      });
+
+      socket.on('disconnect', () => {
+        console.log('Disconnected from workers WebSocket');
+      });
+
+      socket.on('connect_error', (err) => {
+        console.error('Workers WebSocket connection error:', err);
+      });
+
+      // Listen for worker.seen events
+      socket.on(WorkerWireEvents.WORKER_SEEN, (event: WorkerSeenWireEvent) => {
+        if (!isMounted) return;
+
+        setWorkers((prevWorkers) => {
+          const existingIndex = prevWorkers.findIndex(
+            (w) => w.id === event.worker.id
+          );
+
+          if (existingIndex >= 0) {
+            // Update existing worker
+            const updated = [...prevWorkers];
+            updated[existingIndex] = event.worker;
+            return updated;
+          } else {
+            // Add new worker
+            return [...prevWorkers, event.worker];
+          }
+        });
+      });
+    };
+
+    fetchWorkers();
+    connectWebSocket();
+
+    return () => {
+      isMounted = false;
+      if (socket) {
+        socket.disconnect();
+      }
+    };
+  }, []);
+
+  return { workers, isLoading, error };
+}

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types/task-events.js';
 export * from './types/thread-events.js';
 export * from './types/execution-events.js';
+export * from './types/worker-events.js';

--- a/packages/events/src/types/worker-events.ts
+++ b/packages/events/src/types/worker-events.ts
@@ -1,0 +1,48 @@
+/**
+ * Worker Wire Event Types for WebSocket Communication
+ *
+ * These types define the structure of events sent between backend and frontend
+ * via WebSocket for the Workers domain. They serve as a contract between the
+ * backend gateway and frontend consumers.
+ *
+ * Import these types in both backend (for emission) and frontend (for reception)
+ * to ensure type safety across the wire protocol.
+ */
+
+/**
+ * Wire event names for Workers domain
+ * These are the stable, external event identifiers sent over the wire protocol.
+ */
+export const WorkerWireEvents = {
+  WORKER_SEEN: 'worker.seen',
+} as const;
+
+export type WorkerWireEventName =
+  (typeof WorkerWireEvents)[keyof typeof WorkerWireEvents];
+
+/**
+ * Worker structure as sent over the wire
+ * Matches WorkerResponseDto from backend
+ */
+export interface WorkerWirePayload {
+  id: string;
+  oauthClientId: string;
+  lastSeenAt: string;
+  harnesses: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Worker seen event
+ * Emitted when a worker is seen (connects, sends heartbeat, or executes)
+ */
+export interface WorkerSeenWireEvent {
+  worker: WorkerWirePayload;
+  occurredAt: string;
+}
+
+/**
+ * Union type of all worker wire events
+ */
+export type WorkerWireEvent = WorkerSeenWireEvent;


### PR DESCRIPTION
## Summary
- Added Workers settings page at `/settings/workers` matching look & feel of Chat settings
- Shows user-friendly message to configure new worker with `npx -y @taico/worker --serverurl ${window.location}`
- Displays list of all configured workers pulling data from workers module
- Realtime updates when workers connect/disconnect via WebSocket

## Implementation Details

### Backend
- Created `workers.controller.ts` with `GET /workers` endpoint to list all workers
- Created `workers.gateway.ts` at `/workers` namespace for WebSocket realtime events
- Created `workers.events.ts` with `WorkerSeenEvent` following Symbol-based event pattern
- Updated `workers.service.ts` to emit `WorkerSeenEvent` when `recordWorkerSeen` is called
- Added `workers:read` and `workers:write` scopes to `executions/workers.scopes.ts`
- Updated `workers.module.ts` to import `AuthGuardsModule` for auth guards

### Frontend
- Created `SettingsWorkersPage.tsx` showing configuration command and workers list
- Created `useWorkers.ts` hook with WebSocket subscription for realtime updates
- Added `/settings/workers` route in `HomeRoutes.tsx`
- Added Workers card in `SettingsPage.tsx`
- Command shows `npx -y @taico/worker --serverurl ${protocol}//${host}` from `window.location`
- Workers shown with connected (green) / disconnected (red) status
- Connection status based on `lastSeenAt` <= 5 minutes

### Wire Events
- Added `@taico/events` `worker-events.ts` with `WorkerWireEvents` and type definitions
- Gateway emits `worker.seen` events to all connected clients
- Frontend subscribes to `worker.seen` events for automatic UI updates

## Test plan
- [x] Backend compiles successfully
- [ ] Navigate to `/settings/workers`
- [ ] Verify command shown matches current host (localhost or deployed URL)
- [ ] Run command to launch a worker
- [ ] Verify worker appears in list with "Connected" status
- [ ] Stop worker and verify status changes to "Disconnected" within 5 minutes
- [ ] Launch worker again and verify realtime update (no page refresh needed)
- [ ] Verify harnesses are displayed if worker reports them

🤖 Generated with [Claude Code](https://claude.com/claude-code)