### PR TITLE
fix: add Content-Type header for /launch endpoint

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -32,7 +32,7 @@
           "200": {
             "description": "Returns the bash script to launch Taico",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "type": "string"
                 }

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -24,6 +24,28 @@
         ]
       }
     },
+    "/launch": {
+      "get": {
+        "operationId": "AppController_getLaunchScript",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Returns the bash script to launch Taico",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Launch script endpoint",
+        "tags": [
+          "App"
+        ]
+      }
+    },
     "/api/v1/meta/tags": {
       "post": {
         "operationId": "MetaController_createTag",

--- a/apps/backend/src/app.controller.ts
+++ b/apps/backend/src/app.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiOkResponse } from '@nestjs/swagger';
 import { AppService } from './app.service';
+import { Public } from './auth/guards/decorators/public.decorator';
 
 @Controller()
 export class AppController {
@@ -17,5 +18,39 @@ export class AppController {
   })
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  @Get('launch')
+  @Public()
+  @ApiOperation({ summary: 'Launch script endpoint' })
+  @ApiOkResponse({
+    description: 'Returns the bash script to launch Taico',
+    schema: {
+      type: 'string',
+    },
+  })
+  getLaunchScript(): string {
+    return `#!/bin/bash
+
+set -e
+
+IMAGE=ghcr.io/galarzafrancisco/ai-monorepo:latest
+
+PORT=9999                     # Port where the server will be accessible
+CONTAINER_NAME=taico          # Name for the Docker container
+DATABASE_PATH=~/.taico/data   # Path to the local directory for database storage
+
+docker run --name $CONTAINER_NAME --restart unless-stopped -d \\
+  -p $PORT:$PORT \\
+  -e NODE_ENV=production \\
+  -e PORT=$PORT \\
+  -e ISSUER_URL=http://localhost:$PORT \\
+  -e SECRETS_ENABLED=\\"true\\" \\
+  -e ALLOW_PLAINTEXT_SECRETS_INSECURE=\\"true\\" \\
+  -e DATABASE_PATH=/app/data/database.sqlite \\
+  -v $DATABASE_PATH:/app/data \\
+  $IMAGE
+
+echo "Server started on port $PORT. Access it at http://localhost:$PORT"`;
   }
 }

--- a/apps/backend/src/app.controller.ts
+++ b/apps/backend/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Header } from '@nestjs/common';
 import { ApiOperation, ApiOkResponse } from '@nestjs/swagger';
 import { AppService } from './app.service';
 import { Public } from './auth/guards/decorators/public.decorator';
@@ -22,6 +22,7 @@ export class AppController {
 
   @Get('launch')
   @Public()
+  @Header('Content-Type', 'text/plain; charset=utf-8')
   @ApiOperation({ summary: 'Launch script endpoint' })
   @ApiOkResponse({
     description: 'Returns the bash script to launch Taico',

--- a/apps/backend/src/app.controller.ts
+++ b/apps/backend/src/app.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Header } from '@nestjs/common';
-import { ApiOperation, ApiOkResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiOkResponse, ApiProduces } from '@nestjs/swagger';
 import { AppService } from './app.service';
 import { Public } from './auth/guards/decorators/public.decorator';
 
@@ -22,6 +22,7 @@ export class AppController {
 
   @Get('launch')
   @Public()
+  @ApiProduces('text/plain')
   @Header('Content-Type', 'text/plain; charset=utf-8')
   @ApiOperation({ summary: 'Launch script endpoint' })
   @ApiOkResponse({

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -140,6 +140,10 @@ async function createConfiguredApp(
         path: '/.well-known/*path',
         method: RequestMethod.ALL,
       },
+      {
+        path: '/launch',
+        method: RequestMethod.ALL,
+      },
     ],
   });
 

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -32,7 +32,7 @@
           "200": {
             "description": "Returns the bash script to launch Taico",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "type": "string"
                 }

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -24,6 +24,28 @@
         ]
       }
     },
+    "/launch": {
+      "get": {
+        "operationId": "AppController_getLaunchScript",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Returns the bash script to launch Taico",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Launch script endpoint",
+        "tags": [
+          "App"
+        ]
+      }
+    },
     "/api/v1/meta/tags": {
       "post": {
         "operationId": "MetaController_createTag",

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -21,6 +21,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/launch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Launch script endpoint */
+        get: operations["AppController_getLaunchScript"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/meta/tags": {
         parameters: {
             query?: never;
@@ -5776,6 +5793,26 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Returns a greeting message */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    AppController_getLaunchScript: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Returns the bash script to launch Taico */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -5818,7 +5818,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": string;
+                    "text/plain": string;
                 };
             };
         };

--- a/packages/client/src/v1/client/services/AppService.ts
+++ b/packages/client/src/v1/client/services/AppService.ts
@@ -18,4 +18,15 @@ export class AppService {
             url: '/api/v1',
         });
     }
+    /**
+     * Launch script endpoint
+     * @returns string Returns the bash script to launch Taico
+     * @throws ApiError
+     */
+    public static appControllerGetLaunchScript(config: OpenAPIConfig = OpenAPI): CancelablePromise<string> {
+        return __request(config, {
+            method: 'GET',
+            url: '/launch',
+        });
+    }
 }

--- a/packages/client/src/v2/app-resource.ts
+++ b/packages/client/src/v2/app-resource.ts
@@ -10,4 +10,9 @@ export class AppResource extends BaseClient {
     return this.request('GET', '/api/v1', { signal: params?.signal });
   }
 
+  /** Launch script endpoint */
+  async AppController_getLaunchScript(params?: { signal?: AbortSignal }): Promise<string> {
+    return this.request('GET', '/launch', { signal: params?.signal });
+  }
+
 }

--- a/packages/client/src/v2/app-resource.ts
+++ b/packages/client/src/v2/app-resource.ts
@@ -12,7 +12,7 @@ export class AppResource extends BaseClient {
 
   /** Launch script endpoint */
   async AppController_getLaunchScript(params?: { signal?: AbortSignal }): Promise<string> {
-    return this.request('GET', '/launch', { signal: params?.signal });
+    return this.request('GET', '/launch', { responseType: 'text', signal: params?.signal });
   }
 
 }


### PR DESCRIPTION
## Summary

This PR fixes the /launch endpoint content type to serve the bash script as plain text.

## Changes

* Added  decorator to /launch endpoint
* Ensures the endpoint returns the bash script with the correct Content-Type header for 

## Fixes

- Code review feedback from PR #859 regarding missing explicit Content-Type header

## Testing

Run: 