### PR TITLE
Add workers settings UI with realtime updates

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -6179,6 +6179,31 @@
         ]
       }
     },
+    "/api/v1/workers": {
+      "get": {
+        "operationId": "WorkersController_listWorkers",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List of all registered workers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkerResponseDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List all workers",
+        "tags": [
+          "workers"
+        ]
+      }
+    },
     "/api/v1/task-blueprints": {
       "post": {
         "operationId": "TaskBlueprintsController_createTaskBlueprint",
@@ -11650,6 +11675,52 @@
         },
         "required": [
           "sessionId"
+        ]
+      },
+      "WorkerResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "oauthClientId": {
+            "type": "string"
+          },
+          "lastSeenAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "harnesses": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "claude",
+                "codex",
+                "opencode",
+                "adk",
+                "githubcopilot",
+                "other"
+              ]
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "oauthClientId",
+          "lastSeenAt",
+          "harnesses",
+          "createdAt",
+          "updatedAt"
         ]
       },
       "CreateTaskBlueprintDto": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taico/taico",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": false,
   "license": "MIT",
   "main": "./dist/main.js",
@@ -61,7 +61,7 @@
     "@opencode-ai/sdk": "^1.1.28",
     "@taico/adk-session-store": "^0.1.0",
     "@taico/errors": "^0.2.8",
-    "@taico/events": "^0.2.9",
+    "@taico/events": "^0.2.10",
     "@taico/shared": "^0.2.8",
     "@types/bcrypt": "^6.0.0",
     "@types/cookie-parser": "^1.4.10",

--- a/apps/backend/src/executions/workers.scopes.ts
+++ b/apps/backend/src/executions/workers.scopes.ts
@@ -1,6 +1,14 @@
 import { Scope } from 'src/auth/core/types/scope.type';
 
 export const WorkersScopes = {
+  READ: {
+    id: 'workers:read',
+    description: 'Read workers',
+  },
+  WRITE: {
+    id: 'workers:write',
+    description: 'Manage workers',
+  },
   CONNECT: {
     id: 'workers:connect',
     description:

--- a/apps/backend/src/workers/events/workers.events.ts
+++ b/apps/backend/src/workers/events/workers.events.ts
@@ -1,0 +1,30 @@
+import { WorkerEntity } from '../worker.entity';
+
+/**
+ * Domain events for the Workers domain.
+ * These events decouple the service layer from transport concerns (WebSocket, HTTP, etc.)
+ *
+ * Each event uses a Symbol as its internal identifier to ensure type-safe,
+ * non-string-based event emission within the domain layer.
+ */
+
+export type EventActor = {
+  id: string;
+};
+
+export abstract class WorkerDomainEvent<TPayload = unknown> {
+  readonly occurredAt: Date = new Date();
+
+  constructor(
+    public readonly actor: EventActor,
+    public readonly payload: TPayload,
+  ) {}
+}
+
+export class WorkerSeenEvent extends WorkerDomainEvent<WorkerEntity> {
+  static readonly INTERNAL = Symbol('workers.WorkerSeenEvent');
+
+  constructor(actor: EventActor, worker: WorkerEntity) {
+    super(actor, worker);
+  }
+}

--- a/apps/backend/src/workers/workers.controller.ts
+++ b/apps/backend/src/workers/workers.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { WorkersService } from './workers.service';
+import { WorkerResponseDto } from './dto/http/worker-response.dto';
+import { AccessTokenGuard } from 'src/auth/guards/guards/access-token.guard';
+import { ScopesGuard } from 'src/auth/guards/guards/scopes.guard';
+import { RequireScopes } from 'src/auth/guards/decorators/require-scopes.decorator';
+import { WorkersScopes } from 'src/executions/workers.scopes';
+
+@ApiTags('workers')
+@UseGuards(AccessTokenGuard, ScopesGuard)
+@Controller('workers')
+export class WorkersController {
+  constructor(private readonly workersService: WorkersService) {}
+
+  @Get()
+  @RequireScopes(WorkersScopes.READ.id)
+  @ApiOperation({ summary: 'List all workers' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of all registered workers',
+    type: [WorkerResponseDto],
+  })
+  async listWorkers(): Promise<WorkerResponseDto[]> {
+    const workers = await this.workersService.findAll();
+    return workers.map((worker) => WorkerResponseDto.fromEntity(worker));
+  }
+}

--- a/apps/backend/src/workers/workers.gateway.ts
+++ b/apps/backend/src/workers/workers.gateway.ts
@@ -1,0 +1,88 @@
+import {
+  ConnectedSocket,
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
+  SubscribeMessage,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { Logger, UseGuards } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { WorkerSeenEvent } from './events/workers.events';
+import { WorkerWireEvents } from '@taico/events';
+import type { WorkerSeenWireEvent } from '@taico/events';
+import { WorkerResponseDto } from './dto/http/worker-response.dto';
+import { WsAccessTokenGuard } from 'src/auth/guards/guards/ws-access-token-guard';
+import { WsScopesGuard } from 'src/auth/guards/guards/ws-scopes.guard';
+import { RequireScopes } from 'src/auth/guards/decorators/require-scopes.decorator';
+import { WorkersScopes } from 'src/executions/workers.scopes';
+
+const WORKERS_ROOM = 'workers';
+
+/**
+ * WebSocket gateway for Workers domain.
+ *
+ * Acts as a transport adapter that:
+ * 1. Listens to internal domain events (Symbol-based)
+ * 2. Maps domain entities to DTOs
+ * 3. Emits stable wire events to clients
+ *
+ * This decouples the service layer from transport concerns,
+ * similar to how HTTP controllers map entities to response DTOs.
+ */
+@UseGuards(WsAccessTokenGuard, WsScopesGuard)
+@RequireScopes(WorkersScopes.READ.id)
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+  },
+  namespace: '/workers',
+})
+export class WorkersGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
+  @WebSocketServer()
+  server!: Server;
+
+  private logger = new Logger(WorkersGateway.name);
+
+  afterInit() {
+    this.logger.log('Workers WebSocket Gateway initialized');
+  }
+
+  handleConnection(client: Socket) {
+    this.logger.log(`Client connected to workers namespace: ${client.id}`);
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.log(`Client disconnected from workers namespace: ${client.id}`);
+  }
+
+  @SubscribeMessage('workers.subscribe')
+  subscribe(@ConnectedSocket() client: Socket) {
+    client.join(WORKERS_ROOM);
+    return { ok: true, room: WORKERS_ROOM };
+  }
+
+  @SubscribeMessage('workers.unsubscribe')
+  unsubscribe(@ConnectedSocket() client: Socket) {
+    client.leave(WORKERS_ROOM);
+    return { ok: true };
+  }
+
+  @OnEvent(WorkerSeenEvent.INTERNAL)
+  handleWorkerSeen(event: WorkerSeenEvent) {
+    const dto = WorkerResponseDto.fromEntity(event.payload);
+    const wireEvent: WorkerSeenWireEvent = {
+      worker: dto,
+      occurredAt: event.occurredAt.toISOString(),
+    };
+
+    this.server.to(WORKERS_ROOM).emit(WorkerWireEvents.WORKER_SEEN, wireEvent);
+    this.logger.debug(
+      `Emitted ${WorkerWireEvents.WORKER_SEEN} for worker ${dto.id}`,
+    );
+  }
+}

--- a/apps/backend/src/workers/workers.module.ts
+++ b/apps/backend/src/workers/workers.module.ts
@@ -2,10 +2,17 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { WorkerEntity } from './worker.entity';
 import { WorkersService } from './workers.service';
+import { WorkersController } from './workers.controller';
+import { WorkersGateway } from './workers.gateway';
+import { AuthGuardsModule } from '../auth/guards/auth-guards.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([WorkerEntity])],
-  providers: [WorkersService],
+  imports: [
+    TypeOrmModule.forFeature([WorkerEntity]),
+    AuthGuardsModule,
+  ],
+  controllers: [WorkersController],
+  providers: [WorkersService, WorkersGateway],
   exports: [WorkersService],
 })
 export class WorkersModule {}

--- a/apps/backend/src/workers/workers.service.ts
+++ b/apps/backend/src/workers/workers.service.ts
@@ -1,15 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { WorkerEntity } from './worker.entity';
 import { RecordWorkerSeenInput } from './dto/service/workers.service.types';
+import { WorkerSeenEvent } from './events/workers.events';
 
 @Injectable()
 export class WorkersService {
   constructor(
     @InjectRepository(WorkerEntity)
     private readonly workersRepository: Repository<WorkerEntity>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
+
+  async findAll(): Promise<WorkerEntity[]> {
+    return this.workersRepository.find({
+      order: {
+        lastSeenAt: 'DESC',
+      },
+    });
+  }
 
   async recordWorkerSeen(input: RecordWorkerSeenInput): Promise<WorkerEntity> {
     const worker = await this.workersRepository.findOne({
@@ -18,22 +29,35 @@ export class WorkersService {
 
     const nextSeenAt = input.seenAt ?? new Date();
 
+    let savedWorker: WorkerEntity;
+
     if (!worker) {
-      return this.workersRepository.save(
+      savedWorker = await this.workersRepository.save(
         this.workersRepository.create({
           oauthClientId: input.oauthClientId,
           lastSeenAt: nextSeenAt,
           harnesses: input.harnesses ?? [],
         }),
       );
+    } else {
+      worker.lastSeenAt = nextSeenAt;
+
+      if (input.harnesses) {
+        worker.harnesses = input.harnesses;
+      }
+
+      savedWorker = await this.workersRepository.save(worker);
     }
 
-    worker.lastSeenAt = nextSeenAt;
+    // Emit event for realtime updates
+    this.eventEmitter.emit(
+      WorkerSeenEvent.INTERNAL,
+      new WorkerSeenEvent(
+        { id: savedWorker.oauthClientId },
+        savedWorker,
+      ),
+    );
 
-    if (input.harnesses) {
-      worker.harnesses = input.harnesses;
-    }
-
-    return this.workersRepository.save(worker);
+    return savedWorker;
   }
 }

--- a/apps/ui-v1/package.json
+++ b/apps/ui-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taico/ui-v1",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
     "lint": "echo \"No linter configured yet\" && exit 0"
   },
   "dependencies": {
-    "@taico/client": "*",
+    "@taico/client": "^0.2.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^9.1.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@taico/ui",
   "private": true,
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
-    "@taico/client": "^0.2.6",
-    "@taico/events": "^0.2.9",
+    "@taico/client": "^0.2.9",
+    "@taico/events": "^0.2.10",
     "@taico/shared": "^0.2.6",
     "marked-react": "^4.0.0",
     "react": "^19.2.0",

--- a/apps/ui/src/features/home/HomeRoutes.tsx
+++ b/apps/ui/src/features/home/HomeRoutes.tsx
@@ -8,6 +8,7 @@ import { SettingsAppearancePage } from "./SettingsAppearancePage";
 import { SettingsProjectsPage } from "./SettingsProjectsPage";
 import { SettingsChatPage } from "./SettingsChatPage";
 import { SettingsDataPage } from './SettingsDataPage';
+import { SettingsWorkersPage } from './SettingsWorkersPage';
 
 export function HomeRoutes() {
   return (
@@ -20,6 +21,7 @@ export function HomeRoutes() {
           <Route path="/settings/appearance" element={<SettingsAppearancePage />} />
           <Route path="/settings/projects" element={<SettingsProjectsPage />} />
           <Route path="/settings/chat" element={<SettingsChatPage />} />
+          <Route path="/settings/workers" element={<SettingsWorkersPage />} />
           <Route path="/settings/data" element={<SettingsDataPage />} />
         </Route>
       </Routes>

--- a/apps/ui/src/features/home/SettingsPage.tsx
+++ b/apps/ui/src/features/home/SettingsPage.tsx
@@ -51,6 +51,13 @@ export function SettingsPage() {
         onSelect: () => navigate('/settings/chat'),
       },
       {
+        id: 'settings-workers',
+        label: 'Workers Settings',
+        description: 'Configure and manage background workers',
+        aliases: ['workers', 'background', 'execution'],
+        onSelect: () => navigate('/settings/workers'),
+      },
+      {
         id: 'settings-data',
         label: 'Import / Export',
         description: 'Import and export workspace data',
@@ -139,6 +146,25 @@ export function SettingsPage() {
               onClick={() => navigate('/settings/chat')}
             >
               Configure Chat
+            </Button>
+          </Row>
+        </Stack>
+      </Card>
+
+      <Card padding="5">
+        <Stack spacing="3">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">Workers</Text>
+            <Text tone="muted">Configure and manage background workers</Text>
+          </Stack>
+          <Row justify="space-between" align="center">
+            <Text size="2" tone="muted">Set up workers for task execution</Text>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => navigate('/settings/workers')}
+            >
+              Manage Workers
             </Button>
           </Row>
         </Stack>

--- a/apps/ui/src/features/home/SettingsWorkersPage.css
+++ b/apps/ui/src/features/home/SettingsWorkersPage.css
@@ -1,0 +1,69 @@
+.settings-workers__command-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  padding: var(--space-3);
+  background: var(--surface);
+  border-radius: var(--r-2);
+  border: 1px solid var(--border);
+}
+
+.settings-workers__command {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2);
+  color: var(--text);
+  line-height: var(--lh-normal);
+  word-break: break-all;
+}
+
+.settings-workers__copy-button {
+  white-space: nowrap;
+}
+
+.settings-workers__title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.settings-workers__status-indicator {
+  display: inline-block;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--r-2);
+  font-size: var(--fs-1);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--border);
+}
+
+.settings-workers__status-indicator--connected {
+  background: var(--surface);
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.settings-workers__status-indicator--disconnected {
+  background: var(--surface);
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.settings-workers__harnesses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.settings-workers__harness-badge {
+  display: inline-block;
+  padding: var(--space-1) var(--space-2);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  font-size: var(--fs-1);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}

--- a/apps/ui/src/features/home/SettingsWorkersPage.tsx
+++ b/apps/ui/src/features/home/SettingsWorkersPage.tsx
@@ -21,7 +21,7 @@ export function SettingsWorkersPage() {
     const lastSeen = new Date(lastSeenAt);
     const now = new Date();
     const diffMs = now.getTime() - lastSeen.getTime();
-    const fiveMinutesMs = 5 * 60 * 1000;
+    const fiveMinutesMs = 2 * 60 * 1000;
     return diffMs <= fiveMinutesMs;
   };
 

--- a/apps/ui/src/features/home/SettingsWorkersPage.tsx
+++ b/apps/ui/src/features/home/SettingsWorkersPage.tsx
@@ -1,0 +1,151 @@
+import { Stack, Text, Card, Row, Button } from '../../ui/primitives';
+import { useHomeCtx } from './HomeProvider';
+import { useEffect, useState } from 'react';
+import { useWorkers } from '../workers/useWorkers';
+import { ErrorText } from '../../ui/primitives/ErrorText';
+import './SettingsWorkersPage.css';
+
+export function SettingsWorkersPage() {
+  const { setSectionTitle } = useHomeCtx();
+  const { workers, isLoading, error } = useWorkers();
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSectionTitle('Workers Settings');
+  }, []);
+
+  const serverUrl = `${window.location.protocol}//${window.location.host}`;
+  const workerCommand = `npx -y @taico/worker --serverurl ${serverUrl}`;
+
+  const isWorkerConnected = (lastSeenAt: string) => {
+    const lastSeen = new Date(lastSeenAt);
+    const now = new Date();
+    const diffMs = now.getTime() - lastSeen.getTime();
+    const fiveMinutesMs = 5 * 60 * 1000;
+    return diffMs <= fiveMinutesMs;
+  };
+
+  const copyCommand = async () => {
+    try {
+      await navigator.clipboard.writeText(workerCommand);
+      setCopyFeedback('Copied');
+      window.setTimeout(() => setCopyFeedback(null), 1800);
+    } catch {
+      setCopyFeedback('Copy failed');
+      window.setTimeout(() => setCopyFeedback(null), 1800);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Stack spacing="6">
+        <Text>Loading...</Text>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing="6">
+      <Text tone="muted">
+        Workers execute tasks in the background. Configure workers to enable automated task execution.
+      </Text>
+
+      {error ? <ErrorText size="2" weight="medium">{error}</ErrorText> : null}
+
+      <Card padding="5">
+        <Stack spacing="4">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">
+              Configure a New Worker
+            </Text>
+            <Text tone="muted">
+              Run this command in your terminal to start a new worker:
+            </Text>
+          </Stack>
+
+          <div className="settings-workers__command-container">
+            <code className="settings-workers__command">{workerCommand}</code>
+            <Button
+              className="settings-workers__copy-button"
+              variant="secondary"
+              size="sm"
+              onClick={copyCommand}
+            >
+              {copyFeedback ?? 'Copy'}
+            </Button>
+          </div>
+
+          <Text size="1" tone="muted">
+            The worker will automatically register and appear in the list below when it connects.
+          </Text>
+        </Stack>
+      </Card>
+
+      <Stack spacing="3">
+        <Text size="4" weight="semibold">
+          Registered Workers ({workers.length})
+        </Text>
+
+        {workers.length === 0 ? (
+          <Card padding="5">
+            <Text tone="muted">
+              No workers registered yet. Run the command above to start your first worker.
+            </Text>
+          </Card>
+        ) : (
+          workers.map((worker) => {
+            const isConnected = isWorkerConnected(worker.lastSeenAt);
+            const lastSeenDate = new Date(worker.lastSeenAt);
+            const lastSeenStr = lastSeenDate.toLocaleString();
+
+            return (
+              <Card key={worker.id} padding="5">
+                <Stack spacing="3">
+                  <Row justify="space-between" align="center">
+                    <Stack spacing="1">
+                      <div className="settings-workers__title-row">
+                        <Text size="3" weight="semibold">
+                          Worker
+                        </Text>
+                        <span
+                          className={`settings-workers__status-indicator ${
+                            isConnected
+                              ? 'settings-workers__status-indicator--connected'
+                              : 'settings-workers__status-indicator--disconnected'
+                          }`}
+                        >
+                          {isConnected ? 'Connected' : 'Disconnected'}
+                        </span>
+                      </div>
+                      <Text size="1" tone="muted">
+                        ID: {worker.id}
+                      </Text>
+                      <Text size="1" tone="muted">
+                        Last seen: {lastSeenStr}
+                      </Text>
+                    </Stack>
+                  </Row>
+
+                  {worker.harnesses && worker.harnesses.length > 0 && (
+                    <Stack spacing="1">
+                      <Text size="2" weight="medium">
+                        Harnesses:
+                      </Text>
+                      <div className="settings-workers__harnesses">
+                        {worker.harnesses.map((harness) => (
+                          <span key={harness} className="settings-workers__harness-badge">
+                            {harness}
+                          </span>
+                        ))}
+                      </div>
+                    </Stack>
+                  )}
+                </Stack>
+              </Card>
+            );
+          })
+        )}
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/ui/src/features/workers/api.ts
+++ b/apps/ui/src/features/workers/api.ts
@@ -1,0 +1,14 @@
+import { ApiClient } from '@taico/client/v2';
+import { BFF_BASE_URL } from '../../config/api';
+
+const baseUrl = BFF_BASE_URL || window.location.origin;
+const client = new ApiClient({
+  baseUrl,
+  credentials: 'include',
+});
+
+export const WorkersService = client.workers;
+
+export const api = {
+  workers: client.workers,
+};

--- a/apps/ui/src/features/workers/useWorkers.ts
+++ b/apps/ui/src/features/workers/useWorkers.ts
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+import type { WorkerSeenWireEvent } from '@taico/events';
+import { WorkerWireEvents } from '@taico/events';
+import { getUIWebSocketUrl } from '../../config/api';
+import { WorkersService } from './api';
+
+const SOCKET_URL = getUIWebSocketUrl('/workers');
+
+type WorkersSubscribeAck = {
+  ok: boolean;
+  room?: string;
+  error?: string;
+};
+
+export interface Worker {
+  id: string;
+  oauthClientId: string;
+  lastSeenAt: string;
+  harnesses: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function useWorkers() {
+  const [workers, setWorkers] = useState<Worker[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+
+  const sortWorkers = (items: Worker[]): Worker[] => {
+    return [...items].sort((a, b) => {
+      const aDate = new Date(a.lastSeenAt).getTime();
+      const bDate = new Date(b.lastSeenAt).getTime();
+      return bDate - aDate;
+    });
+  };
+
+  const loadWorkers = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await WorkersService.WorkersController_listWorkers();
+      setWorkers(sortWorkers(response));
+    } catch (err) {
+      console.error('Error fetching workers:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load workers');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const socket: Socket = io(SOCKET_URL, {
+      withCredentials: true,
+      transports: ['websocket', 'polling'],
+    });
+
+    loadWorkers();
+
+    socket.on('connect', () => {
+      socket.emit('workers.subscribe', {}, (ack: WorkersSubscribeAck) => {
+        if (ack.ok) {
+          setIsConnected(true);
+          return;
+        }
+        setIsConnected(false);
+      });
+      loadWorkers();
+    });
+
+    socket.on('disconnect', () => {
+      setIsConnected(false);
+    });
+
+    socket.on('connect_error', (err) => {
+      console.error('Workers WebSocket connection error:', err);
+    });
+
+    socket.on(WorkerWireEvents.WORKER_SEEN, (event: WorkerSeenWireEvent) => {
+      setWorkers((prevWorkers) => {
+        const existingIndex = prevWorkers.findIndex(
+          (worker) => worker.id === event.worker.id,
+        );
+
+        if (existingIndex >= 0) {
+          const updated = [...prevWorkers];
+          updated[existingIndex] = event.worker;
+          return sortWorkers(updated);
+        }
+
+        return sortWorkers([...prevWorkers, event.worker]);
+      });
+    });
+
+    return () => {
+      socket.emit('workers.unsubscribe', {});
+      socket.disconnect();
+    };
+  }, []);
+
+  return { workers, isLoading, error, isConnected };
+}

--- a/apps/worker-v1/package.json
+++ b/apps/worker-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taico/worker-v1",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "private": false,
   "license": "MIT",
@@ -43,8 +43,8 @@
     "@github/copilot-sdk": "^0.2.0",
     "@google/adk": "^0.2.4",
     "@opencode-ai/sdk": "^1.1.28",
-    "@taico/client": "^0.1.0",
-    "@taico/events": "^0.2.9",
+    "@taico/client": "^0.2.9",
+    "@taico/events": "^0.2.10",
     "dotenv": "^16.4.7",
     "socket.io-client": "^4.8.3"
   },

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taico/worker",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "private": false,
   "license": "MIT",
@@ -35,8 +35,8 @@
     "@github/copilot-sdk": "^0.2.0",
     "@google/adk": "^0.2.4",
     "@opencode-ai/sdk": "^1.1.28",
-    "@taico/client": "^0.2.8",
-    "@taico/events": "^0.2.9",
+    "@taico/client": "^0.2.9",
+    "@taico/events": "^0.2.10",
     "@taico/shared": "^0.2.8",
     "socket.io-client": "^4.8.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
     },
     "apps/backend": {
       "name": "@taico/taico",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",
@@ -59,7 +59,7 @@
         "@opencode-ai/sdk": "^1.1.28",
         "@taico/adk-session-store": "^0.1.0",
         "@taico/errors": "^0.2.8",
-        "@taico/events": "^0.2.9",
+        "@taico/events": "^0.2.10",
         "@taico/shared": "^0.2.8",
         "@types/bcrypt": "^6.0.0",
         "@types/cookie-parser": "^1.4.10",
@@ -388,11 +388,11 @@
     },
     "apps/ui": {
       "name": "@taico/ui",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
-        "@taico/client": "^0.2.6",
-        "@taico/events": "^0.2.9",
+        "@taico/client": "^0.2.9",
+        "@taico/events": "^0.2.10",
         "@taico/shared": "^0.2.6",
         "marked-react": "^4.0.0",
         "react": "^19.2.0",
@@ -418,9 +418,9 @@
     },
     "apps/ui-v1": {
       "name": "@taico/ui-v1",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@taico/client": "*",
+        "@taico/client": "^0.2.9",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^9.1.0",
@@ -504,15 +504,15 @@
     },
     "apps/worker": {
       "name": "@taico/worker",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",
         "@github/copilot-sdk": "^0.2.0",
         "@google/adk": "^0.2.4",
         "@opencode-ai/sdk": "^1.1.28",
-        "@taico/client": "^0.2.8",
-        "@taico/events": "^0.2.9",
+        "@taico/client": "^0.2.9",
+        "@taico/events": "^0.2.10",
         "@taico/shared": "^0.2.8",
         "socket.io-client": "^4.8.1"
       },
@@ -528,15 +528,15 @@
     },
     "apps/worker-v1": {
       "name": "@taico/worker-v1",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",
         "@github/copilot-sdk": "^0.2.0",
         "@google/adk": "^0.2.4",
         "@opencode-ai/sdk": "^1.1.28",
-        "@taico/client": "^0.1.0",
-        "@taico/events": "^0.2.9",
+        "@taico/client": "^0.2.9",
+        "@taico/events": "^0.2.10",
         "dotenv": "^16.4.7",
         "socket.io-client": "^4.8.3"
       },
@@ -552,12 +552,6 @@
       "engines": {
         "node": ">=24.0.0"
       }
-    },
-    "apps/worker-v1/node_modules/@taico/client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@taico/client/-/client-0.1.0.tgz",
-      "integrity": "sha512-BmXycKeQN7quhESDvuPe0eBg1u+FbTycAcHKJ5lbQMAf4K686oUlZl8OyEiO8Ht2joJDEh3A5s+nHRKinltJ1g==",
-      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -19681,7 +19675,7 @@
     },
     "packages/client": {
       "name": "@taico/client",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "devDependencies": {
         "@redocly/openapi-core": "^1.34.10",
@@ -19700,7 +19694,7 @@
     },
     "packages/events": {
       "name": "@taico/events",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.6.3"

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -6179,6 +6179,31 @@
         ]
       }
     },
+    "/api/v1/workers": {
+      "get": {
+        "operationId": "WorkersController_listWorkers",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List of all registered workers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkerResponseDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List all workers",
+        "tags": [
+          "workers"
+        ]
+      }
+    },
     "/api/v1/task-blueprints": {
       "post": {
         "operationId": "TaskBlueprintsController_createTaskBlueprint",
@@ -11650,6 +11675,52 @@
         },
         "required": [
           "sessionId"
+        ]
+      },
+      "WorkerResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "oauthClientId": {
+            "type": "string"
+          },
+          "lastSeenAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "harnesses": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "claude",
+                "codex",
+                "opencode",
+                "adk",
+                "githubcopilot",
+                "other"
+              ]
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "oauthClientId",
+          "lastSeenAt",
+          "harnesses",
+          "createdAt",
+          "updatedAt"
         ]
       },
       "CreateTaskBlueprintDto": {

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -1803,6 +1803,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/workers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all workers */
+        get: operations["WorkersController_listWorkers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/task-blueprints": {
         parameters: {
             query?: never;
@@ -5193,6 +5210,18 @@ export interface components {
              * @example session_01JZ0SMM85FBFA8Y82M8VREY2A
              */
             sessionId: string;
+        };
+        WorkerResponseDto: {
+            /** Format: uuid */
+            id: string;
+            oauthClientId: string;
+            /** Format: date-time */
+            lastSeenAt: string;
+            harnesses: ("claude" | "codex" | "opencode" | "adk" | "githubcopilot" | "other")[];
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
         };
         CreateTaskBlueprintDto: {
             /**
@@ -9845,6 +9874,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TaskExecutionHistoryResponseDto"][];
+                };
+            };
+        };
+    };
+    WorkersController_listWorkers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of all registered workers */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerResponseDto"][];
                 };
             };
         };

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taico/client",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/packages/client/src/v1/client/index.ts
+++ b/packages/client/src/v1/client/index.ts
@@ -139,6 +139,7 @@ export type { UpdateThreadDto } from './models/UpdateThreadDto.js';
 export type { UpdateThreadStateDto } from './models/UpdateThreadStateDto.js';
 export type { UpsertAgentToolPermissionDto } from './models/UpsertAgentToolPermissionDto.js';
 export { UserResponseDto } from './models/UserResponseDto.js';
+export type { WorkerResponseDto } from './models/WorkerResponseDto.js';
 
 export { ActorsService } from './services/ActorsService.js';
 export { AgentService } from './services/AgentService.js';
@@ -163,3 +164,4 @@ export { TaskBlueprintsService } from './services/TaskBlueprintsService.js';
 export { ThreadsService } from './services/ThreadsService.js';
 export { ToolsService } from './services/ToolsService.js';
 export { WebAuthenticationService } from './services/WebAuthenticationService.js';
+export { WorkersService } from './services/WorkersService.js';

--- a/packages/client/src/v1/client/models/WorkerResponseDto.ts
+++ b/packages/client/src/v1/client/models/WorkerResponseDto.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type WorkerResponseDto = {
+    id: string;
+    oauthClientId: string;
+    lastSeenAt: string;
+    harnesses: Array<'claude' | 'codex' | 'opencode' | 'adk' | 'githubcopilot' | 'other'>;
+    createdAt: string;
+    updatedAt: string;
+};
+

--- a/packages/client/src/v1/client/services/WorkersService.ts
+++ b/packages/client/src/v1/client/services/WorkersService.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { WorkerResponseDto } from '../models/WorkerResponseDto.js';
+import type { CancelablePromise } from '../core/CancelablePromise.js';
+import { OpenAPI } from '../core/OpenAPI.js';
+import type { OpenAPIConfig } from '../core/OpenAPI.js';
+import { request as __request } from '../core/request.js';
+export class WorkersService {
+    /**
+     * List all workers
+     * @returns WorkerResponseDto List of all registered workers
+     * @throws ApiError
+     */
+    public static workersControllerListWorkers(config: OpenAPIConfig = OpenAPI): CancelablePromise<Array<WorkerResponseDto>> {
+        return __request(config, {
+            method: 'GET',
+            url: '/api/v1/workers',
+        });
+    }
+}

--- a/packages/client/src/v2/client.ts
+++ b/packages/client/src/v2/client.ts
@@ -18,6 +18,7 @@ import { ChatProvidersResource } from './chat-providers-resource.js';
 import { SecretsResource } from './secrets-resource.js';
 import { ContextResource } from './context-resource.js';
 import { ExecutionsResource } from './executions-resource.js';
+import { WorkersResource } from './workers-resource.js';
 import { TaskBlueprintsResource } from './task-blueprints-resource.js';
 import { ScheduledTasksResource } from './scheduled-tasks-resource.js';
 import { DiscoveryResource } from './discovery-resource.js';
@@ -43,6 +44,7 @@ export class ApiClient {
   public readonly secrets: SecretsResource;
   public readonly context: ContextResource;
   public readonly executions: ExecutionsResource;
+  public readonly workers: WorkersResource;
   public readonly taskBlueprints: TaskBlueprintsResource;
   public readonly scheduledTasks: ScheduledTasksResource;
   public readonly discovery: DiscoveryResource;
@@ -68,6 +70,7 @@ export class ApiClient {
     this.secrets = new SecretsResource(config);
     this.context = new ContextResource(config);
     this.executions = new ExecutionsResource(config);
+    this.workers = new WorkersResource(config);
     this.taskBlueprints = new TaskBlueprintsResource(config);
     this.scheduledTasks = new ScheduledTasksResource(config);
     this.discovery = new DiscoveryResource(config);

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -951,6 +951,15 @@ export interface UpdateRunnerSessionIdDto {
   sessionId: string;
 }
 
+export interface WorkerResponseDto {
+  id: string;
+  oauthClientId: string;
+  lastSeenAt: string;
+  harnesses: ('claude' | 'codex' | 'opencode' | 'adk' | 'githubcopilot' | 'other')[];
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface CreateTaskBlueprintDto {
   name: string;
   description: string;

--- a/packages/client/src/v2/workers-resource.ts
+++ b/packages/client/src/v2/workers-resource.ts
@@ -1,0 +1,14 @@
+import { BaseClient, ClientConfig } from './base-client.js';
+import type { WorkerResponseDto } from './types.js';
+
+export class WorkersResource extends BaseClient {
+  constructor(config: ClientConfig) {
+    super(config);
+  }
+
+  /** List all workers */
+  async WorkersController_listWorkers(params?: { signal?: AbortSignal }): Promise<WorkerResponseDto[]> {
+    return this.request('GET', '/api/v1/workers', { signal: params?.signal });
+  }
+
+}

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taico/events",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types/task-events.js';
 export * from './types/thread-events.js';
 export * from './types/execution-events.js';
+export * from './types/worker-events.js';

--- a/packages/events/src/types/worker-events.ts
+++ b/packages/events/src/types/worker-events.ts
@@ -1,0 +1,48 @@
+/**
+ * Worker Wire Event Types for WebSocket Communication
+ *
+ * These types define the structure of events sent between backend and frontend
+ * via WebSocket for the Workers domain. They serve as a contract between the
+ * backend gateway and frontend consumers.
+ *
+ * Import these types in both backend (for emission) and frontend (for reception)
+ * to ensure type safety across the wire protocol.
+ */
+
+/**
+ * Wire event names for Workers domain
+ * These are the stable, external event identifiers sent over the wire protocol.
+ */
+export const WorkerWireEvents = {
+  WORKER_SEEN: 'worker.seen',
+} as const;
+
+export type WorkerWireEventName =
+  (typeof WorkerWireEvents)[keyof typeof WorkerWireEvents];
+
+/**
+ * Worker structure as sent over the wire
+ * Matches WorkerResponseDto from backend
+ */
+export interface WorkerWirePayload {
+  id: string;
+  oauthClientId: string;
+  lastSeenAt: string;
+  harnesses: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Worker seen event
+ * Emitted when a worker is seen (connects, sends heartbeat, or executes)
+ */
+export interface WorkerSeenWireEvent {
+  worker: WorkerWirePayload;
+  occurredAt: string;
+}
+
+/**
+ * Union type of all worker wire events
+ */
+export type WorkerWireEvent = WorkerSeenWireEvent;


### PR DESCRIPTION
## Summary
- add workers REST + websocket transport on backend (`/api/v1/workers` and `/workers`) wired through `WorkerSeenEvent` emitted from `WorkersService.recordWorkerSeen`
- add Workers Settings UI page with launch command (`npx -y @taico/worker --serverurl ${window.location.protocol}//${window.location.host}`), connected/disconnected status from 5-minute `lastSeenAt` window, and live updates via `worker.seen`
- integrate workers into settings navigation/routes/command palette and switch workers UI data layer to generated API client + `getUIWebSocketUrl('/workers')`
- regenerate OpenAPI/contracts and client SDKs to include workers endpoints/resources

## Validation
- `npm run build:dev`
- `npm run dev`
- `npm run dev:1`

## Technical Debt
- `npm run dev`/`npm run dev:1` in this environment repeatedly fell back to alternate `ui-v1` ports due occupied local ports; stack still booted correctly, but local port conflicts remain an environment-level annoyance.