### PR TITLE
Add MCP tools for managing task dependencies

### DIFF
--- a/apps/backend/src/tasks/tasks.mcp.gateway.ts
+++ b/apps/backend/src/tasks/tasks.mcp.gateway.ts
@@ -813,6 +813,92 @@ export class TasksMcpGateway {
         },
       );
 
+    canWrite &&
+      server.registerTool(
+        'add_dependency',
+        {
+          title: 'Add task dependency',
+          description: 'Add a dependency to a task (task A depends on task B)',
+          inputSchema: {
+            taskId: z.string(),
+            dependsOnTaskId: z.string(),
+          },
+        },
+        async ({ taskId, dependsOnTaskId }) => {
+          // Fetch current task to get existing dependencies
+          const task = await this.tasksService.getTaskById(taskId);
+          const currentDependencyIds = task.dependsOnIds || [];
+
+          // Check if dependency already exists
+          if (currentDependencyIds.includes(dependsOnTaskId)) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'Dependency already exists',
+                },
+              ],
+            };
+          }
+
+          // Add new dependency
+          const updatedDependencyIds = [...currentDependencyIds, dependsOnTaskId];
+          await this.tasksService.updateTask(
+            taskId,
+            { dependsOnIds: updatedDependencyIds },
+            user.actorId,
+          );
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'done',
+              },
+            ],
+          };
+        },
+      );
+
+    canWrite &&
+      server.registerTool(
+        'remove_dependency',
+        {
+          title: 'Remove task dependency',
+          description: 'Remove a dependency from a task',
+          inputSchema: {
+            taskId: z.string(),
+            dependsOnTaskId: z.string(),
+          },
+        },
+        async ({ taskId, dependsOnTaskId }) => {
+          // Fetch current task to get existing dependencies
+          const task = await this.tasksService.getTaskById(taskId);
+          const currentDependencyIds = task.dependsOnIds || [];
+
+          // Filter out the dependency to remove
+          const updatedDependencyIds = currentDependencyIds.filter(
+            (id) => id !== dependsOnTaskId,
+          );
+
+          // Update task with new dependency list
+          await this.tasksService.updateTask(
+            taskId,
+            { dependsOnIds: updatedDependencyIds },
+            user.actorId,
+          );
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'done',
+              },
+            ],
+          };
+        },
+      );
+
     return server;
   }
 


### PR DESCRIPTION
## Summary
- Added `add_dependency` MCP tool to add task dependencies (task A depends on task B)
- Added `remove_dependency` MCP tool to remove task dependencies
- Both tools provide a more ergonomic API than replacing the entire `dependsOnIds` array

## Implementation Details
These tools leverage the existing `updateTask` service method which already supports the `dependsOnIds` parameter. The tools:
1. Fetch the current task to get existing dependencies
2. Add or remove the specified dependency from the list
3. Update the task with the modified dependency list

The `add_dependency` tool checks for duplicates before adding. Both tools follow the same pattern as other MCP tools in the gateway.

## Side Quest
Found and bumped the "Add / edit dependency" UI task that was created earlier but hadn't been worked on yet.

## Testing
- ✅ `npm run build:dev` passed
- ✅ `npm run dev:1` started successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)