### PR TITLE
Add AI Providers settings page with usage links

### DIFF
--- a/apps/ui/src/features/home/HomeRoutes.tsx
+++ b/apps/ui/src/features/home/HomeRoutes.tsx
@@ -9,6 +9,7 @@ import { SettingsProjectsPage } from "./SettingsProjectsPage";
 import { SettingsChatPage } from "./SettingsChatPage";
 import { SettingsDataPage } from './SettingsDataPage';
 import { SettingsWorkersPage } from './SettingsWorkersPage';
+import { SettingsAIProvidersPage } from './SettingsAIProvidersPage';
 import { WalkthroughPage } from '../walkthrough/WalkthroughPage';
 
 export function HomeRoutes() {
@@ -23,6 +24,7 @@ export function HomeRoutes() {
           <Route path="/settings/projects" element={<SettingsProjectsPage />} />
           <Route path="/settings/chat" element={<SettingsChatPage />} />
           <Route path="/settings/workers" element={<SettingsWorkersPage />} />
+          <Route path="/settings/ai-providers" element={<SettingsAIProvidersPage />} />
           <Route path="/settings/data" element={<SettingsDataPage />} />
           <Route path="/walkthrough" element={<WalkthroughPage />} />
         </Route>

--- a/apps/ui/src/features/home/SettingsAIProvidersPage.css
+++ b/apps/ui/src/features/home/SettingsAIProvidersPage.css
@@ -1,0 +1,2 @@
+/* Placeholder for future AI Providers page styles */
+/* Currently using shared primitives and tokens */

--- a/apps/ui/src/features/home/SettingsAIProvidersPage.tsx
+++ b/apps/ui/src/features/home/SettingsAIProvidersPage.tsx
@@ -22,22 +22,19 @@ export function SettingsAIProvidersPage() {
         <Stack spacing="4">
           <Row justify="space-between" align="center">
             <Stack spacing="1">
-              <Text size="4" weight="semibold">Anthropic</Text>
+              <Text size="4" weight="semibold">OpenAI</Text>
               <Text size="1" tone="muted">
-                Claude models usage and quota tracking
+                Codex and GPT models
               </Text>
             </Stack>
           </Row>
 
           <Stack spacing="2">
-            <Text size="2" tone="muted">
-              Monitor your Claude API usage, quotas, and billing information
-            </Text>
             <Row spacing="2">
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => window.open('https://claude.ai/settings/usage', '_blank', 'noopener,noreferrer')}
+                onClick={() => window.open('https://chatgpt.com/codex/cloud/settings/usage', '_blank', 'noopener,noreferrer')}
               >
                 See usage
               </Button>
@@ -46,26 +43,24 @@ export function SettingsAIProvidersPage() {
         </Stack>
       </Card>
 
+
       <Card padding="5">
         <Stack spacing="4">
           <Row justify="space-between" align="center">
             <Stack spacing="1">
-              <Text size="4" weight="semibold">OpenAI</Text>
+              <Text size="4" weight="semibold">Anthropic</Text>
               <Text size="1" tone="muted">
-                ChatGPT and GPT models usage tracking
+                Claude models
               </Text>
             </Stack>
           </Row>
 
           <Stack spacing="2">
-            <Text size="2" tone="muted">
-              View your OpenAI API usage, limits, and subscription details
-            </Text>
             <Row spacing="2">
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => window.open('https://chatgpt.com/codex/cloud/settings/usage', '_blank', 'noopener,noreferrer')}
+                onClick={() => window.open('https://claude.ai/settings/usage', '_blank', 'noopener,noreferrer')}
               >
                 See usage
               </Button>

--- a/apps/ui/src/features/home/SettingsAIProvidersPage.tsx
+++ b/apps/ui/src/features/home/SettingsAIProvidersPage.tsx
@@ -1,0 +1,78 @@
+import { Stack, Text, Card, Button, Row } from '../../ui/primitives';
+import { useHomeCtx } from './HomeProvider';
+import { useEffect } from 'react';
+import { useDocumentTitle } from '../../shared/hooks/useDocumentTitle';
+import './SettingsAIProvidersPage.css';
+
+export function SettingsAIProvidersPage() {
+  const { setSectionTitle } = useHomeCtx();
+
+  // Set document title (browser tab)
+  useDocumentTitle();
+
+  useEffect(() => {
+    setSectionTitle('AI Providers');
+  }, []);
+
+  return (
+    <Stack spacing="6">
+      <Text tone="muted">View usage and quota information for AI providers</Text>
+
+      <Card padding="5">
+        <Stack spacing="4">
+          <Row justify="space-between" align="center">
+            <Stack spacing="1">
+              <Text size="4" weight="semibold">Anthropic</Text>
+              <Text size="1" tone="muted">
+                Claude models usage and quota tracking
+              </Text>
+            </Stack>
+          </Row>
+
+          <Stack spacing="2">
+            <Text size="2" tone="muted">
+              Monitor your Claude API usage, quotas, and billing information
+            </Text>
+            <Row spacing="2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => window.open('https://claude.ai/settings/usage', '_blank', 'noopener,noreferrer')}
+              >
+                See usage
+              </Button>
+            </Row>
+          </Stack>
+        </Stack>
+      </Card>
+
+      <Card padding="5">
+        <Stack spacing="4">
+          <Row justify="space-between" align="center">
+            <Stack spacing="1">
+              <Text size="4" weight="semibold">OpenAI</Text>
+              <Text size="1" tone="muted">
+                ChatGPT and GPT models usage tracking
+              </Text>
+            </Stack>
+          </Row>
+
+          <Stack spacing="2">
+            <Text size="2" tone="muted">
+              View your OpenAI API usage, limits, and subscription details
+            </Text>
+            <Row spacing="2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => window.open('https://chatgpt.com/codex/cloud/settings/usage', '_blank', 'noopener,noreferrer')}
+              >
+                See usage
+              </Button>
+            </Row>
+          </Stack>
+        </Stack>
+      </Card>
+    </Stack>
+  );
+}

--- a/apps/ui/src/features/home/SettingsPage.tsx
+++ b/apps/ui/src/features/home/SettingsPage.tsx
@@ -190,7 +190,7 @@ export function SettingsPage() {
               size="sm"
               onClick={() => navigate('/settings/ai-providers')}
             >
-              View Usage
+              Settings
             </Button>
           </Row>
         </Stack>

--- a/apps/ui/src/features/home/SettingsPage.tsx
+++ b/apps/ui/src/features/home/SettingsPage.tsx
@@ -58,6 +58,13 @@ export function SettingsPage() {
         onSelect: () => navigate('/settings/workers'),
       },
       {
+        id: 'settings-ai-providers',
+        label: 'AI Providers',
+        description: 'View usage and quota for AI providers',
+        aliases: ['ai', 'providers', 'usage', 'quota', 'anthropic', 'openai', 'claude'],
+        onSelect: () => navigate('/settings/ai-providers'),
+      },
+      {
         id: 'settings-data',
         label: 'Import / Export',
         description: 'Import and export workspace data',
@@ -165,6 +172,25 @@ export function SettingsPage() {
               onClick={() => navigate('/settings/workers')}
             >
               Manage Workers
+            </Button>
+          </Row>
+        </Stack>
+      </Card>
+
+      <Card padding="5">
+        <Stack spacing="3">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">AI Providers</Text>
+            <Text tone="muted">View usage and quota for AI providers</Text>
+          </Stack>
+          <Row justify="space-between" align="center">
+            <Text size="2" tone="muted">Monitor Anthropic and OpenAI usage</Text>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => navigate('/settings/ai-providers')}
+            >
+              View Usage
             </Button>
           </Row>
         </Stack>


### PR DESCRIPTION
## Summary
- Added new "AI Providers" settings page to help users monitor AI subscription quotas
- Provides quick access to Anthropic (Claude) and OpenAI usage dashboards
- Integrated with command palette for easy navigation

## Changes
- Created `SettingsAIProvidersPage` component with provider cards
- Added route `/settings/ai-providers` 
- Added navigation card in main Settings page
- Registered command palette shortcuts

## Problem Solved
Users had no way to check their AI quota consumption. AI subscriptions have ~5 hour windows and weekly quotas that can be easily exhausted. This page provides direct links to:
- Claude usage: https://claude.ai/settings/usage
- OpenAI usage: https://chatgpt.com/codex/cloud/settings/usage

## Implementation Notes
Kept it simple for now with external links only. The page is extensible for future features like:
- OAuth subscriptions management
- Model configuration
- Usage graphs/analytics

## Test Plan
- [x] Ran `npm run build:dev` - build successful
- [x] Ran `npm run dev:1` - app starts correctly
- [x] New page accessible at `/settings/ai-providers`
- [x] Links open correct external dashboards
- [x] Command palette includes new shortcuts
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)