### PR TITLE
Add context block and thread titles to browser tabs

### DIFF
--- a/apps/ui/src/features/context/ContextBlockDetailPage.tsx
+++ b/apps/ui/src/features/context/ContextBlockDetailPage.tsx
@@ -12,6 +12,7 @@ import './ContextBlockDetailPage.css';
 import Markdown from 'marked-react';
 import { DeleteWithConfirmation } from '../../ui/components';
 import { useIsDesktop } from '../../app/hooks/useIsDesktop';
+import { useDocumentTitle } from '../../shared/hooks/useDocumentTitle';
 
 function normalizeParentId(parentId: { id?: string } | string | null | undefined): string | null {
   if (typeof parentId === 'string') {
@@ -41,6 +42,9 @@ export function ContextBlockDetailPage() {
   // State for thread detection
   const [threadId, setThreadId] = useState<string | null>(null);
   const [isCheckingThread, setIsCheckingThread] = useState(false);
+
+  // Set browser tab title
+  useDocumentTitle(block ? { contextBlock: { title: block.title } } : undefined);
 
   useEffect(() => {
     if (block) {

--- a/apps/ui/src/features/threads/ThreadDetailPage.tsx
+++ b/apps/ui/src/features/threads/ThreadDetailPage.tsx
@@ -24,6 +24,7 @@ import { ThreadTaskRow } from "./ThreadTaskRow";
 import { ThreadChat } from "./ThreadChat";
 import { TaskStatus, TASKS_STATUS } from "../../shared/const/taskStatus";
 import { ThreadNavItemsForThreadId, THREADS_NAVEGATION_ITEMS } from "./const";
+import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
 
 type ThreadTask = Thread["tasks"][number];
 type DisplayContextBlock = {
@@ -160,6 +161,9 @@ export function ThreadDetailPage() {
   const threadTaskIdsRef = useRef<Set<string>>(new Set());
 
   const { setNavItems } = useThreadsCtx();
+
+  // Set browser tab title
+  useDocumentTitle(thread ? { thread: { title: thread.title } } : undefined);
 
   const refreshThread = useCallback(async () => {
     if (!threadId) return;

--- a/apps/ui/src/shared/hooks/useDocumentTitle.ts
+++ b/apps/ui/src/shared/hooks/useDocumentTitle.ts
@@ -5,6 +5,8 @@ interface RouteData {
   task?: { name?: string };
   agent?: { name?: string };
   tool?: { name?: string };
+  thread?: { title?: string };
+  contextBlock?: { title?: string };
 }
 
 /**
@@ -34,6 +36,13 @@ export function useDocumentTitle(routeData?: RouteData) {
     else if (path.startsWith('/tasks')) {
       title = '🧩 tasks';
     }
+    // Context block detail page
+    else if (path.match(/\/context\/block\/.+/) && routeData?.contextBlock?.title) {
+      const blockTitle = routeData.contextBlock.title;
+      // Trim if too long (max 50 chars)
+      const trimmedTitle = blockTitle.length > 50 ? blockTitle.substring(0, 50) + '...' : blockTitle;
+      title = `🧱 ${trimmedTitle}`;
+    }
     // Context blocks view
     else if (path.startsWith('/context')) {
       title = '🧱 context';
@@ -57,6 +66,13 @@ export function useDocumentTitle(routeData?: RouteData) {
     // Tools view
     else if (path.startsWith('/tools')) {
       title = '🧰 tools';
+    }
+    // Thread detail page
+    else if (path.match(/\/threads\/.+/) && routeData?.thread?.title) {
+      const threadTitle = routeData.thread.title;
+      // Trim if too long (max 50 chars)
+      const trimmedTitle = threadTitle.length > 50 ? threadTitle.substring(0, 50) + '...' : threadTitle;
+      title = `🧵 ${trimmedTitle}`;
     }
     // Threads view
     else if (path.startsWith('/threads')) {


### PR DESCRIPTION
## Summary
- Updates browser tab titles to show actual context block and thread names instead of generic "🧱 context" and "🧵 threads"
- Extends the `useDocumentTitle` hook to handle context blocks and threads similar to how it handles tasks
- Titles are automatically trimmed to 50 characters max for consistency

## Changes Made
1. Extended `RouteData` interface in `useDocumentTitle.ts` to include `thread` and `contextBlock` fields
2. Added pattern matching for `/context/block/:id` routes to show "🧱 <BLOCK_TITLE>"
3. Added pattern matching for `/threads/:id` routes to show "🧵 <THREAD_TITLE>"
4. Updated `ContextBlockDetailPage.tsx` to pass block title to `useDocumentTitle` hook
5. Updated `ThreadDetailPage.tsx` to pass thread title to `useDocumentTitle` hook

## Test Plan
- ✅ `npm run build:dev` - All packages build successfully
- ✅ `npm run dev` - Application starts without errors
- Manual testing: Navigate to context block and thread detail pages to verify tab titles update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)