### PR TITLE
poc codex runner - inherits tools from codex app

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -34,6 +34,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.1.76",
     "@github/copilot-sdk": "^0.2.0",
     "@google/adk": "^0.2.4",
+    "@openai/codex-sdk": "^0.120.0",
     "@opencode-ai/sdk": "^1.1.28",
     "@taico/client": "^0.2.11",
     "@taico/events": "^0.2.11",

--- a/apps/worker/src/runners/CodexAgentRunner.ts
+++ b/apps/worker/src/runners/CodexAgentRunner.ts
@@ -1,0 +1,163 @@
+import { on } from "events";
+import { AgentModelConfig, AgentRunContext, RuntimeMcpServerConfig } from "./AgentRunner.js";
+import { BaseAgentRunner } from "./BaseAgentRunner.js";
+import { Codex } from "@openai/codex-sdk";
+
+function makeMcpConfig(ctx: AgentRunContext): any {
+  const config: any = {
+    "codex_apps": {
+      url: "http://localhost",
+      enabled: false,
+    }
+  };
+  if (!ctx.mcpServers) {
+    return config;
+  }
+  for (const [name, serverConfig] of Object.entries(ctx.mcpServers)) {
+    if (serverConfig.type === "http") {
+      config[name] = {
+        url: serverConfig.url,
+        http_headers: serverConfig.headers,
+      };
+      if (ctx.accessToken) {
+        config[name].http_headers = {
+          ...config[name].http_headers,
+          Authorization: `Bearer ${ctx.accessToken}`,
+        };
+      }
+    } else if (serverConfig.type === "stdio") {
+      config[name] = {
+        command: serverConfig.command,
+        args: serverConfig.args,
+      };
+    }
+  }
+  return config;
+}
+
+export class CodexAgentRunner extends BaseAgentRunner {
+  readonly kind = 'codex';
+
+  private model: string;
+
+  constructor(modelConfig: AgentModelConfig = {}) {
+    super();
+    this.model = modelConfig.modelId ?? 'gpt-5.3-codex';
+  }
+
+  protected async runInternal(
+    ctx: AgentRunContext,
+    emit: (msg: string) => Promise<void>,
+    setSession: (id: string) => Promise<void>,
+    onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
+    onToolCall?: (toolName: string) => void | Promise<void>,
+  ): Promise<string> {
+    
+    // Init client
+    const mcpConfig = makeMcpConfig(ctx);
+    console.log(mcpConfig);
+    
+    const codex = new Codex(
+      {
+        config: {
+          mcp_servers: mcpConfig,
+        },
+      }
+    );
+    // Start a session
+    const thread = codex.startThread({
+      model: this.model,
+      sandboxMode: "workspace-write",
+      workingDirectory: ctx.cwd,
+      skipGitRepoCheck: true, // we could check from the runner if the folder is a git repo and only skip if it is not, but for testing purposes we can just skip
+      networkAccessEnabled: true,
+      webSearchEnabled: true,
+      webSearchMode: "live",
+    });
+    // Send the prompt
+    const { events } = await thread.runStreamed(ctx.prompt);
+
+    // React to respones
+    for await (const event of events) {
+      switch (event.type) {
+        case "item.completed":
+          switch (event.item.type) {
+            case "agent_message":
+              void emit(`@${ctx.agentSlug} ${event.item.text}`);
+              break;
+            case "command_execution":
+              void emit(`@${ctx.agentSlug} 🔧 Running ${event.item.command}`);
+              if (onToolCall) {
+                await onToolCall(event.item.command);
+              }
+              break;
+            case "file_change":
+              void emit(`@${ctx.agentSlug} ✏️ editing file`);
+              break;
+            case "mcp_tool_call":
+              void emit(`@${ctx.agentSlug} 🧰 calling MCP Tool ${event.item.server} ${event.item.tool}`);
+              if (onToolCall) {
+                await onToolCall(event.item.tool);
+              }
+              break;
+            case "reasoning":
+              void emit(`@${ctx.agentSlug} 🤔 ${event.item.text}`);
+              break;
+            case "todo_list":
+              void emit(`@${ctx.agentSlug} 📝 Reading ${event.item.items.length} todo items`);
+              break;
+            case "web_search":
+              void emit(`@${ctx.agentSlug} 🔍 Searching the web for "${event.item.query}"`);
+              break;
+            default:
+              void emit(`@${ctx.agentSlug} ...`);
+              break;
+          }
+          break;
+        case "turn.completed":
+          console.log("turn completed");
+          console.log(` - input tokens: ${event.usage.input_tokens}`);
+          console.log(` - output tokens: ${event.usage.output_tokens}`);
+          void emit(`@${ctx.agentSlug} [done]`);
+          break;
+        case "turn.failed":
+          console.log("turn failed", event.error);
+          void emit(`@${ctx.agentSlug} [error]`);
+          if (onError) {
+            await onError({
+              message: event.error.message,
+              rawMessage: event.error,
+            });
+          }
+          return "error";
+        case "turn.started":
+          void emit(`@${ctx.agentSlug} [turn started]`);
+          break;
+        case "item.started":
+          void emit(`@${ctx.agentSlug} [item started]`);
+          break;
+        case "item.updated":
+          void emit(`@${ctx.agentSlug} [item updated]`);
+          break;
+        case "thread.started":
+          await setSession(event.thread_id);
+          void emit(`@${ctx.agentSlug} [thread started] ${event.thread_id}`);
+          break;
+        case "error":
+          console.log("thread error", event.message);
+          void emit(`@${ctx.agentSlug} [error]`);
+          if (onError) {
+            await onError({
+              message: event.message,
+              rawMessage: event,
+            });
+          }
+          return "error";
+        default:
+          console.log("event", event);
+      }
+    }
+
+    return "done";
+  }
+}

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -18,6 +18,7 @@ import {
   classifyAgentError,
   classifyRunnerError,
 } from './task-execution-errors.js';
+import { CodexAgentRunner } from './runners/CodexAgentRunner.js';
 
 type ExecuteTaskParams = {
   taskId: string;
@@ -119,6 +120,8 @@ export async function executeTask({
     runner = new ADKAgentRunner(modelConfig);
   } else if (agent.type === 'githubcopilot') {
     runner = new GitHubCopilotAgentRunner(modelConfig);
+  } else if (agent.type === 'codex') {
+    runner = new CodexAgentRunner(modelConfig);
   }
 
   if (!runner) {

--- a/apps/worker/src/test.ts
+++ b/apps/worker/src/test.ts
@@ -3,24 +3,35 @@
 import { ADKAgentRunner } from "./runners/ADKAgentRunner.js";
 import { AgentRunCallbacks, AgentRunContext } from "./runners/AgentRunner.js";
 import { ClaudeAgentRunner } from "./runners/ClaudeAgentRunner.js";
+import { CodexAgentRunner } from "./runners/CodexAgentRunner.js";
 import { GitHubCopilotAgentRunner } from "./runners/GitHubCopilotAgentRunner.js";
 import { OpencodeAgentRunner } from "./runners/OpenCodeAgentRunner.js";
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { createOpencode } from "@opencode-ai/sdk";
 
 const TOKEN = "";
 
 type AgentArgs = { runContext: AgentRunContext, callbacks: AgentRunCallbacks };
 
 async function main(): Promise<void> {
-  console.log("Hello");
 
   const runContext: AgentRunContext = {
     taskId: '830d2707-1b8e-4bba-a4d5-62418b2df65a', // this is not really needed I just found out, never used
-    prompt: `Fetch task 830d2707-1b8e-4bba-a4d5-62418b2df65a and do what it says`,
+    // prompt: `Fetch task 830d2707-1b8e-4bba-a4d5-62418b2df65a and do what it says`,
+    prompt: `Show me what tools and mcp servers you have available. Use tasks to list tasks not started and list agents`,
     cwd: '/Users/franciscogalarza/github/ai-monorepo/tmp/worker-test',
     baseUrl: 'http://localhost:2000',
     accessToken: TOKEN,
     executionId: '123', // this seems to only go as a header in the MCP connection, not really needed other than for tracking and spawning sub tasks
     agentSlug: 'claude-test',
+    mcpServers: {
+      tasks: {
+        type: 'http',
+        url: 'http://localhost:2000/api/v1/tasks/tasks/mcp',
+        headers: {},
+      }
+    }
   };
 
   const onHeartbeat = () => {
@@ -49,6 +60,11 @@ async function main(): Promise<void> {
     onError,
   }
 
+  await codex({
+    runContext,
+    callbacks,
+  });
+
   // await claude({
   //   runContext,
   //   callbacks,
@@ -68,8 +84,38 @@ async function main(): Promise<void> {
   //   runContext,
   //   callbacks,
   // });
+
+  // claudeModel();
+  // openCodeModel();
 }
 
+async function claudeModel() {
+  const r = query({
+    prompt: '',
+  });
+  const models = await r.supportedModels(); // <-- useless, prints display names but not the actual model keys needed to run the agent.
+  console.log(models);
+}
+
+async function openCodeModel() {
+  const opencode = await createOpencode({
+    port: 1234,
+    signal: AbortSignal.timeout(15 * 1000), // 15 seconds
+    timeout: 10 * 1000, // 10 seconds
+  });
+  const response = await opencode.client.config.providers();
+  const providers = response.data?.providers;
+
+  providers?.forEach((provider) => {
+    console.log(`Provider: ${provider.id}`);          // <-- this is good.
+    Object.keys(provider.models).forEach((modelKey) => {
+      const model = provider.models[modelKey];
+      console.log(`  - ${modelKey}: ${model.name}`);  // <-- this is good.
+    });
+  });
+  await opencode.client.instance.dispose(); // <-- also doesn't help the server shut down
+  opencode.server.close(); // <-- this doesn't do Jack 💩 - process stays open
+}
 
 async function claude({ runContext, callbacks }: AgentArgs) {
   const runner = new ClaudeAgentRunner({});
@@ -91,5 +137,9 @@ async function copilot({ runContext, callbacks }: AgentArgs) {
   runner.run(runContext, callbacks);
 }
 
+async function codex({ runContext, callbacks }: AgentArgs) {
+  const runner = new CodexAgentRunner({});
+  runner.run(runContext, callbacks);
+}
 
 void main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -510,6 +510,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",
         "@github/copilot-sdk": "^0.2.0",
         "@google/adk": "^0.2.4",
+        "@openai/codex-sdk": "^0.120.0",
         "@opencode-ai/sdk": "^1.1.28",
         "@taico/client": "^0.2.11",
         "@taico/events": "^0.2.11",
@@ -3903,6 +3904,140 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0.tgz",
+      "integrity": "sha512-e2P1Gya3dwsRe9IPOiswVz5JfR700u+/sWCqDc3jkqv2QViPkNiBmZoGhFnZL5jBpKakSjehC4/Fpspg70nHTw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.120.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.120.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.120.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.120.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.120.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.120.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.120.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-arm64.tgz",
+      "integrity": "sha512-7CU+I5kBaMuoqfG3xisq0mUWzxoEHvfu34cB8a0KpBiIhAgu12fKpmYgZ4/DvRP6Wm9Fu6LJYKVF5apUHFp8nQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.120.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-x64.tgz",
+      "integrity": "sha512-d7joNYuwrmd5iIdp/xAE5f8bZT1r82MnmU6Hzgxq3G+xClwEyhxU737ZWnstFSpnZNfxJ5zXCuFUJh4CAkHNtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.120.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-arm64.tgz",
+      "integrity": "sha512-sVYY25/URlpZPtb0Q0ryLh+lcq9UTEtHAkdZKa0a/R7mAdyPuhpU9V6jWmxwiUh7s53XZOEVFoKmLfH8YIDWCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.120.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-x64.tgz",
+      "integrity": "sha512-VcP9B/c/O+EFEgqoetCzvHrLfAdo8vrt09Gx1lJ8ikewctqAuJ/ozj/6wuvlz7XaaK64ib5cge01pOAeCyt2Sg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-sdk": {
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.120.0.tgz",
+      "integrity": "sha512-Y6y3EyLpSSJjRGqIFxxb1G9X6Hod+B1CnWzGoO7qrg3URPnjBL/DLLQWdZSENU5yIlRjHEQDSu7y1rKBlx+jUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openai/codex": "0.120.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.120.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-arm64.tgz",
+      "integrity": "sha512-SAaTQU1XHa1qDnmQldmbyROIY5SiaspF+Cw3ziWeeTgyAET3rWusm4ELOElx6QiY1ugYW5ZD+7AFufS2z1xtpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.120.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-x64.tgz",
+      "integrity": "sha512-zja1GNrbHyOUTvOy5FVMa+rAYIs3m+FOS8rAXftxMEhodMmkMw2O8zcvso657SHhZR0hIEiZ6T70lcyH2YX0mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@opencode-ai/sdk": {


### PR DESCRIPTION
# Codex runner 🚀

Codex finally has an [SDK](https://github.com/openai/codex/blob/main/sdk/typescript/README.md)! 
This means we don't have to rely on OpenCode and can potentially move to the native harness.

This PR is a POC to get a feel for the SDK.

## What works:
- transparent auth
- can configure working directory
- can configure additional MCP tools
- provides async event generator with typed events

## What doesn't:
- inherits MCP from the Codex App which are inherited from ChatGPT. Meaning, if ChatGPT is connected to something, I can't disable that from the codex runner.

As such, I'm not merging yet.