### PR TITLE
Fix command palette appearing on login screen

### DIFF
--- a/apps/ui/src/app/App.tsx
+++ b/apps/ui/src/app/App.tsx
@@ -79,29 +79,29 @@ export function App() {
         <ToastProvider>
           <AuthProvider>
             <ActorsProvider>
-              <CommandPaletteProvider>
-                <Routes>
-                  <Route path="/onboarding" element={<OnboardingPage />} />
-                  <Route path="/login" element={
-                    <OnboardingChecker>
-                      <LoginPage />
-                    </OnboardingChecker>
-                  } />
-                  <Route
-                    path='*'
-                    element={
-                      <ProtectedRoute>
+              <Routes>
+                <Route path="/onboarding" element={<OnboardingPage />} />
+                <Route path="/login" element={
+                  <OnboardingChecker>
+                    <LoginPage />
+                  </OnboardingChecker>
+                } />
+                <Route
+                  path='*'
+                  element={
+                    <ProtectedRoute>
+                      <CommandPaletteProvider>
                         <WalkthroughGate>
                           <BetaShell>
                             <BetaAppRoutes />
                           </BetaShell>
                         </WalkthroughGate>
-                      </ProtectedRoute>
-                    }
-                  />
-                </Routes>
-                <ToastContainer />
-              </CommandPaletteProvider>
+                      </CommandPaletteProvider>
+                    </ProtectedRoute>
+                  }
+                />
+              </Routes>
+              <ToastContainer />
             </ActorsProvider>
           </AuthProvider>
         </ToastProvider>


### PR DESCRIPTION
## Summary
- Fixed bug where CMD+/ keyboard shortcut triggered command palette on login screen
- Moved `CommandPaletteProvider` to only wrap authenticated routes (inside `ProtectedRoute`)
- Command palette now only available after user authentication

## Technical Details
The `CommandPaletteProvider` was wrapping all routes in `App.tsx`, including `/login` and `/onboarding`. This caused the `CommandPalette` component to mount and register its global keyboard shortcut (CMD+/) even on unauthenticated pages.

The fix restructures the provider hierarchy so that `CommandPaletteProvider` only wraps the protected routes, ensuring it's only active for authenticated users.

## Test Plan
- [x] Build verified with `npm run build:dev`
- [x] App starts successfully with `npm run dev:2`
- [ ] Manual test: Navigate to login page and verify CMD+/ does not trigger command palette
- [ ] Manual test: After logging in, verify CMD+/ still works on authenticated pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)