### PR TITLE
Map Claude "hit your limit" errors to OUT_OF_QUOTA

### DIFF
--- a/apps/worker/src/task-execution-errors.ts
+++ b/apps/worker/src/task-execution-errors.ts
@@ -4,6 +4,15 @@ export type ExecutionErrorCode = 'OUT_OF_QUOTA' | 'UNKNOWN';
 
 const MAX_ERROR_MESSAGE_LENGTH = 1000;
 
+const QUOTA_MESSAGE_PATTERNS: RegExp[] = [
+  /quota/i,
+  /rate\s*limit/i,
+  /credit/i,
+  /billing/i,
+  /you\s*(?:have|'ve)?\s*hit\s*(?:your\s*)?limit/i,
+  /usage\s*limit/i,
+];
+
 export class TaskExecutionError extends Error {
   readonly displayMessage: string;
 
@@ -65,14 +74,7 @@ export function classifyAgentError(input: {
   message: string;
   rawMessage?: unknown;
 }): TaskExecutionError {
-  const text = input.message.toLowerCase();
-
-  if (
-    text.includes('quota') ||
-    text.includes('rate limit') ||
-    text.includes('credit') ||
-    text.includes('billing')
-  ) {
+  if (QUOTA_MESSAGE_PATTERNS.some((pattern) => pattern.test(input.message))) {
     return new AgentQuotaExceededError(input.message, input.rawMessage);
   }
 


### PR DESCRIPTION
## Summary
- extend worker agent error classification to detect limit-style quota phrasing (for example: \"You've hit your limit · resets 9pm (Australia/Sydney)\")
- map those messages to `OUT_OF_QUOTA` so Claude task runs are no longer reported as `UNKNOWN`
- keep existing quota/rate-limit/credit/billing matching while centralizing checks in a regex pattern list

## Validation
- `npm run build:dev`
- `npm run dev:1` (startup validation only)

## Technical debt
- worker currently has no focused unit tests around `classifyAgentError`; adding coverage for classifier patterns would reduce regression risk.