### PR TITLE
Add onboarding status module and onboarding display mode

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -6831,6 +6831,33 @@
           "Search"
         ]
       }
+    },
+    "/api/v1/onboarding/status": {
+      "get": {
+        "operationId": "OnboardingController_getStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Current onboarding progress and display mode",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOnboardingStatusResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Get onboarding status for the current user",
+        "tags": [
+          "Onboarding"
+        ]
+      }
     }
   },
   "info": {
@@ -7725,10 +7752,15 @@
             "description": "Actor ID associated with this user",
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
-          "hasSeenWalkthrough": {
-            "type": "boolean",
-            "description": "Whether the user has seen the walkthrough",
-            "example": false
+          "onboardingDisplayMode": {
+            "type": "string",
+            "description": "How onboarding UI should be shown for this user (full page, banner, or off)",
+            "enum": [
+              "FULL_PAGE",
+              "BANNER",
+              "OFF"
+            ],
+            "example": "FULL_PAGE"
           }
         },
         "required": [
@@ -7737,7 +7769,7 @@
           "displayName",
           "role",
           "actorId",
-          "hasSeenWalkthrough"
+          "onboardingDisplayMode"
         ]
       },
       "LoginResponseDto": {
@@ -12196,6 +12228,58 @@
           "title",
           "score",
           "url"
+        ]
+      },
+      "UserOnboardingStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "workerConfigured": {
+            "type": "boolean",
+            "example": true
+          },
+          "agentCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "taskCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "projectCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "contextBlockCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "threadConfigured": {
+            "type": "boolean",
+            "example": true
+          },
+          "taskWithProjectCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "onboardingDisplayMode": {
+            "type": "string",
+            "enum": [
+              "FULL_PAGE",
+              "BANNER",
+              "OFF"
+            ],
+            "example": "FULL_PAGE"
+          }
+        },
+        "required": [
+          "workerConfigured",
+          "agentCreated",
+          "taskCreated",
+          "projectCreated",
+          "contextBlockCreated",
+          "threadConfigured",
+          "taskWithProjectCreated",
+          "onboardingDisplayMode"
         ]
       }
     }

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -41,11 +41,13 @@ import { AddAgentToolPermissions1742000000000 } from './migrations/1742000000000
 import { AddExecutionEnrichmentFieldsV21742100000000 } from './migrations/1742100000000-AddExecutionEnrichmentFieldsV2';
 import { RenameExecutionTables1742200000000 } from './migrations/1742200000000-RenameExecutionTables';
 import { AddWorkersTable1742300000000 } from './migrations/1742300000000-AddWorkersTable';
+import { RenameHasSeenWalkthroughToOnboardingDisplayMode1742400000000 } from './migrations/1742400000000-RenameHasSeenWalkthroughToOnboardingDisplayMode';
 import { SecretsModule } from './secrets/secrets.module';
 import { ChatProvidersModule } from './chat-providers/chat-providers.module';
 import { ExecutionsModule } from './executions/executions.module';
 import { GlobalSearchModule } from './global-search/global-search.module';
 import { WorkersModule } from './workers/workers.module';
+import { OnboardingModule } from './onboarding/onboarding.module';
 
 @Module({
   imports: [
@@ -79,6 +81,7 @@ import { WorkersModule } from './workers/workers.module';
         AddExecutionEnrichmentFieldsV21742100000000,
         RenameExecutionTables1742200000000,
         AddWorkersTable1742300000000,
+        RenameHasSeenWalkthroughToOnboardingDisplayMode1742400000000,
       ],
     }),
     EventEmitterModule.forRoot(),
@@ -101,6 +104,7 @@ import { WorkersModule } from './workers/workers.module';
     ExecutionsModule,
     WorkersModule,
     GlobalSearchModule,
+    OnboardingModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/authorization-server/dto/user-response.dto.ts
+++ b/apps/backend/src/authorization-server/dto/user-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { OnboardingDisplayMode } from 'src/identity-provider/enums';
 
 export class UserResponseDto {
   @ApiProperty({
@@ -33,8 +34,10 @@ export class UserResponseDto {
   actorId!: string;
 
   @ApiProperty({
-    description: 'Whether the user has seen the walkthrough',
-    example: false,
+    description:
+      'How onboarding UI should be shown for this user (full page, banner, or off)',
+    enum: OnboardingDisplayMode,
+    example: OnboardingDisplayMode.FULL_PAGE,
   })
-  hasSeenWalkthrough!: boolean;
+  onboardingDisplayMode!: OnboardingDisplayMode;
 }

--- a/apps/backend/src/authorization-server/web-auth.controller.ts
+++ b/apps/backend/src/authorization-server/web-auth.controller.ts
@@ -93,7 +93,7 @@ export class WebAuthController {
         displayName: actor.displayName,
         role: user.role,
         actorId: user.actorId,
-        hasSeenWalkthrough: user.hasSeenWalkthrough,
+        onboardingDisplayMode: user.onboardingDisplayMode,
       },
       expiresIn: expiresInSeconds,
     };
@@ -160,7 +160,7 @@ export class WebAuthController {
         displayName: actor.displayName,
         role: user.role,
         actorId: user.actorId,
-        hasSeenWalkthrough: user.hasSeenWalkthrough,
+        onboardingDisplayMode: user.onboardingDisplayMode,
       },
       expiresIn,
     };
@@ -249,7 +249,7 @@ export class WebAuthController {
       displayName: actor.displayName,
       role: actor.user.role,
       actorId: actor.user.actorId,
-      hasSeenWalkthrough: actor.user.hasSeenWalkthrough,
+      onboardingDisplayMode: actor.user.onboardingDisplayMode,
     };
   }
 
@@ -390,7 +390,7 @@ export class WebAuthController {
         displayName: actor.displayName,
         role: UserRole.ADMIN,
         actorId: user.actorId,
-        hasSeenWalkthrough: user.hasSeenWalkthrough,
+        onboardingDisplayMode: user.onboardingDisplayMode,
       },
       expiresIn: expiresInSeconds,
     };

--- a/apps/backend/src/identity-provider/enums/index.ts
+++ b/apps/backend/src/identity-provider/enums/index.ts
@@ -1,2 +1,3 @@
 export { UserRole } from './user-role.enum';
 export { ActorType } from './actor-type.enum';
+export { OnboardingDisplayMode } from './onboarding-display-mode.enum';

--- a/apps/backend/src/identity-provider/enums/onboarding-display-mode.enum.ts
+++ b/apps/backend/src/identity-provider/enums/onboarding-display-mode.enum.ts
@@ -1,0 +1,5 @@
+export enum OnboardingDisplayMode {
+  FULL_PAGE = 'FULL_PAGE',
+  BANNER = 'BANNER',
+  OFF = 'OFF',
+}

--- a/apps/backend/src/identity-provider/identity-provider.service.ts
+++ b/apps/backend/src/identity-provider/identity-provider.service.ts
@@ -13,7 +13,7 @@ import {
 } from './dto/service/identity-provider.service.types';
 import { ActorService } from './actor.service';
 import { ActorEntity } from './actor.entity';
-import { ActorType, UserRole } from './enums';
+import { ActorType, OnboardingDisplayMode, UserRole } from './enums';
 import {
   InvalidCredentialsError,
   InvalidCurrentPasswordError,
@@ -71,6 +71,12 @@ export class IdentityProviderService {
   async getUserByEmail(email: string): Promise<User | null> {
     return this.userRepository.findOne({
       where: { email, isActive: true },
+    });
+  }
+
+  async getUserByActorId(actorId: string): Promise<User | null> {
+    return this.userRepository.findOne({
+      where: { actorId, isActive: true },
     });
   }
 
@@ -242,7 +248,7 @@ export class IdentityProviderService {
       throw new UserNotFoundError(userId);
     }
 
-    user.hasSeenWalkthrough = true;
+    user.onboardingDisplayMode = OnboardingDisplayMode.OFF;
     await this.userRepository.save(user);
 
     this.logger.log(`Walkthrough marked as seen for user: ${user.email}`);

--- a/apps/backend/src/identity-provider/user.entity.ts
+++ b/apps/backend/src/identity-provider/user.entity.ts
@@ -1,4 +1,8 @@
 import {
+  OnboardingDisplayMode,
+} from './enums';
+
+import {
   Entity,
   PrimaryGeneratedColumn,
   Column,
@@ -35,8 +39,12 @@ export class User {
   @Column({ type: 'varchar', default: 'standard' })
   role!: 'admin' | 'standard';
 
-  @Column({ default: false, name: 'has_seen_walkthrough' })
-  hasSeenWalkthrough!: boolean;
+  @Column({
+    type: 'varchar',
+    default: OnboardingDisplayMode.FULL_PAGE,
+    name: 'onboarding_display_mode',
+  })
+  onboardingDisplayMode!: OnboardingDisplayMode;
 
   @VersionColumn()
   rowVersion!: number;

--- a/apps/backend/src/migrations/1742400000000-RenameHasSeenWalkthroughToOnboardingDisplayMode.ts
+++ b/apps/backend/src/migrations/1742400000000-RenameHasSeenWalkthroughToOnboardingDisplayMode.ts
@@ -1,0 +1,83 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameHasSeenWalkthroughToOnboardingDisplayMode1742400000000
+  implements MigrationInterface
+{
+  name = 'RenameHasSeenWalkthroughToOnboardingDisplayMode1742400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE users_new (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL UNIQUE,
+        passwordHash TEXT NOT NULL,
+        actor_id TEXT NOT NULL UNIQUE,
+        isActive BOOLEAN NOT NULL DEFAULT 1,
+        role TEXT NOT NULL DEFAULT 'standard',
+        onboarding_display_mode TEXT NOT NULL DEFAULT 'FULL_PAGE',
+        rowVersion INTEGER NOT NULL DEFAULT 1,
+        createdAt DATETIME NOT NULL DEFAULT (datetime('now')),
+        updatedAt DATETIME NOT NULL DEFAULT (datetime('now')),
+        deletedAt DATETIME,
+        FOREIGN KEY (actor_id) REFERENCES actors(id)
+      )
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO users_new (
+        id, email, passwordHash, actor_id, isActive, role,
+        onboarding_display_mode,
+        rowVersion, createdAt, updatedAt, deletedAt
+      )
+      SELECT
+        id, email, passwordHash, actor_id, isActive, role,
+        CASE
+          WHEN has_seen_walkthrough = 1 THEN 'OFF'
+          ELSE 'FULL_PAGE'
+        END,
+        rowVersion, createdAt, updatedAt, deletedAt
+      FROM users
+    `);
+
+    await queryRunner.query(`DROP TABLE users`);
+    await queryRunner.query(`ALTER TABLE users_new RENAME TO users`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE users_new (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL UNIQUE,
+        passwordHash TEXT NOT NULL,
+        actor_id TEXT NOT NULL UNIQUE,
+        isActive BOOLEAN NOT NULL DEFAULT 1,
+        role TEXT NOT NULL DEFAULT 'standard',
+        has_seen_walkthrough BOOLEAN NOT NULL DEFAULT 0,
+        rowVersion INTEGER NOT NULL DEFAULT 1,
+        createdAt DATETIME NOT NULL DEFAULT (datetime('now')),
+        updatedAt DATETIME NOT NULL DEFAULT (datetime('now')),
+        deletedAt DATETIME,
+        FOREIGN KEY (actor_id) REFERENCES actors(id)
+      )
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO users_new (
+        id, email, passwordHash, actor_id, isActive, role,
+        has_seen_walkthrough,
+        rowVersion, createdAt, updatedAt, deletedAt
+      )
+      SELECT
+        id, email, passwordHash, actor_id, isActive, role,
+        CASE
+          WHEN onboarding_display_mode = 'OFF' THEN 1
+          ELSE 0
+        END,
+        rowVersion, createdAt, updatedAt, deletedAt
+      FROM users
+    `);
+
+    await queryRunner.query(`DROP TABLE users`);
+    await queryRunner.query(`ALTER TABLE users_new RENAME TO users`);
+  }
+}

--- a/apps/backend/src/onboarding/dto/onboarding-status-response.dto.ts
+++ b/apps/backend/src/onboarding/dto/onboarding-status-response.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { OnboardingDisplayMode } from '../../identity-provider/enums';
+
+export class UserOnboardingStatusResponseDto {
+  @ApiProperty({ example: true })
+  workerConfigured!: boolean;
+
+  @ApiProperty({ example: true })
+  agentCreated!: boolean;
+
+  @ApiProperty({ example: true })
+  taskCreated!: boolean;
+
+  @ApiProperty({ example: true })
+  projectCreated!: boolean;
+
+  @ApiProperty({ example: true })
+  contextBlockCreated!: boolean;
+
+  @ApiProperty({ example: true })
+  threadConfigured!: boolean;
+
+  @ApiProperty({ example: true })
+  taskWithProjectCreated!: boolean;
+
+  @ApiProperty({
+    enum: OnboardingDisplayMode,
+    example: OnboardingDisplayMode.FULL_PAGE,
+  })
+  onboardingDisplayMode!: OnboardingDisplayMode;
+}

--- a/apps/backend/src/onboarding/onboarding.controller.ts
+++ b/apps/backend/src/onboarding/onboarding.controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ApiCookieAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AccessTokenGuard } from '../auth/guards/guards/access-token.guard';
+import { CurrentUser } from '../auth/guards/decorators/current-user.decorator';
+import type { UserContext } from '../auth/guards/context/auth-context.types';
+import { UserOnboardingStatusResponseDto } from './dto/onboarding-status-response.dto';
+import { OnboardingService } from './onboarding.service';
+
+@ApiTags('Onboarding')
+@ApiCookieAuth('JWT-Cookie')
+@Controller('onboarding')
+@UseGuards(AccessTokenGuard)
+export class OnboardingController {
+  constructor(private readonly onboardingService: OnboardingService) {}
+
+  @Get('status')
+  @ApiOperation({ summary: 'Get onboarding status for the current user' })
+  @ApiOkResponse({
+    type: UserOnboardingStatusResponseDto,
+    description: 'Current onboarding progress and display mode',
+  })
+  async getStatus(
+    @CurrentUser() user: UserContext,
+  ): Promise<UserOnboardingStatusResponseDto> {
+    const status = await this.onboardingService.getStatusForActor(user.actorId);
+
+    return {
+      workerConfigured: status.workerConfigured,
+      agentCreated: status.agentCreated,
+      taskCreated: status.taskCreated,
+      projectCreated: status.projectCreated,
+      contextBlockCreated: status.contextBlockCreated,
+      threadConfigured: status.threadConfigured,
+      taskWithProjectCreated: status.taskWithProjectCreated,
+      onboardingDisplayMode: status.onboardingDisplayMode,
+    };
+  }
+}

--- a/apps/backend/src/onboarding/onboarding.module.ts
+++ b/apps/backend/src/onboarding/onboarding.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AgentEntity } from '../agents/agent.entity';
+import { AuthGuardsModule } from '../auth/guards/auth-guards.module';
+import { ContextBlockEntity } from '../context/block.entity';
+import { User } from '../identity-provider/user.entity';
+import { ProjectEntity } from '../meta/project.entity';
+import { TaskEntity } from '../tasks/task.entity';
+import { ThreadEntity } from '../threads/thread.entity';
+import { WorkerEntity } from '../workers/worker.entity';
+import { OnboardingController } from './onboarding.controller';
+import { OnboardingService } from './onboarding.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      User,
+      WorkerEntity,
+      AgentEntity,
+      TaskEntity,
+      ProjectEntity,
+      ContextBlockEntity,
+      ThreadEntity,
+    ]),
+    AuthGuardsModule,
+  ],
+  controllers: [OnboardingController],
+  providers: [OnboardingService],
+})
+export class OnboardingModule {}

--- a/apps/backend/src/onboarding/onboarding.service.ts
+++ b/apps/backend/src/onboarding/onboarding.service.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AgentEntity } from '../agents/agent.entity';
+import { ContextBlockEntity } from '../context/block.entity';
+import { User } from '../identity-provider/user.entity';
+import { UserNotFoundError } from '../identity-provider/errors/identity-provider.errors';
+import { ProjectEntity } from '../meta/project.entity';
+import { TaskEntity } from '../tasks/task.entity';
+import { ThreadEntity } from '../threads/thread.entity';
+import { WorkerEntity } from '../workers/worker.entity';
+
+export type OnboardingStatusResult = {
+  workerConfigured: boolean;
+  agentCreated: boolean;
+  taskCreated: boolean;
+  projectCreated: boolean;
+  contextBlockCreated: boolean;
+  threadConfigured: boolean;
+  taskWithProjectCreated: boolean;
+  onboardingDisplayMode: User['onboardingDisplayMode'];
+};
+
+@Injectable()
+export class OnboardingService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+    @InjectRepository(WorkerEntity)
+    private readonly workersRepository: Repository<WorkerEntity>,
+    @InjectRepository(AgentEntity)
+    private readonly agentsRepository: Repository<AgentEntity>,
+    @InjectRepository(TaskEntity)
+    private readonly tasksRepository: Repository<TaskEntity>,
+    @InjectRepository(ProjectEntity)
+    private readonly projectsRepository: Repository<ProjectEntity>,
+    @InjectRepository(ContextBlockEntity)
+    private readonly contextBlocksRepository: Repository<ContextBlockEntity>,
+    @InjectRepository(ThreadEntity)
+    private readonly threadsRepository: Repository<ThreadEntity>,
+  ) {}
+
+  async getStatusForActor(actorId: string): Promise<OnboardingStatusResult> {
+    const user = await this.usersRepository.findOne({ where: { actorId } });
+
+    if (!user) {
+      throw new UserNotFoundError(actorId);
+    }
+
+    const [
+      workerConfigured,
+      agentCreated,
+      taskCreated,
+      projectCreated,
+      contextBlockCreated,
+      threadConfigured,
+      taskWithProjectCreated,
+    ] = await Promise.all([
+      this.workersRepository.existsBy({}),
+      this.agentsRepository.existsBy({}),
+      this.tasksRepository.existsBy({ createdByActorId: actorId }),
+      this.projectsRepository.existsBy({}),
+      this.contextBlocksRepository.existsBy({ createdByActorId: actorId }),
+      this.threadsRepository.existsBy({ createdByActorId: actorId }),
+      this.tasksRepository
+        .createQueryBuilder('task')
+        .innerJoin('task.tags', 'tag')
+        .innerJoin(ProjectEntity, 'project', 'project.tagId = tag.id')
+        .where('task.createdByActorId = :actorId', { actorId })
+        .getExists(),
+    ]);
+
+    return {
+      workerConfigured,
+      agentCreated,
+      taskCreated,
+      projectCreated,
+      contextBlockCreated,
+      threadConfigured,
+      taskWithProjectCreated,
+      onboardingDisplayMode: user.onboardingDisplayMode,
+    };
+  }
+}

--- a/apps/ui/src/auth/WalkthroughChecker.tsx
+++ b/apps/ui/src/auth/WalkthroughChecker.tsx
@@ -19,7 +19,7 @@ export function WalkthroughChecker({ children }: { children: React.ReactNode }) 
   }
 
   // User hasn't seen walkthrough - redirect
-  if (!user.hasSeenWalkthrough) {
+  if (user.onboardingDisplayMode === 'FULL_PAGE') {
     return <Navigate to="/walkthrough" replace />;
   }
 

--- a/apps/ui/src/auth/WalkthroughPage.tsx
+++ b/apps/ui/src/auth/WalkthroughPage.tsx
@@ -50,7 +50,7 @@ export function WalkthroughPage() {
       setIsLoading(true);
       setError(null);
       await WebAuthenticationService.webAuthControllerMarkWalkthroughSeen();
-      // Refresh auth state to update hasSeenWalkthrough flag
+      // Refresh auth state to update onboarding display mode
       await refreshAuth();
       navigate('/home', { replace: true });
     } catch (err) {

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -6831,6 +6831,33 @@
           "Search"
         ]
       }
+    },
+    "/api/v1/onboarding/status": {
+      "get": {
+        "operationId": "OnboardingController_getStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Current onboarding progress and display mode",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOnboardingStatusResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Get onboarding status for the current user",
+        "tags": [
+          "Onboarding"
+        ]
+      }
     }
   },
   "info": {
@@ -7725,10 +7752,15 @@
             "description": "Actor ID associated with this user",
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
-          "hasSeenWalkthrough": {
-            "type": "boolean",
-            "description": "Whether the user has seen the walkthrough",
-            "example": false
+          "onboardingDisplayMode": {
+            "type": "string",
+            "description": "How onboarding UI should be shown for this user (full page, banner, or off)",
+            "enum": [
+              "FULL_PAGE",
+              "BANNER",
+              "OFF"
+            ],
+            "example": "FULL_PAGE"
           }
         },
         "required": [
@@ -7737,7 +7769,7 @@
           "displayName",
           "role",
           "actorId",
-          "hasSeenWalkthrough"
+          "onboardingDisplayMode"
         ]
       },
       "LoginResponseDto": {
@@ -12196,6 +12228,58 @@
           "title",
           "score",
           "url"
+        ]
+      },
+      "UserOnboardingStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "workerConfigured": {
+            "type": "boolean",
+            "example": true
+          },
+          "agentCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "taskCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "projectCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "contextBlockCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "threadConfigured": {
+            "type": "boolean",
+            "example": true
+          },
+          "taskWithProjectCreated": {
+            "type": "boolean",
+            "example": true
+          },
+          "onboardingDisplayMode": {
+            "type": "string",
+            "enum": [
+              "FULL_PAGE",
+              "BANNER",
+              "OFF"
+            ],
+            "example": "FULL_PAGE"
+          }
+        },
+        "required": [
+          "workerConfigured",
+          "agentCreated",
+          "taskCreated",
+          "projectCreated",
+          "contextBlockCreated",
+          "threadConfigured",
+          "taskWithProjectCreated",
+          "onboardingDisplayMode"
         ]
       }
     }

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -1967,6 +1967,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/onboarding/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get onboarding status for the current user */
+        get: operations["OnboardingController_getStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2578,10 +2595,11 @@ export interface components {
              */
             actorId: string;
             /**
-             * @description Whether the user has seen the walkthrough
-             * @example false
+             * @description How onboarding UI should be shown for this user (full page, banner, or off)
+             * @example FULL_PAGE
+             * @enum {string}
              */
-            hasSeenWalkthrough: boolean;
+            onboardingDisplayMode: "FULL_PAGE" | "BANNER" | "OFF";
         };
         LoginResponseDto: {
             /** @description Authenticated user information */
@@ -5551,6 +5569,27 @@ export interface components {
              * @example /tasks/task/ba1cffdd-6c42-4cfc-ab00-ba1cf934fb81
              */
             url: string;
+        };
+        UserOnboardingStatusResponseDto: {
+            /** @example true */
+            workerConfigured: boolean;
+            /** @example true */
+            agentCreated: boolean;
+            /** @example true */
+            taskCreated: boolean;
+            /** @example true */
+            projectCreated: boolean;
+            /** @example true */
+            contextBlockCreated: boolean;
+            /** @example true */
+            threadConfigured: boolean;
+            /** @example true */
+            taskWithProjectCreated: boolean;
+            /**
+             * @example FULL_PAGE
+             * @enum {string}
+             */
+            onboardingDisplayMode: "FULL_PAGE" | "BANNER" | "OFF";
         };
     };
     responses: never;
@@ -10291,6 +10330,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GlobalSearchResultDto"][];
+                };
+            };
+        };
+    };
+    OnboardingController_getStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current onboarding progress and display mode */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserOnboardingStatusResponseDto"];
                 };
             };
         };

--- a/packages/client/src/v1/client/index.ts
+++ b/packages/client/src/v1/client/index.ts
@@ -138,6 +138,7 @@ export type { UpdateTaskDto } from './models/UpdateTaskDto.js';
 export type { UpdateThreadDto } from './models/UpdateThreadDto.js';
 export type { UpdateThreadStateDto } from './models/UpdateThreadStateDto.js';
 export type { UpsertAgentToolPermissionDto } from './models/UpsertAgentToolPermissionDto.js';
+export { UserOnboardingStatusResponseDto } from './models/UserOnboardingStatusResponseDto.js';
 export { UserResponseDto } from './models/UserResponseDto.js';
 
 export { ActorsService } from './services/ActorsService.js';
@@ -155,6 +156,7 @@ export { ExecutionsService } from './services/ExecutionsService.js';
 export { JwksService } from './services/JwksService.js';
 export { MetaService } from './services/MetaService.js';
 export { MetaProjectsService } from './services/MetaProjectsService.js';
+export { OnboardingService } from './services/OnboardingService.js';
 export { ScheduledTasksService } from './services/ScheduledTasksService.js';
 export { SearchService } from './services/SearchService.js';
 export { SecretsService } from './services/SecretsService.js';

--- a/packages/client/src/v1/client/models/UserOnboardingStatusResponseDto.ts
+++ b/packages/client/src/v1/client/models/UserOnboardingStatusResponseDto.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UserOnboardingStatusResponseDto = {
+    workerConfigured: boolean;
+    agentCreated: boolean;
+    taskCreated: boolean;
+    projectCreated: boolean;
+    contextBlockCreated: boolean;
+    threadConfigured: boolean;
+    taskWithProjectCreated: boolean;
+    onboardingDisplayMode: UserOnboardingStatusResponseDto.onboardingDisplayMode;
+};
+export namespace UserOnboardingStatusResponseDto {
+    export enum onboardingDisplayMode {
+        FULL_PAGE = 'FULL_PAGE',
+        BANNER = 'BANNER',
+        OFF = 'OFF',
+    }
+}
+

--- a/packages/client/src/v1/client/models/UserResponseDto.ts
+++ b/packages/client/src/v1/client/models/UserResponseDto.ts
@@ -24,9 +24,9 @@ export type UserResponseDto = {
      */
     actorId: string;
     /**
-     * Whether the user has seen the walkthrough
+     * How onboarding UI should be shown for this user (full page, banner, or off)
      */
-    hasSeenWalkthrough: boolean;
+    onboardingDisplayMode: UserResponseDto.onboardingDisplayMode;
 };
 export namespace UserResponseDto {
     /**
@@ -35,6 +35,14 @@ export namespace UserResponseDto {
     export enum role {
         ADMIN = 'admin',
         STANDARD = 'standard',
+    }
+    /**
+     * How onboarding UI should be shown for this user (full page, banner, or off)
+     */
+    export enum onboardingDisplayMode {
+        FULL_PAGE = 'FULL_PAGE',
+        BANNER = 'BANNER',
+        OFF = 'OFF',
     }
 }
 

--- a/packages/client/src/v1/client/services/OnboardingService.ts
+++ b/packages/client/src/v1/client/services/OnboardingService.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { UserOnboardingStatusResponseDto } from '../models/UserOnboardingStatusResponseDto.js';
+import type { CancelablePromise } from '../core/CancelablePromise.js';
+import { OpenAPI } from '../core/OpenAPI.js';
+import type { OpenAPIConfig } from '../core/OpenAPI.js';
+import { request as __request } from '../core/request.js';
+export class OnboardingService {
+    /**
+     * Get onboarding status for the current user
+     * @returns UserOnboardingStatusResponseDto Current onboarding progress and display mode
+     * @throws ApiError
+     */
+    public static onboardingControllerGetStatus(config: OpenAPIConfig = OpenAPI): CancelablePromise<UserOnboardingStatusResponseDto> {
+        return __request(config, {
+            method: 'GET',
+            url: '/api/v1/onboarding/status',
+        });
+    }
+}

--- a/packages/client/src/v2/client.ts
+++ b/packages/client/src/v2/client.ts
@@ -22,6 +22,7 @@ import { TaskBlueprintsResource } from './task-blueprints-resource.js';
 import { ScheduledTasksResource } from './scheduled-tasks-resource.js';
 import { DiscoveryResource } from './discovery-resource.js';
 import { SearchResource } from './search-resource.js';
+import { OnboardingResource } from './onboarding-resource.js';
 
 export class ApiClient {
   public readonly app: AppResource;
@@ -47,6 +48,7 @@ export class ApiClient {
   public readonly scheduledTasks: ScheduledTasksResource;
   public readonly discovery: DiscoveryResource;
   public readonly search: SearchResource;
+  public readonly onboarding: OnboardingResource;
 
   constructor(config: ClientConfig) {
     this.app = new AppResource(config);
@@ -72,5 +74,6 @@ export class ApiClient {
     this.scheduledTasks = new ScheduledTasksResource(config);
     this.discovery = new DiscoveryResource(config);
     this.search = new SearchResource(config);
+    this.onboarding = new OnboardingResource(config);
   }
 }

--- a/packages/client/src/v2/onboarding-resource.ts
+++ b/packages/client/src/v2/onboarding-resource.ts
@@ -1,0 +1,14 @@
+import { BaseClient, ClientConfig } from './base-client.js';
+import type { UserOnboardingStatusResponseDto } from './types.js';
+
+export class OnboardingResource extends BaseClient {
+  constructor(config: ClientConfig) {
+    super(config);
+  }
+
+  /** Get onboarding status for the current user */
+  async OnboardingController_getStatus(params?: { signal?: AbortSignal }): Promise<UserOnboardingStatusResponseDto> {
+    return this.request('GET', '/api/v1/onboarding/status', { signal: params?.signal });
+  }
+
+}

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -171,7 +171,7 @@ export interface UserResponseDto {
   displayName: string;
   role: 'admin' | 'standard';
   actorId: string;
-  hasSeenWalkthrough: boolean;
+  onboardingDisplayMode: 'FULL_PAGE' | 'BANNER' | 'OFF';
 }
 
 export interface LoginResponseDto {
@@ -1045,4 +1045,15 @@ export interface GlobalSearchResultDto {
   title: string;
   score: number;
   url: string;
+}
+
+export interface UserOnboardingStatusResponseDto {
+  workerConfigured: boolean;
+  agentCreated: boolean;
+  taskCreated: boolean;
+  projectCreated: boolean;
+  contextBlockCreated: boolean;
+  threadConfigured: boolean;
+  taskWithProjectCreated: boolean;
+  onboardingDisplayMode: 'FULL_PAGE' | 'BANNER' | 'OFF';
 }


### PR DESCRIPTION
## Summary
- migrate users.has_seen_walkthrough to enum-based users.onboarding_display_mode (FULL_PAGE/BANNER/OFF) and update auth user DTO payloads to expose onboardingDisplayMode
- add a new authenticated backend onboarding module with GET /api/v1/onboarding/status returning derived onboarding progress booleans plus the current display mode
- regenerate OpenAPI/client contracts and update walkthrough gating in UI to use onboardingDisplayMode === FULL_PAGE

## Validation
- npm run build:dev
- npm run dev:1

## Technical debt
- onboarding progress currently mixes user-scoped and global checks because some domains (workers/projects/agents) do not persist creator ownership; if strictly per-user onboarding is required later, ownership metadata should be added upstream.