### PR TITLE
Replace gpt-5.2 with gpt-5.4 in default agent models

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -10085,7 +10085,7 @@
           "modelId": {
             "type": "string",
             "description": "Model ID used by the agent runtime",
-            "example": "gpt-5.2-codex"
+            "example": "gpt-5.4"
           },
           "statusTriggers": {
             "type": "array",
@@ -10208,7 +10208,7 @@
             "type": "string",
             "nullable": true,
             "description": "Model ID used by the agent runtime",
-            "example": "gpt-5.2-codex"
+            "example": "gpt-5.4"
           },
           "statusTriggers": {
             "type": "array",
@@ -10546,7 +10546,7 @@
           "modelId": {
             "type": "string",
             "description": "Model ID used by the agent runtime",
-            "example": "gpt-5.2-codex"
+            "example": "gpt-5.4"
           },
           "statusTriggers": {
             "type": "array",

--- a/apps/backend/src/agents/dto/agent-response.dto.ts
+++ b/apps/backend/src/agents/dto/agent-response.dto.ts
@@ -68,7 +68,7 @@ export class AgentResponseDto {
     type: String,
     nullable: true,
     description: 'Model ID used by the agent runtime',
-    example: 'gpt-5.2-codex',
+    example: 'gpt-5.4',
   })
   modelId!: string | null;
 

--- a/apps/backend/src/agents/dto/create-agent.dto.ts
+++ b/apps/backend/src/agents/dto/create-agent.dto.ts
@@ -83,7 +83,7 @@ export class CreateAgentDto {
 
   @ApiPropertyOptional({
     description: 'Model ID used by the agent runtime',
-    example: 'gpt-5.2-codex',
+    example: 'gpt-5.4',
   })
   @IsString()
   @IsOptional()

--- a/apps/backend/src/agents/dto/patch-agent.dto.ts
+++ b/apps/backend/src/agents/dto/patch-agent.dto.ts
@@ -50,7 +50,7 @@ export class PatchAgentDto {
 
   @ApiPropertyOptional({
     description: 'Model ID used by the agent runtime',
-    example: 'gpt-5.2-codex',
+    example: 'gpt-5.4',
   })
   @IsString()
   @IsOptional()

--- a/apps/backend/src/llm/openai-responses.service.ts
+++ b/apps/backend/src/llm/openai-responses.service.ts
@@ -40,7 +40,7 @@ export class OpenAiResponsesService {
     try {
       const client = new OpenAI({ apiKey });
       const response = await client.responses.create({
-        model: input.model || 'gpt-5.2',
+        model: input.model || 'gpt-5.4',
         input: input.prompt,
       });
 

--- a/apps/backend/src/threads/backends/openai.backend.ts
+++ b/apps/backend/src/threads/backends/openai.backend.ts
@@ -65,7 +65,7 @@ export class OpenAiBackend implements ChatBackend {
     const agent = new Agent({
       name: 'taico task runner',
       instructions: args.instructions,
-        model: args.modelId ?? 'gpt-5.4-codex',
+        model: args.modelId ?? 'gpt-5.4',
       mcpServers,
     });
     const runner = new Runner({ modelProvider });
@@ -80,7 +80,7 @@ export class OpenAiBackend implements ChatBackend {
       const agent = new Agent({
         name: args.agentName,
         instructions: buildThreadScopedInstructions(args.systemPrompt, args.threadId),
-      model: args.modelId ?? 'gpt-5.4-codex',
+      model: args.modelId ?? 'gpt-5.4',
         mcpServers,
       });
       const runner = new Runner({ modelProvider });

--- a/apps/backend/src/threads/backends/openai.backend.ts
+++ b/apps/backend/src/threads/backends/openai.backend.ts
@@ -43,7 +43,7 @@ export class OpenAiBackend implements ChatBackend {
       const apiKey = await this.getApiKey();
       const client = new OpenAI({ apiKey });
       const response = await client.responses.create({
-        model: modelId ?? 'gpt-5.2',
+        model: modelId ?? 'gpt-5.4',
         input: prompt,
       });
       return response.output_text?.trim() || null;
@@ -65,7 +65,7 @@ export class OpenAiBackend implements ChatBackend {
     const agent = new Agent({
       name: 'taico task runner',
       instructions: args.instructions,
-      model: args.modelId ?? 'gpt-5.2-codex',
+        model: args.modelId ?? 'gpt-5.4-codex',
       mcpServers,
     });
     const runner = new Runner({ modelProvider });
@@ -80,7 +80,7 @@ export class OpenAiBackend implements ChatBackend {
       const agent = new Agent({
         name: args.agentName,
         instructions: buildThreadScopedInstructions(args.systemPrompt, args.threadId),
-        model: args.modelId ?? 'gpt-5.2-codex',
+      model: args.modelId ?? 'gpt-5.4-codex',
         mcpServers,
       });
       const runner = new Runner({ modelProvider });

--- a/apps/worker-v1/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker-v1/src/runners/GitHubCopilotAgentRunner.ts
@@ -10,7 +10,7 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
 
   constructor(modelConfig: AgentModelConfig = {}) {
     super();
-    this.model = modelConfig.modelId ?? 'gpt-5.2-codex';
+    this.model = modelConfig.modelId ?? 'gpt-5.4-codex';
   }
 
   protected async runInternal(

--- a/apps/worker-v1/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker-v1/src/runners/GitHubCopilotAgentRunner.ts
@@ -10,7 +10,7 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
 
   constructor(modelConfig: AgentModelConfig = {}) {
     super();
-    this.model = modelConfig.modelId ?? 'gpt-5.4-codex';
+    this.model = modelConfig.modelId ?? 'gpt-5.4';
   }
 
   protected async runInternal(

--- a/apps/worker-v1/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker-v1/src/runners/OpenCodeAgentRunner.ts
@@ -22,7 +22,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     const hasCustomModel = Boolean(modelConfig.providerId && modelConfig.modelId);
     this.model = {
       providerId: hasCustomModel ? modelConfig.providerId! : 'openai',
-      modelId: hasCustomModel ? modelConfig.modelId! : 'gpt-5.2-codex',
+      modelId: hasCustomModel ? modelConfig.modelId! : 'gpt-5.4-codex',
     };
   }
 

--- a/apps/worker-v1/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker-v1/src/runners/OpenCodeAgentRunner.ts
@@ -22,7 +22,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     const hasCustomModel = Boolean(modelConfig.providerId && modelConfig.modelId);
     this.model = {
       providerId: hasCustomModel ? modelConfig.providerId! : 'openai',
-      modelId: hasCustomModel ? modelConfig.modelId! : 'gpt-5.4-codex',
+      modelId: hasCustomModel ? modelConfig.modelId! : 'gpt-5.4',
     };
   }
 

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -35,7 +35,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     const hasCustomModel = Boolean(modelConfig.providerId && modelConfig.modelId);
     this.model = {
       providerId: hasCustomModel ? modelConfig.providerId! : 'openai',
-      modelId: hasCustomModel ? modelConfig.modelId! : 'gpt-5.4-codex',
+      modelId: hasCustomModel ? modelConfig.modelId! : 'gpt-5.4',
     };
   }
 

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -35,7 +35,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     const hasCustomModel = Boolean(modelConfig.providerId && modelConfig.modelId);
     this.model = {
       providerId: hasCustomModel ? modelConfig.providerId! : 'openai',
-      modelId: hasCustomModel ? modelConfig.modelId! : 'gpt-5.2-codex',
+      modelId: hasCustomModel ? modelConfig.modelId! : 'gpt-5.4-codex',
     };
   }
 

--- a/docs/how-to-guides/llm-module.md
+++ b/docs/how-to-guides/llm-module.md
@@ -43,7 +43,7 @@ export class MyFeatureLlmService {
 
   async summarize(text: string): Promise<string | null> {
     return await this.openAiResponsesService.generateText({
-      model: 'gpt-5.2',
+      model: 'gpt-5.4',
       prompt: `Summarize the following text in one sentence:\n${text}`,
     });
   }

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -10085,7 +10085,7 @@
           "modelId": {
             "type": "string",
             "description": "Model ID used by the agent runtime",
-            "example": "gpt-5.2-codex"
+            "example": "gpt-5.4"
           },
           "statusTriggers": {
             "type": "array",
@@ -10208,7 +10208,7 @@
             "type": "string",
             "nullable": true,
             "description": "Model ID used by the agent runtime",
-            "example": "gpt-5.2-codex"
+            "example": "gpt-5.4"
           },
           "statusTriggers": {
             "type": "array",
@@ -10546,7 +10546,7 @@
           "modelId": {
             "type": "string",
             "description": "Model ID used by the agent runtime",
-            "example": "gpt-5.2-codex"
+            "example": "gpt-5.4"
           },
           "statusTriggers": {
             "type": "array",

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -4122,7 +4122,7 @@ export interface components {
             providerId?: string;
             /**
              * @description Model ID used by the agent runtime
-             * @example gpt-5.2-codex
+             * @example gpt-5.4
              */
             modelId?: string;
             /**
@@ -4212,7 +4212,7 @@ export interface components {
             providerId?: string | null;
             /**
              * @description Model ID used by the agent runtime
-             * @example gpt-5.2-codex
+             * @example gpt-5.4
              */
             modelId?: string | null;
             /**
@@ -4419,7 +4419,7 @@ export interface components {
             providerId?: string;
             /**
              * @description Model ID used by the agent runtime
-             * @example gpt-5.2-codex
+             * @example gpt-5.4
              */
             modelId?: string;
             /**


### PR DESCRIPTION
## Summary
- Replaced `gpt-5.2-codex` with `gpt-5.4-codex` as the default model in 5 locations