### PR TITLE
Add MCP context block search and filtered listing

### DIFF
--- a/apps/backend/src/context/context.mcp.gateway.ts
+++ b/apps/backend/src/context/context.mcp.gateway.ts
@@ -58,6 +58,76 @@ export class ContextMcpGateway {
     );
 
     server.registerTool(
+      'list_blocks_filtered',
+      {
+        title: 'List context blocks with filters',
+        description:
+          'List context blocks with additional filters for more precise queries',
+        annotations: readOnlyAnnotations,
+        inputSchema: {
+          tag: z.string().optional(),
+          createdByActorId: z.string().optional(),
+          parentId: z.string().nullable().optional(),
+          updatedWithinHours: z.number().positive().optional(),
+          limit: z.number().int().positive().max(500).optional(),
+        },
+      },
+      async ({ tag, createdByActorId, parentId, updatedWithinHours, limit }) => {
+        const updatedAfter =
+          updatedWithinHours !== undefined
+            ? new Date(Date.now() - updatedWithinHours * 60 * 60 * 1000)
+            : undefined;
+
+        const blocks = await this.contextService.listBlocks({
+          tag,
+          createdByActorId,
+          parentId,
+          updatedAfter,
+          limit: limit ?? 100,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(blocks),
+            },
+          ],
+        };
+      },
+    );
+
+    server.registerTool(
+      'search_blocks',
+      {
+        title: 'Search context blocks',
+        description:
+          'Fuzzy search for context blocks by title and content. Returns matching blocks sorted by relevance.',
+        annotations: readOnlyAnnotations,
+        inputSchema: {
+          query: z.string(),
+          limit: z.number().optional(),
+          threshold: z.number().optional(),
+        },
+      },
+      async ({ query, limit, threshold }) => {
+        const results = await this.contextService.searchBlocks({
+          query,
+          limit,
+          threshold,
+        });
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(results),
+            },
+          ],
+        };
+      },
+    );
+
+    server.registerTool(
       'get_thread_state_memory',
       {
         title: 'Get thread state memory',

--- a/apps/backend/src/context/context.service.ts
+++ b/apps/backend/src/context/context.service.ts
@@ -137,27 +137,65 @@ export class ContextService {
   }
 
   async listBlocks(input?: ListBlocksInput): Promise<BlockSummaryResult[]> {
-    this.logger.log({ message: 'Listing context blocks', tag: input?.tag });
+    this.logger.log({
+      message: 'Listing context blocks',
+      filters: {
+        tag: input?.tag,
+        createdByActorId: input?.createdByActorId,
+        parentId: input?.parentId,
+        updatedAfter: input?.updatedAfter,
+        limit: input?.limit,
+      }
+    });
 
-    // If tag filter is provided, use query builder for join
+    // Use query builder for complex filtering
+    let queryBuilder = this.blockRepository
+      .createQueryBuilder('block')
+      .leftJoinAndSelect('block.tags', 'tags')
+      .leftJoinAndSelect('block.createdByActor', 'createdByActor')
+      .leftJoinAndSelect('block.assigneeActor', 'assigneeActor');
+
+    // Apply tag filter if provided
     if (input?.tag) {
-      const blocks = await this.blockRepository
-        .createQueryBuilder('block')
-        .leftJoinAndSelect('block.tags', 'tags')
-        .leftJoinAndSelect('block.createdByActor', 'createdByActor')
+      queryBuilder = queryBuilder
         .innerJoin('block.tags', 'filterTag')
-        .where('filterTag.name = :tagName', { tagName: input.tag })
-        .orderBy('block.createdAt', 'DESC')
-        .getMany();
-
-      return blocks.map((block) => this.mapToSummary(block));
+        .andWhere('filterTag.name = :tagName', { tagName: input.tag });
     }
 
-    // Standard filtering without tags
-    const blocks = await this.blockRepository.find({
-      relations: ['tags', 'createdByActor', 'assigneeActor'],
-      order: { createdAt: 'DESC' },
-    });
+    // Apply createdByActorId filter if provided
+    if (input?.createdByActorId) {
+      queryBuilder = queryBuilder.andWhere('block.createdByActorId = :createdByActorId', {
+        createdByActorId: input.createdByActorId,
+      });
+    }
+
+    // Apply parentId filter if provided (including explicit null)
+    if (input?.parentId !== undefined) {
+      if (input.parentId === null) {
+        queryBuilder = queryBuilder.andWhere('block.parentId IS NULL');
+      } else {
+        queryBuilder = queryBuilder.andWhere('block.parentId = :parentId', {
+          parentId: input.parentId,
+        });
+      }
+    }
+
+    // Apply updatedAfter filter if provided
+    if (input?.updatedAfter) {
+      queryBuilder = queryBuilder.andWhere('block.updatedAt >= :updatedAfter', {
+        updatedAfter: input.updatedAfter,
+      });
+    }
+
+    // Apply ordering
+    queryBuilder = queryBuilder.orderBy('block.createdAt', 'DESC');
+
+    // Apply limit if provided
+    if (input?.limit) {
+      queryBuilder = queryBuilder.take(input.limit);
+    }
+
+    const blocks = await queryBuilder.getMany();
 
     return blocks.map((block) => this.mapToSummary(block));
   }

--- a/apps/backend/src/context/dto/service/context.service.types.ts
+++ b/apps/backend/src/context/dto/service/context.service.types.ts
@@ -22,6 +22,10 @@ export interface AppendBlockInput {
 
 export interface ListBlocksInput {
   tag?: string;
+  createdByActorId?: string;
+  parentId?: string | null;
+  updatedAfter?: Date;
+  limit?: number;
 }
 
 export interface TagResult {


### PR DESCRIPTION
## Summary

Implements MCP support for searching context blocks and listing context blocks with additional filters.

This PR adds two new MCP tools to the Context gateway:
- `search_blocks` - Fuzzy search for context blocks by title and content
- `list_blocks_filtered` - Enhanced listing with filters (createdByActorId, parentId, updatedWithinHours, limit)

## Changes

### Backend Service Layer
- Enhanced `ListBlocksInput` type with new filter fields
- Refactored `ContextService.listBlocks()` to use query builder for all filtering
- Added support for filtering by creator, parent, time range, and limit

### MCP Gateway
- Added `search_blocks` tool using existing `searchBlocks` service method
- Added `list_blocks_filtered` tool with pattern matching Tasks MCP gateway
- Maintained backward compatibility with existing `list_blocks` tool

## Pattern Consistency

- Follows Tasks MCP gateway conventions exactly
- Uses `updatedWithinHours` parameter that converts to `updatedAfter` internally
- Default limit of 100, max 500 (same as tasks)
- Proper zod schema with `.nullable().optional()` for parentId
- Read-only annotations on search/list tools

## Testing

- ✅ `npm run build:dev` - Build passes
- ✅ `npm run dev:1` - App starts successfully
- No new backend search logic - leverages existing `SearchService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)