### PR TITLE
Improve worker OAuth callback page with styled redirect

### DIFF
--- a/apps/worker/src/auth/callback-server.ts
+++ b/apps/worker/src/auth/callback-server.ts
@@ -68,7 +68,15 @@ export async function createOAuthCallbackServer(
 }
 
 function generateSuccessPage(serverUrl: string): string {
-  const redirectUrl = `${serverUrl}/settings/worker`;
+  // Build redirect URL safely and escape for HTML/JS contexts
+  const redirectUrl = new URL('/settings/worker', serverUrl).toString();
+  const escapedHtmlUrl = redirectUrl
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+  const escapedJsUrl = JSON.stringify(redirectUrl);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -207,24 +215,25 @@ function generateSuccessPage(serverUrl: string): string {
       Redirecting in <span class="countdown-number" id="countdown">5</span> seconds...
     </div>
     <div class="manual-link">
-      <a href="${redirectUrl}" id="manual-link">Go to Workers page now</a>
+      <a href="${escapedHtmlUrl}" id="manual-link">Go to Workers page now</a>
     </div>
   </div>
 
   <script>
     let count = 5;
     const countdownElement = document.getElementById('countdown');
-    const redirectUrl = '${redirectUrl}';
+    const redirectUrl = ${escapedJsUrl};
 
     const interval = setInterval(() => {
       count--;
-      if (countdownElement) {
-        countdownElement.textContent = count.toString();
-      }
 
-      if (count <= 0) {
+      if (count === 0) {
         clearInterval(interval);
         window.location.href = redirectUrl;
+      } else {
+        if (countdownElement) {
+          countdownElement.textContent = count.toString();
+        }
       }
     }, 1000);
 

--- a/apps/worker/src/auth/callback-server.ts
+++ b/apps/worker/src/auth/callback-server.ts
@@ -69,7 +69,7 @@ export async function createOAuthCallbackServer(
 
 function generateSuccessPage(serverUrl: string): string {
   // Build redirect URL safely and escape for HTML/JS contexts
-  const redirectUrl = new URL('/settings/worker', serverUrl).toString();
+  const redirectUrl = new URL('/settings/workers', serverUrl).toString();
   const escapedHtmlUrl = redirectUrl
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/apps/worker/src/auth/callback-server.ts
+++ b/apps/worker/src/auth/callback-server.ts
@@ -1,6 +1,8 @@
 import { createServer } from 'http';
 
-export async function createOAuthCallbackServer(): Promise<{
+export async function createOAuthCallbackServer(
+  serverUrl: string,
+): Promise<{
   redirectUri: string;
   waitForCode: (expectedState: string) => Promise<{ code: string }>;
 }> {
@@ -21,7 +23,8 @@ export async function createOAuthCallbackServer(): Promise<{
     }
 
     res.statusCode = 200;
-    res.end('Taico worker authorization completed. You can close this tab.');
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.end(generateSuccessPage(serverUrl));
 
     if (pendingResolve) {
       pendingResolve({ code, state });
@@ -62,4 +65,174 @@ export async function createOAuthCallbackServer(): Promise<{
       return { code: result.code };
     },
   };
+}
+
+function generateSuccessPage(serverUrl: string): string {
+  const redirectUrl = `${serverUrl}/settings/worker`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Worker Paired - Taico</title>
+  <style>
+    /* Design tokens - Light theme */
+    :root {
+      --bg: #ffffff;
+      --surface: #f6f8fa;
+      --text: #1f2328;
+      --text-muted: #59636e;
+      --border: #d1d9e0;
+      --accent: #0969da;
+      --accent-hover: #0550ae;
+      --success: #1a7f37;
+      --space-4: 16px;
+      --space-5: 24px;
+      --space-6: 32px;
+      --r-3: 8px;
+      --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+      --fs-2: 14px;
+      --fs-3: 16px;
+      --fs-5: 24px;
+      --fw-normal: 400;
+      --fw-semibold: 600;
+      --lh-normal: 1.5;
+      --shadow-2: 0 4px 8px rgba(31, 35, 40, 0.12);
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--surface);
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: var(--space-5);
+      line-height: var(--lh-normal);
+    }
+
+    .container {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--r-3);
+      padding: var(--space-6);
+      max-width: 480px;
+      width: 100%;
+      box-shadow: var(--shadow-2);
+      text-align: center;
+    }
+
+    .icon {
+      width: 48px;
+      height: 48px;
+      margin: 0 auto var(--space-5);
+      background: var(--success);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .checkmark {
+      width: 24px;
+      height: 24px;
+      stroke: white;
+      stroke-width: 3;
+      fill: none;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    h1 {
+      font-size: var(--fs-5);
+      font-weight: var(--fw-semibold);
+      margin-bottom: var(--space-4);
+      color: var(--text);
+    }
+
+    p {
+      font-size: var(--fs-3);
+      color: var(--text-muted);
+      margin-bottom: var(--space-5);
+    }
+
+    .countdown {
+      font-size: var(--fs-3);
+      color: var(--text);
+      margin-top: var(--space-5);
+    }
+
+    .countdown-number {
+      font-weight: var(--fw-semibold);
+      color: var(--accent);
+      font-size: var(--fs-5);
+    }
+
+    .manual-link {
+      margin-top: var(--space-5);
+      padding-top: var(--space-5);
+      border-top: 1px solid var(--border);
+    }
+
+    .manual-link a {
+      color: var(--accent);
+      text-decoration: none;
+      font-size: var(--fs-2);
+    }
+
+    .manual-link a:hover {
+      color: var(--accent-hover);
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">
+      <svg class="checkmark" viewBox="0 0 24 24">
+        <polyline points="20 6 9 17 4 12"></polyline>
+      </svg>
+    </div>
+    <h1>Worker Successfully Paired</h1>
+    <p>Your Taico worker has been successfully paired with the server. You can now close this tab or wait to be redirected.</p>
+    <div class="countdown">
+      Redirecting in <span class="countdown-number" id="countdown">5</span> seconds...
+    </div>
+    <div class="manual-link">
+      <a href="${redirectUrl}" id="manual-link">Go to Workers page now</a>
+    </div>
+  </div>
+
+  <script>
+    let count = 5;
+    const countdownElement = document.getElementById('countdown');
+    const redirectUrl = '${redirectUrl}';
+
+    const interval = setInterval(() => {
+      count--;
+      if (countdownElement) {
+        countdownElement.textContent = count.toString();
+      }
+
+      if (count <= 0) {
+        clearInterval(interval);
+        window.location.href = redirectUrl;
+      }
+    }, 1000);
+
+    // Also allow manual click during countdown
+    document.getElementById('manual-link')?.addEventListener('click', () => {
+      clearInterval(interval);
+    });
+  </script>
+</body>
+</html>`;
 }

--- a/apps/worker/src/auth/worker-auth.ts
+++ b/apps/worker/src/auth/worker-auth.ts
@@ -136,7 +136,7 @@ export class WorkerAuth {
   }
 
   private async bootstrapFromBrowserAuthorization(): Promise<WorkerCredentials> {
-    const callback = await createOAuthCallbackServer();
+    const callback = await createOAuthCallbackServer(this.serverUrl);
     const redirectUri = callback.redirectUri;
     const codeVerifier = randomBytes(32).toString('base64url');
     const codeChallenge = createHash('sha256')


### PR DESCRIPTION
## Summary
- Enhanced the OAuth callback page served by the worker after successful authorization
- Replaced plain text "soviet frugal" response with a polished, styled HTML page
- Implemented 5-second countdown with auto-redirect to `/settings/worker`
- Used Taico design tokens for consistent look and feel with the main application

## Changes
### `apps/worker/src/auth/callback-server.ts`
- Updated `createOAuthCallbackServer()` to accept `serverUrl` parameter
- Created `generateSuccessPage()` function that returns styled HTML
- Added inline CSS using Taico light theme design tokens
- Implemented JavaScript countdown timer with auto-redirect
- Used user-friendly "paired" language (like Bluetooth pairing)
- Added success icon with checkmark for visual feedback
- Included manual "Go to Workers page now" link for users who don't want to wait

### `apps/worker/src/auth/worker-auth.ts`
- Updated call to `createOAuthCallbackServer()` to pass `this.serverUrl`

## User Experience
After authorizing the worker via OAuth:
1. User sees a styled success page with checkmark icon
2. Page displays "Worker Successfully Paired" message
3. 5-second countdown shows before redirect
4. User can click "Go to Workers page now" to skip waiting
5. Auto-redirects to `{serverUrl}/settings/worker` where workers are managed

## Testing
- ✅ `npm run build:dev` - All packages compile successfully
- ✅ `npm run dev:1` - App starts correctly
- ✅ No breaking changes to existing OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)