### PR TITLE
Add execution interrupt functionality

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -6175,6 +6175,37 @@
         ]
       }
     },
+    "/api/v1/executions/active/{executionId}/interrupt": {
+      "post": {
+        "description": "Signals the worker to abort the currently running agent execution.",
+        "operationId": "ActiveTaskExecutionController_interruptExecution",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to interrupt",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Request interruption of an active execution",
+        "tags": [
+          "Executions"
+        ]
+      }
+    },
     "/api/v1/executions/history": {
       "get": {
         "description": "Returns the persisted execution history rows in the execution system.",
@@ -11847,6 +11878,7 @@
             "description": "Optional error code for failed execution outcomes",
             "enum": [
               "OUT_OF_QUOTA",
+              "INTERRUPTED",
               "UNKNOWN"
             ],
             "nullable": true,
@@ -11940,6 +11972,7 @@
             "description": "Optional failure code when execution ended with an error",
             "enum": [
               "OUT_OF_QUOTA",
+              "INTERRUPTED",
               "UNKNOWN"
             ],
             "nullable": true

--- a/apps/backend/src/executions/active/active-task-execution.controller.ts
+++ b/apps/backend/src/executions/active/active-task-execution.controller.ts
@@ -139,4 +139,31 @@ export class ActiveTaskExecutionController {
       throw error;
     }
   }
+
+  @Post(':executionId/interrupt')
+  @HttpCode(204)
+  @RequireScopes(TasksScopes.WRITE.id)
+  @ApiOperation({
+    summary: 'Request interruption of an active execution',
+    description:
+      'Signals the worker to abort the currently running agent execution.',
+  })
+  @ApiParam({ name: 'executionId', description: 'Execution ID to interrupt' })
+  async interruptExecution(
+    @Param('executionId') executionId: string,
+    @CurrentAuth() auth: AuthContext,
+  ): Promise<void> {
+    try {
+      await this.activeTaskExecutionService.interruptExecution(
+        { executionId },
+        auth.subject,
+      );
+    } catch (error) {
+      if (error instanceof ActiveTaskExecutionNotFoundError) {
+        throw new NotFoundException(error.message);
+      }
+
+      throw error;
+    }
+  }
 }

--- a/apps/backend/src/executions/active/active-task-execution.service.ts
+++ b/apps/backend/src/executions/active/active-task-execution.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   ActiveTaskExecutionEntity,
   type ActiveTaskExecutionTagSnapshot,
@@ -20,6 +21,7 @@ import {
   TaskExecutionQueueEntryNotFoundError,
 } from '../errors/executions.errors';
 import { ExecutionActivityService } from '../execution-activity.service';
+import { ExecutionInterruptEvent } from '../events/execution-interrupt.event';
 
 export type ClaimTaskExecutionInput = {
   taskId: string;
@@ -43,6 +45,10 @@ export type IncrementToolCallCountInput = {
   executionId: string;
 };
 
+export type InterruptExecutionInput = {
+  executionId: string;
+};
+
 @Injectable()
 export class ActiveTaskExecutionService {
   constructor(
@@ -50,6 +56,7 @@ export class ActiveTaskExecutionService {
     private readonly activeTaskExecutionRepository: Repository<ActiveTaskExecutionEntity>,
     private readonly dataSource: DataSource,
     private readonly executionActivityService: ExecutionActivityService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async listActiveExecutions(): Promise<ActiveTaskExecutionEntity[]> {
@@ -248,5 +255,39 @@ export class ActiveTaskExecutionService {
     if ((result.affected ?? 0) === 0) {
       throw new ActiveTaskExecutionNotFoundError(input.executionId);
     }
+  }
+
+  async interruptExecution(
+    input: InterruptExecutionInput,
+    actorId: string,
+  ): Promise<void> {
+    const execution = await this.activeTaskExecutionRepository.findOne({
+      where: { id: input.executionId },
+    });
+
+    if (!execution) {
+      throw new ActiveTaskExecutionNotFoundError(input.executionId);
+    }
+
+    // Emit internal event that will be picked up by the gateway
+    this.eventEmitter.emit(
+      ExecutionInterruptEvent.INTERNAL,
+      new ExecutionInterruptEvent(
+        { id: actorId },
+        {
+          executionId: execution.id,
+          workerClientId: execution.workerClientId,
+        },
+      ),
+    );
+
+    // Publish activity for visibility
+    this.executionActivityService.publishSystemActivity({
+      executionId: execution.id,
+      taskId: execution.taskId,
+      agentActorId: execution.agentActorId,
+      kind: 'execution.interrupt.requested',
+      message: 'Execution interrupt requested',
+    });
   }
 }

--- a/apps/backend/src/executions/events/execution-interrupt.event.ts
+++ b/apps/backend/src/executions/events/execution-interrupt.event.ts
@@ -1,0 +1,15 @@
+export type ExecutionInterruptPayload = {
+  executionId: string;
+  workerClientId: string;
+};
+
+export class ExecutionInterruptEvent {
+  static readonly INTERNAL = Symbol('executions.ExecutionInterruptEvent');
+
+  readonly occurredAt: Date = new Date();
+
+  constructor(
+    public readonly actor: { id: string },
+    public readonly payload: ExecutionInterruptPayload,
+  ) {}
+}

--- a/apps/backend/src/executions/executions-worker.gateway.ts
+++ b/apps/backend/src/executions/executions-worker.gateway.ts
@@ -17,6 +17,7 @@ import {
   type PostExecutionHeartbeatPayload,
   type PostExecutionActivityPayload,
   type TaskExecutionQueuedWireEvent,
+  type ExecutionInterruptRequestWireEvent,
 } from '@taico/events';
 import { WsAccessTokenGuard } from '../auth/guards/guards/ws-access-token-guard';
 import { WsScopesGuard } from '../auth/guards/guards/ws-scopes.guard';
@@ -30,6 +31,7 @@ import { AccessTokenValidationService } from '../auth/guards/validation/access-t
 import { tokenFromHeaders } from '../auth/guards/extractors/token-header.extractor';
 import { tokenFromCookies } from '../auth/guards/extractors/token-cookie.extractor';
 import { TaskExecutionQueuedEvent } from './queue/task-execution-queued.event';
+import { ExecutionInterruptEvent } from './events/execution-interrupt.event';
 
 const SOCKET_AUTH_EXPIRY_SKEW_MS = 1_000;
 
@@ -50,6 +52,7 @@ export class ExecutionsWorkerGateway
   private readonly logger = new Logger(ExecutionsWorkerGateway.name);
   private readonly socketExpiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly harnessReportRequestedSocketIds = new Set<string>();
+  private readonly workerSocketsByClientId = new Map<string, Set<string>>();
 
   constructor(
     private readonly executionActivityService: ExecutionActivityService,
@@ -75,6 +78,16 @@ export class ExecutionsWorkerGateway
 
   handleConnection(client: Socket) {
     this.logger.log(`Worker client connected: ${client.id}`);
+
+    // Track socket by worker client ID
+    const oauthClientId = this.getOauthClientId(client);
+    if (oauthClientId) {
+      if (!this.workerSocketsByClientId.has(oauthClientId)) {
+        this.workerSocketsByClientId.set(oauthClientId, new Set());
+      }
+      this.workerSocketsByClientId.get(oauthClientId)!.add(client.id);
+    }
+
     void this.recordAuthenticatedWorkerSeen(client).catch((error: unknown) => {
       this.logger.warn({
         message: 'Failed to record worker connection liveness',
@@ -88,6 +101,18 @@ export class ExecutionsWorkerGateway
     this.logger.log(`Worker client disconnected: ${client.id}`);
     this.clearTokenExpiryDisconnect(client.id);
     this.harnessReportRequestedSocketIds.delete(client.id);
+
+    // Remove socket from worker tracking
+    const oauthClientId = this.getOauthClientId(client);
+    if (oauthClientId) {
+      const sockets = this.workerSocketsByClientId.get(oauthClientId);
+      if (sockets) {
+        sockets.delete(client.id);
+        if (sockets.size === 0) {
+          this.workerSocketsByClientId.delete(oauthClientId);
+        }
+      }
+    }
   }
 
   @SubscribeMessage(ExecutionWireEvents.EXECUTION_ACTIVITY_POST)
@@ -278,5 +303,33 @@ export class ExecutionsWorkerGateway
     this.logger.debug(
       `Emitted ${ExecutionWireEvents.TASK_EXECUTION_QUEUED} for task ${event.taskId} to all workers`,
     );
+  }
+
+  @OnEvent(ExecutionInterruptEvent.INTERNAL)
+  handleExecutionInterrupt(event: ExecutionInterruptEvent) {
+    const wireEvent: ExecutionInterruptRequestWireEvent = {
+      executionId: event.payload.executionId,
+      requestedAt: event.occurredAt.toISOString(),
+    };
+
+    // Find the worker socket(s) for this worker client ID
+    const socketIds = this.workerSocketsByClientId.get(event.payload.workerClientId);
+    if (!socketIds || socketIds.size === 0) {
+      this.logger.warn(
+        `No connected sockets found for worker ${event.payload.workerClientId} when interrupting execution ${event.payload.executionId}`,
+      );
+      return;
+    }
+
+    // Emit to all sockets for this worker
+    for (const socketId of socketIds) {
+      const socket = this.server.sockets.sockets.get(socketId);
+      if (socket) {
+        socket.emit(ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST, wireEvent);
+        this.logger.log(
+          `Emitted ${ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST} for execution ${event.payload.executionId} to worker socket ${socketId}`,
+        );
+      }
+    }
   }
 }

--- a/apps/backend/src/executions/history/task-execution-history-error-code.enum.ts
+++ b/apps/backend/src/executions/history/task-execution-history-error-code.enum.ts
@@ -1,4 +1,5 @@
 export enum TaskExecutionHistoryErrorCode {
   OUT_OF_QUOTA = 'OUT_OF_QUOTA',
+  INTERRUPTED = 'INTERRUPTED',
   UNKNOWN = 'UNKNOWN',
 }

--- a/apps/worker/src/execution-activity-gateway-client.ts
+++ b/apps/worker/src/execution-activity-gateway-client.ts
@@ -4,6 +4,7 @@ import {
   type PostExecutionActivityPayload,
   type PostExecutionHeartbeatPayload,
   type TaskExecutionQueuedWireEvent,
+  type ExecutionInterruptRequestWireEvent,
 } from '@taico/events';
 import { WorkerAuth } from './auth/worker-auth.js';
 
@@ -27,6 +28,7 @@ export type ExecutionActivityGatewayClientOptions = {
   randomizationFactor?: number;
   tokenRefreshSkewMs?: number;
   onTaskQueued?: (event: TaskExecutionQueuedWireEvent) => void;
+  onExecutionInterruptRequest?: (event: ExecutionInterruptRequestWireEvent) => void;
 };
 
 export class ExecutionActivityGatewayClient {
@@ -218,6 +220,13 @@ export class ExecutionActivityGatewayClient {
         console.log('[execution-activity] task queued event received:', event);
       }
       this.options.onTaskQueued?.(event);
+    });
+
+    this.socket.on(ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST, (event: ExecutionInterruptRequestWireEvent) => {
+      if (this.options.debug) {
+        console.log('[execution-activity] execution interrupt request received:', event);
+      }
+      this.options.onExecutionInterruptRequest?.(event);
     });
 
     this.socket.on('connect_error', (err: Error) => {

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -152,7 +152,22 @@ export class ADKAgentRunner extends BaseAgentRunner {
       }
     });
 
+    // Set up abort signal handler if provided
+    // Note: ADK doesn't have native abort support, so we'll break out of the loop
+    let aborted = false;
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener('abort', () => {
+        console.log('[ADKAgentRunner] Abort signal received, will stop processing');
+        aborted = true;
+      });
+    }
+
     for await (const msg of stream) {
+      if (aborted) {
+        console.log('[ADKAgentRunner] Breaking out of message loop due to abort');
+        break;
+      }
+
       if (msg.content?.parts) {
         for (const part of msg.content.parts) {
           if (part.functionCall?.name) {

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -15,6 +15,7 @@ import {
   RuntimeMcpServerConfig,
 } from "./AgentRunner.js";
 import { randomUUID } from "node:crypto";
+import { InterruptedExecutionError } from "../task-execution-errors.js";
 
 class NamespacedTool extends BaseTool {
   constructor(
@@ -184,6 +185,11 @@ export class ADKAgentRunner extends BaseAgentRunner {
     }
 
     await Promise.all(toolsets.map((toolset) => toolset.close()));
+
+    // If we were aborted, throw an error instead of returning success
+    if (aborted) {
+      throw new InterruptedExecutionError('ADK agent execution was interrupted');
+    }
 
     return finalResult;
   }

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -157,6 +157,10 @@ export class ADKAgentRunner extends BaseAgentRunner {
     // Note: ADK doesn't have native abort support, so we'll break out of the loop
     let aborted = false;
     if (ctx.abortSignal) {
+      // Check if already aborted before we even started
+      if (ctx.abortSignal.aborted) {
+        throw new InterruptedExecutionError('ADK agent execution was interrupted before start');
+      }
       ctx.abortSignal.addEventListener('abort', () => {
         console.log('[ADKAgentRunner] Abort signal received, will stop processing');
         aborted = true;

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -86,6 +86,11 @@ export class ADKAgentRunner extends BaseAgentRunner {
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
     onToolCall?: (toolName: string) => void | Promise<void>,
   ): Promise<string> {
+    // Check if already aborted before creating any resources
+    if (ctx.abortSignal?.aborted) {
+      throw new InterruptedExecutionError('ADK agent execution was interrupted before start');
+    }
+
     const formatter = new ADKMessageFormatter(ctx.agentSlug);
 
     let finalResult = '';
@@ -124,78 +129,77 @@ export class ADKAgentRunner extends BaseAgentRunner {
       ),
     );
 
-    await this.preflightToolsets(toolsets, mcpServers);
+    try {
+      await this.preflightToolsets(toolsets, mcpServers);
 
-    const agent = new LlmAgent({
-      name: 'agent',
-      model: this.modelId,
-      description: '',
-      instruction: '',
-      tools: toolsets,
-    });
-
-    const runner = new Runner({
-      appName: 'app-123',
-      agent: agent,
-      sessionService: this.sessionService,
-    });
-
-    const stream = runner.runAsync({
-      userId: session.userId,
-      sessionId: session.id,
-      newMessage: {
-        parts: [
-          {
-            text: ctx.prompt,
-          }
-        ],
-        role: 'user',
-      }
-    });
-
-    // Set up abort signal handler if provided
-    // Note: ADK doesn't have native abort support, so we'll break out of the loop
-    let aborted = false;
-    if (ctx.abortSignal) {
-      // Check if already aborted before we even started
-      if (ctx.abortSignal.aborted) {
-        throw new InterruptedExecutionError('ADK agent execution was interrupted before start');
-      }
-      ctx.abortSignal.addEventListener('abort', () => {
-        console.log('[ADKAgentRunner] Abort signal received, will stop processing');
-        aborted = true;
+      const agent = new LlmAgent({
+        name: 'agent',
+        model: this.modelId,
+        description: '',
+        instruction: '',
+        tools: toolsets,
       });
-    }
 
-    for await (const msg of stream) {
-      if (aborted) {
-        console.log('[ADKAgentRunner] Breaking out of message loop due to abort');
-        break;
+      const runner = new Runner({
+        appName: 'app-123',
+        agent: agent,
+        sessionService: this.sessionService,
+      });
+
+      const stream = runner.runAsync({
+        userId: session.userId,
+        sessionId: session.id,
+        newMessage: {
+          parts: [
+            {
+              text: ctx.prompt,
+            }
+          ],
+          role: 'user',
+        }
+      });
+
+      // Set up abort signal handler if provided
+      // Note: ADK doesn't have native abort support, so we'll break out of the loop
+      let aborted = false;
+      if (ctx.abortSignal) {
+        ctx.abortSignal.addEventListener('abort', () => {
+          console.log('[ADKAgentRunner] Abort signal received, will stop processing');
+          aborted = true;
+        });
       }
 
-      if (msg.content?.parts) {
-        for (const part of msg.content.parts) {
-          if (part.functionCall?.name) {
-            await onToolCall?.(part.functionCall.name);
+      for await (const msg of stream) {
+        if (aborted) {
+          console.log('[ADKAgentRunner] Breaking out of message loop due to abort');
+          break;
+        }
+
+        if (msg.content?.parts) {
+          for (const part of msg.content.parts) {
+            if (part.functionCall?.name) {
+              await onToolCall?.(part.functionCall.name);
+            }
           }
         }
+
+        // map → string
+        const messages = formatter.format(msg);
+        messages.forEach(async (message) => {
+          await emit(message);
+        });
       }
 
-      // map → string
-      const messages = formatter.format(msg);
-      messages.forEach(async (message) => {
-        await emit(message);
-      });
+      // If we were aborted, throw an error instead of returning success
+      if (aborted) {
+        throw new InterruptedExecutionError('ADK agent execution was interrupted');
+      }
+
+      return finalResult;
+    } finally {
+      // Always close toolsets, even if we were interrupted or errored
+      await Promise.all(toolsets.map((toolset) => toolset.close()));
     }
-
-    await Promise.all(toolsets.map((toolset) => toolset.close()));
-
-    // If we were aborted, throw an error instead of returning success
-    if (aborted) {
-      throw new InterruptedExecutionError('ADK agent execution was interrupted');
-    }
-
-    return finalResult;
   }
 
   private toConnectionParams(serverConfig: RuntimeMcpServerConfig) {

--- a/apps/worker/src/runners/AgentRunner.ts
+++ b/apps/worker/src/runners/AgentRunner.ts
@@ -55,6 +55,9 @@ export type AgentRunContext = {
 
   /** Allowed tool list for SDKs that support tool filtering */
   allowedTools?: string[];
+
+  /** Abort signal for cancellation */
+  abortSignal?: AbortSignal;
 };
 
 export type AgentRunCallbacks = {

--- a/apps/worker/src/runners/ClaudeAgentRunner.ts
+++ b/apps/worker/src/runners/ClaudeAgentRunner.ts
@@ -47,6 +47,10 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
     let abortController: AbortController | undefined;
     if (ctx.abortSignal) {
       abortController = new AbortController();
+      // Check if already aborted before we even started
+      if (ctx.abortSignal.aborted) {
+        abortController.abort();
+      }
       ctx.abortSignal.addEventListener('abort', () => {
         abortController?.abort();
       });

--- a/apps/worker/src/runners/ClaudeAgentRunner.ts
+++ b/apps/worker/src/runners/ClaudeAgentRunner.ts
@@ -43,6 +43,15 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
         },
       };
 
+    // Create abort controller if external signal is provided
+    let abortController: AbortController | undefined;
+    if (ctx.abortSignal) {
+      abortController = new AbortController();
+      ctx.abortSignal.addEventListener('abort', () => {
+        abortController?.abort();
+      });
+    }
+
     const stream = query({
       prompt: ctx.prompt,
       options: {
@@ -53,6 +62,7 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
         ...(ctx.options ?? {}),
         mcpServers,
         allowedTools: ctx.allowedTools ?? [...DEFAULT_AGENT_ALLOWED_TOOLS],
+        abortController,
       },
     });
 

--- a/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
@@ -11,6 +11,7 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
   readonly kind = 'githubcopilot';
   private client: CopilotClient | null = null;
   private model: string;
+  private currentSession: any = null;
 
   constructor(modelConfig: AgentModelConfig = {}) {
     super();
@@ -42,6 +43,17 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
           onPermissionRequest: approveAll,
           mcpServers,
         });
+        this.currentSession = session;
+
+        // Set up abort signal handler
+        if (ctx.abortSignal) {
+          ctx.abortSignal.addEventListener('abort', async () => {
+            console.log('[GitHubCopilotAgentRunner] Abort signal received, aborting session');
+            if (this.currentSession) {
+              await this.currentSession.abort();
+            }
+          });
+        }
 
         if (session?.sessionId) {
           await setSession(session.sessionId);

--- a/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
@@ -31,6 +31,11 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
     // Track abort state
     let aborted = false;
 
+    // Check if already aborted before we even started
+    if (ctx.abortSignal?.aborted) {
+      throw new InterruptedExecutionError('GitHub Copilot agent execution was interrupted before start');
+    }
+
     return new Promise(async (resolve, reject) => {
       try {
         // Init client

--- a/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
@@ -6,6 +6,7 @@ import {
   RuntimeMcpServerConfig,
 } from "./AgentRunner.js";
 import { approveAll, CopilotClient, MCPRemoteServerConfig, MCPLocalServerConfig } from "@github/copilot-sdk";
+import { InterruptedExecutionError } from "../task-execution-errors.js";
 
 export class GitHubCopilotAgentRunner extends BaseAgentRunner {
   readonly kind = 'githubcopilot';
@@ -26,6 +27,9 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
     onToolCall?: (toolName: string) => void | Promise<void>,
   ): Promise<string> {
     const agentLabel = ctx.agentSlug ? `@${ctx.agentSlug}` : 'Assistant';
+
+    // Track abort state
+    let aborted = false;
 
     return new Promise(async (resolve, reject) => {
       try {
@@ -49,6 +53,7 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
         if (ctx.abortSignal) {
           ctx.abortSignal.addEventListener('abort', async () => {
             console.log('[GitHubCopilotAgentRunner] Abort signal received, aborting session');
+            aborted = true;
             if (this.currentSession) {
               await this.currentSession.abort();
             }
@@ -69,7 +74,12 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
           if (this.client) {
             await this.client.stop();
           }
-          resolve(lastAssistantMessage);
+          // Check if we were aborted - if so, reject instead of resolve
+          if (aborted) {
+            reject(new InterruptedExecutionError('GitHub Copilot agent execution was interrupted'));
+          } else {
+            resolve(lastAssistantMessage);
+          }
         });
         session.on('assistant.reasoning', (reasoning) => {
           void emit(`💬 ${agentLabel} Thinking... ${reasoning.data.content}`);

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -4,6 +4,7 @@ import { createOpencode, OpencodeClient, TextPartInput } from "@opencode-ai/sdk"
 import { OpencodeAsyncMessageFormatter } from "../formatters/OpencodeMessageFormatter.js";
 import { EXECUTION_ID_HEADER } from "../helpers/config.js";
 import { AgentModelConfig, AgentRunContext, Model } from "./AgentRunner.js";
+import { InterruptedExecutionError } from "../task-execution-errors.js";
 
 type OpenCodeMcpServerConfig =
   | {
@@ -147,10 +148,14 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     const formatter = new OpencodeAsyncMessageFormatter(ctx.agentSlug);
     this.runtimeMcpServers = ctx.mcpServers;
 
+    // Track abort state
+    let aborted = false;
+
     // Set up abort signal handler if provided
     if (ctx.abortSignal) {
       ctx.abortSignal.addEventListener('abort', () => {
         console.log('[OpenCodeAgentRunner] Abort signal received, shutting down');
+        aborted = true;
         this.shutdown();
       });
     }
@@ -236,6 +241,12 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
       }
     } catch (error) {
       console.error(error);
+      // If we were aborted, this is expected - rethrow as interrupted error
+      if (aborted) {
+        throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
+      }
+      // Otherwise rethrow the original error
+      throw error;
     }
     console.log("--------- ENDING EVENT LOOP ---------");
 
@@ -243,6 +254,11 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     this.shutdown();
     this.runtimeMcpServers = undefined;
     console.log('returning final result');
+
+    // If we were aborted (but didn't error), still throw
+    if (aborted) {
+      throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
+    }
 
     return finalResult;
   }

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -147,6 +147,14 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     const formatter = new OpencodeAsyncMessageFormatter(ctx.agentSlug);
     this.runtimeMcpServers = ctx.mcpServers;
 
+    // Set up abort signal handler if provided
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener('abort', () => {
+        console.log('[OpenCodeAgentRunner] Abort signal received, shutting down');
+        this.shutdown();
+      });
+    }
+
     // Start client
     await this.initBullshit({
       executionId: ctx.executionId,

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -153,6 +153,10 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
 
     // Set up abort signal handler if provided
     if (ctx.abortSignal) {
+      // Check if already aborted before we even started
+      if (ctx.abortSignal.aborted) {
+        throw new InterruptedExecutionError('OpenCode agent execution was interrupted before start');
+      }
       ctx.abortSignal.addEventListener('abort', () => {
         console.log('[OpenCodeAgentRunner] Abort signal received, shutting down');
         aborted = true;

--- a/apps/worker/src/task-execution-errors.ts
+++ b/apps/worker/src/task-execution-errors.ts
@@ -1,6 +1,6 @@
-export type ExecutionFailureKind = 'retryable' | 'terminal' | 'cancelled';
+export type ExecutionFailureKind = 'retryable' | 'terminal' | 'cancelled' | 'interrupted';
 
-export type ExecutionErrorCode = 'OUT_OF_QUOTA' | 'UNKNOWN';
+export type ExecutionErrorCode = 'OUT_OF_QUOTA' | 'INTERRUPTED' | 'UNKNOWN';
 
 const MAX_ERROR_MESSAGE_LENGTH = 1000;
 
@@ -70,6 +70,12 @@ export class TaskExecutionPreconditionError extends TerminalExecutionError {}
 
 export class StopRequestedError extends CancelledExecutionError {}
 
+export class InterruptedExecutionError extends TaskExecutionError {
+  constructor(message = 'Execution was interrupted.', cause?: unknown) {
+    super(message, 'interrupted', 'INTERRUPTED', cause);
+  }
+}
+
 export function classifyAgentError(input: {
   message: string;
   rawMessage?: unknown;
@@ -84,6 +90,13 @@ export function classifyAgentError(input: {
 export function classifyRunnerError(error: unknown): TaskExecutionError {
   if (error instanceof TaskExecutionError) {
     return error;
+  }
+
+  // Check if it's an abort error
+  if (error instanceof Error) {
+    if (error.name === 'AbortError' || error.message.includes('aborted')) {
+      return new InterruptedExecutionError(error.message, error);
+    }
   }
 
   return new RunnerProcessError(

--- a/apps/worker/src/task-picker.ts
+++ b/apps/worker/src/task-picker.ts
@@ -30,7 +30,7 @@ export async function pickTask({
   );
 
   let stopStatus: 'SUCCEEDED' | 'FAILED' | 'CANCELLED' = 'SUCCEEDED';
-  let stopErrorCode: 'OUT_OF_QUOTA' | 'UNKNOWN' | undefined;
+  let stopErrorCode: 'OUT_OF_QUOTA' | 'INTERRUPTED' | 'UNKNOWN' | undefined;
   let stopErrorMessage: string | undefined;
 
   try {
@@ -44,9 +44,19 @@ export async function pickTask({
     });
   } catch (error) {
     if (error instanceof TaskExecutionError) {
-      stopStatus = error.kind === 'cancelled' ? 'CANCELLED' : 'FAILED';
-      stopErrorCode = error.kind === 'cancelled' ? undefined : error.errorCode;
-      stopErrorMessage = error.displayMessage;
+      if (error.kind === 'interrupted') {
+        stopStatus = 'CANCELLED';
+        stopErrorCode = 'INTERRUPTED';
+        stopErrorMessage = error.displayMessage;
+      } else if (error.kind === 'cancelled') {
+        stopStatus = 'CANCELLED';
+        stopErrorCode = undefined;
+        stopErrorMessage = error.displayMessage;
+      } else {
+        stopStatus = 'FAILED';
+        stopErrorCode = error.errorCode;
+        stopErrorMessage = error.displayMessage;
+      }
     } else {
       stopStatus = 'FAILED';
       stopErrorCode = 'UNKNOWN';

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -18,6 +18,7 @@ import {
   classifyAgentError,
   classifyRunnerError,
 } from './task-execution-errors.js';
+import { activeExecutionAbortControllers } from './worker-app.js';
 
 type ExecuteTaskParams = {
   taskId: string;
@@ -41,6 +42,10 @@ export async function executeTask({
   inputRequest,
 }: ExecuteTaskParams): Promise<void> {
   console.log(`[worker] Starting execution ${executionId} for task ${taskId}.`);
+
+  // Create and register abort controller for this execution
+  const abortController = new AbortController();
+  activeExecutionAbortControllers.set(executionId, abortController);
 
   // Get the task
   const task = await workerClient.task.TasksController_getTask({ id: taskId });
@@ -142,6 +147,7 @@ export async function executeTask({
         agentSlug: agent.slug,
         mcpServers: runtimeMcpServers,
         allowedTools,
+        abortSignal: abortController.signal,
       },
       {
         onHeartbeat: async () => {
@@ -194,6 +200,9 @@ export async function executeTask({
     );
   } catch (error) {
     throw classifyRunnerError(error);
+  } finally {
+    // Clean up abort controller
+    activeExecutionAbortControllers.delete(executionId);
   }
 }
 

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -47,95 +47,97 @@ export async function executeTask({
   const abortController = new AbortController();
   activeExecutionAbortControllers.set(executionId, abortController);
 
-  // Get the task
-  const task = await workerClient.task.TasksController_getTask({ id: taskId });
-  // TODO: We should validate dependencies are clear
-
-  // Get the agent assigned to the task
-  const actor = task.assigneeActor;
-  if (!actor?.slug) {
-    throw new TaskExecutionPreconditionError(
-      `Task ${task.id} is not assigned or is missing an assignee slug.`,
-    );
-  }
-  const agent = await workerClient.agent.AgentsController_getAgentBySlug({ slug: actor.slug });
-  if (!agent) {
-    throw new TaskExecutionPreconditionError(
-      `Assigned agent @${actor.slug} was not found for task ${task.id}.`,
-    );
-  }
-
-  // See if the task needs a repo cloned
-  let repoUrl: string | undefined = undefined;
-  const projectTag = task.tags?.find((tag) => tag.name.startsWith('project:'));
-  if (projectTag) {
-    const projectSlug = projectTag.name.replace('project:', '');
-    const project = await workerClient.metaProjects.ProjectsController_getProjectBySlug({ slug: projectSlug });
-    if (project) {
-      repoUrl = project.repoUrl;
-    }
-  }
-
-  // Prepare the workspace
-  const workDir = await prepareWorkspace({
-    taskId,
-    agentId: agent.actorId,
-    baseDir,
-    repoUrl: repoUrl,
-  });
-
-  const thread = await workerClient.threads.ThreadsController_getThreadByTaskId({ taskId });
-
-  const permissions =
-    await workerClient.agent.AgentToolPermissionsController_listAgentToolPermissions({
-      actorId: agent.actorId,
-    });
-  const serversById = await fetchMcpServersById(workerClient, permissions);
-  const runtimeMcpServers = buildRuntimeMcpServers(
-    permissions,
-    serversById,
-    executionId,
-  );
-  const allowedTools = deriveAllowedToolsFromProvidedIds(
-    Object.keys(runtimeMcpServers),
-  );
-
-  // Get an access token for the agent
-  const agentToken = await workerClient.agentExecutionTokens.AgentExecutionTokensController_requestExecutionToken({
-    slug: agent.slug,
-    body: {
-      expirationSeconds: 60 * 60, // 1 hour? what's a sensible ttl?
-    }
-  });
-
-  attachRuntimeAuthHeaders(runtimeMcpServers, agentToken.token);
-
-  // Create runner
-  let runner: BaseAgentRunner | null = null;
-  const modelConfig: AgentModelConfig = {
-    providerId: agent.providerId ?? undefined,
-    modelId: agent.modelId ?? undefined,
-  };
-  if (agent.type === 'claude') {
-    runner = new ClaudeAgentRunner(modelConfig);
-  } else if (agent.type === 'opencode') {
-    runner = new OpencodeAgentRunner(modelConfig);
-  } else if (agent.type === 'adk') {
-    runner = new ADKAgentRunner(modelConfig);
-  } else if (agent.type === 'githubcopilot') {
-    runner = new GitHubCopilotAgentRunner(modelConfig);
-  }
-
-  if (!runner) {
-    throw new UnsupportedAgentTypeError(
-      `Agent type "${agent.type}" is not supported by this worker.`,
-    );
-  }
-
-  // Run and pipe results
+  // Wrap entire execution in try/finally to ensure cleanup
   try {
-    let latestRunnerSessionId: string | null = null;
-    await runner.run(
+    // Get the task
+    const task = await workerClient.task.TasksController_getTask({ id: taskId });
+    // TODO: We should validate dependencies are clear
+
+    // Get the agent assigned to the task
+    const actor = task.assigneeActor;
+    if (!actor?.slug) {
+      throw new TaskExecutionPreconditionError(
+        `Task ${task.id} is not assigned or is missing an assignee slug.`,
+      );
+    }
+    const agent = await workerClient.agent.AgentsController_getAgentBySlug({ slug: actor.slug });
+    if (!agent) {
+      throw new TaskExecutionPreconditionError(
+        `Assigned agent @${actor.slug} was not found for task ${task.id}.`,
+      );
+    }
+
+    // See if the task needs a repo cloned
+    let repoUrl: string | undefined = undefined;
+    const projectTag = task.tags?.find((tag) => tag.name.startsWith('project:'));
+    if (projectTag) {
+      const projectSlug = projectTag.name.replace('project:', '');
+      const project = await workerClient.metaProjects.ProjectsController_getProjectBySlug({ slug: projectSlug });
+      if (project) {
+        repoUrl = project.repoUrl;
+      }
+    }
+
+    // Prepare the workspace
+    const workDir = await prepareWorkspace({
+      taskId,
+      agentId: agent.actorId,
+      baseDir,
+      repoUrl: repoUrl,
+    });
+
+    const thread = await workerClient.threads.ThreadsController_getThreadByTaskId({ taskId });
+
+    const permissions =
+      await workerClient.agent.AgentToolPermissionsController_listAgentToolPermissions({
+        actorId: agent.actorId,
+      });
+    const serversById = await fetchMcpServersById(workerClient, permissions);
+    const runtimeMcpServers = buildRuntimeMcpServers(
+      permissions,
+      serversById,
+      executionId,
+    );
+    const allowedTools = deriveAllowedToolsFromProvidedIds(
+      Object.keys(runtimeMcpServers),
+    );
+
+    // Get an access token for the agent
+    const agentToken = await workerClient.agentExecutionTokens.AgentExecutionTokensController_requestExecutionToken({
+      slug: agent.slug,
+      body: {
+        expirationSeconds: 60 * 60, // 1 hour? what's a sensible ttl?
+      }
+    });
+
+    attachRuntimeAuthHeaders(runtimeMcpServers, agentToken.token);
+
+    // Create runner
+    let runner: BaseAgentRunner | null = null;
+    const modelConfig: AgentModelConfig = {
+      providerId: agent.providerId ?? undefined,
+      modelId: agent.modelId ?? undefined,
+    };
+    if (agent.type === 'claude') {
+      runner = new ClaudeAgentRunner(modelConfig);
+    } else if (agent.type === 'opencode') {
+      runner = new OpencodeAgentRunner(modelConfig);
+    } else if (agent.type === 'adk') {
+      runner = new ADKAgentRunner(modelConfig);
+    } else if (agent.type === 'githubcopilot') {
+      runner = new GitHubCopilotAgentRunner(modelConfig);
+    }
+
+    if (!runner) {
+      throw new UnsupportedAgentTypeError(
+        `Agent type "${agent.type}" is not supported by this worker.`,
+      );
+    }
+
+    // Run and pipe results
+    try {
+      let latestRunnerSessionId: string | null = null;
+      await runner.run(
       {
         taskId,
         prompt: buildPrompt(task, agent, mode, inputRequest, thread),
@@ -198,10 +200,11 @@ export async function executeTask({
         }
       }
     );
-  } catch (error) {
-    throw classifyRunnerError(error);
+    } catch (error) {
+      throw classifyRunnerError(error);
+    }
   } finally {
-    // Clean up abort controller
+    // Clean up abort controller - this now runs no matter where we fail
     activeExecutionAbortControllers.delete(executionId);
   }
 }

--- a/apps/worker/src/worker-app.ts
+++ b/apps/worker/src/worker-app.ts
@@ -4,6 +4,9 @@ import { WorkerAuth } from './auth/worker-auth.js';
 import { runTaskClaimWorker, attemptClaimTask } from './task-claim-worker.js';
 import { ExecutionActivityGatewayClient } from './execution-activity-gateway-client.js';
 
+// Global map to track active execution abort controllers
+export const activeExecutionAbortControllers = new Map<string, AbortController>();
+
 const STARTUP_RETRY_DELAY_MS = 2_000;
 
 export type WorkerOptions = {
@@ -61,6 +64,16 @@ export async function startWorkerApp(options: WorkerOptions): Promise<void> {
         auth.serverUrl,
         activityGatewayClient,
       );
+    },
+    onExecutionInterruptRequest: (event) => {
+      console.log(`[worker] Received interrupt request for execution ${event.executionId}`);
+      const abortController = activeExecutionAbortControllers.get(event.executionId);
+      if (abortController) {
+        console.log(`[worker] Aborting execution ${event.executionId}`);
+        abortController.abort();
+      } else {
+        console.warn(`[worker] No active execution found for ${event.executionId}`);
+      }
     },
   });
 

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -6175,6 +6175,37 @@
         ]
       }
     },
+    "/api/v1/executions/active/{executionId}/interrupt": {
+      "post": {
+        "description": "Signals the worker to abort the currently running agent execution.",
+        "operationId": "ActiveTaskExecutionController_interruptExecution",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to interrupt",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Request interruption of an active execution",
+        "tags": [
+          "Executions"
+        ]
+      }
+    },
     "/api/v1/executions/history": {
       "get": {
         "description": "Returns the persisted execution history rows in the execution system.",
@@ -11847,6 +11878,7 @@
             "description": "Optional error code for failed execution outcomes",
             "enum": [
               "OUT_OF_QUOTA",
+              "INTERRUPTED",
               "UNKNOWN"
             ],
             "nullable": true,
@@ -11940,6 +11972,7 @@
             "description": "Optional failure code when execution ended with an error",
             "enum": [
               "OUT_OF_QUOTA",
+              "INTERRUPTED",
               "UNKNOWN"
             ],
             "nullable": true

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -1800,6 +1800,26 @@ export interface paths {
         patch: operations["ActiveTaskExecutionController_incrementToolCallCount"];
         trace?: never;
     };
+    "/api/v1/executions/active/{executionId}/interrupt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request interruption of an active execution
+         * @description Signals the worker to abort the currently running agent execution.
+         */
+        post: operations["ActiveTaskExecutionController_interruptExecution"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/executions/history": {
         parameters: {
             query?: never;
@@ -5306,7 +5326,7 @@ export interface components {
              * @example OUT_OF_QUOTA
              * @enum {string|null}
              */
-            errorCode?: "OUT_OF_QUOTA" | "UNKNOWN" | null;
+            errorCode?: "OUT_OF_QUOTA" | "INTERRUPTED" | "UNKNOWN" | null;
             /**
              * @description Optional human-readable error message for failed or cancelled executions
              * @example ADK runner failed: 429 quota exceeded.
@@ -5373,7 +5393,7 @@ export interface components {
              * @description Optional failure code when execution ended with an error
              * @enum {string|null}
              */
-            errorCode: "OUT_OF_QUOTA" | "UNKNOWN" | null;
+            errorCode: "OUT_OF_QUOTA" | "INTERRUPTED" | "UNKNOWN" | null;
             /**
              * @description Optional human-readable error message for failed or cancelled executions
              * @example ADK runner failed: 429 quota exceeded.
@@ -10063,6 +10083,26 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Execution ID to update */
+                executionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ActiveTaskExecutionController_interruptExecution: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Execution ID to interrupt */
                 executionId: string;
             };
             cookie?: never;

--- a/packages/client/src/v1/client/models/StopActiveTaskExecutionDto.ts
+++ b/packages/client/src/v1/client/models/StopActiveTaskExecutionDto.ts
@@ -31,6 +31,7 @@ export namespace StopActiveTaskExecutionDto {
      */
     export enum errorCode {
         OUT_OF_QUOTA = 'OUT_OF_QUOTA',
+        INTERRUPTED = 'INTERRUPTED',
         UNKNOWN = 'UNKNOWN',
     }
 }

--- a/packages/client/src/v1/client/models/TaskExecutionHistoryResponseDto.ts
+++ b/packages/client/src/v1/client/models/TaskExecutionHistoryResponseDto.ts
@@ -80,6 +80,7 @@ export namespace TaskExecutionHistoryResponseDto {
      */
     export enum errorCode {
         OUT_OF_QUOTA = 'OUT_OF_QUOTA',
+        INTERRUPTED = 'INTERRUPTED',
         UNKNOWN = 'UNKNOWN',
     }
 }

--- a/packages/client/src/v1/client/services/ExecutionsService.ts
+++ b/packages/client/src/v1/client/services/ExecutionsService.ts
@@ -121,6 +121,25 @@ export class ExecutionsService {
         });
     }
     /**
+     * Request interruption of an active execution
+     * Signals the worker to abort the currently running agent execution.
+     * @param executionId Execution ID to interrupt
+     * @returns void
+     * @throws ApiError
+     */
+    public static activeTaskExecutionControllerInterruptExecution(
+        executionId: string,
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<void> {
+        return __request(config, {
+            method: 'POST',
+            url: '/api/v1/executions/active/{executionId}/interrupt',
+            path: {
+                'executionId': executionId,
+            },
+        });
+    }
+    /**
      * List task execution history
      * Returns the persisted execution history rows in the execution system.
      * @returns TaskExecutionHistoryResponseDto

--- a/packages/client/src/v2/executions-resource.ts
+++ b/packages/client/src/v2/executions-resource.ts
@@ -36,6 +36,11 @@ export class ExecutionsResource extends BaseClient {
     return this.request('PATCH', `/api/v1/executions/active/${params.executionId}/tool-calls/increment`, { responseType: 'void', signal: params?.signal });
   }
 
+  /** Request interruption of an active execution */
+  async ActiveTaskExecutionController_interruptExecution(params: { executionId: string; signal?: AbortSignal }): Promise<void> {
+    return this.request('POST', `/api/v1/executions/active/${params.executionId}/interrupt`, { responseType: 'void', signal: params?.signal });
+  }
+
   /** List task execution history */
   async TaskExecutionHistoryController_listHistory(params?: { signal?: AbortSignal }): Promise<TaskExecutionHistoryResponseDto[]> {
     return this.request('GET', '/api/v1/executions/history', { signal: params?.signal });

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -970,7 +970,7 @@ export interface ActiveTaskExecutionResponseDto {
 
 export interface StopActiveTaskExecutionDto {
   status: 'SUCCEEDED' | 'FAILED' | 'STALE' | 'CANCELLED';
-  errorCode?: 'OUT_OF_QUOTA' | 'UNKNOWN';
+  errorCode?: 'OUT_OF_QUOTA' | 'INTERRUPTED' | 'UNKNOWN';
   errorMessage?: string | null;
 }
 
@@ -986,7 +986,7 @@ export interface TaskExecutionHistoryResponseDto {
   runnerSessionId: string | null;
   toolCallCount: number;
   status: 'SUCCEEDED' | 'FAILED' | 'STALE' | 'CANCELLED';
-  errorCode: 'OUT_OF_QUOTA' | 'UNKNOWN';
+  errorCode: 'OUT_OF_QUOTA' | 'INTERRUPTED' | 'UNKNOWN';
   errorMessage: string | null;
 }
 

--- a/packages/events/src/types/execution-events.ts
+++ b/packages/events/src/types/execution-events.ts
@@ -25,6 +25,7 @@ export const ExecutionWireEvents = {
   WORKER_HEARTBEAT_POST: 'worker.heartbeat.post',
   WORKER_HARNESSES_REPORT_REQUESTED: 'worker.harnesses.report.requested',
   TASK_EXECUTION_QUEUED: 'task.execution.queued',
+  EXECUTION_INTERRUPT_REQUEST: 'execution.interrupt.request',
 } as const;
 
 export type ExecutionWireEventName =
@@ -126,6 +127,15 @@ export interface TaskExecutionQueuedWireEvent {
 }
 
 /**
+ * Execution interrupt request event
+ * Emitted when a user requests to interrupt/cancel an active execution
+ */
+export interface ExecutionInterruptRequestWireEvent {
+  executionId: string;
+  requestedAt: string;
+}
+
+/**
  * Union type of all execution wire events
  */
 export type ExecutionWireEvent =
@@ -133,7 +143,8 @@ export type ExecutionWireEvent =
   | ExecutionUpdatedWireEvent
   | ExecutionDeletedWireEvent
   | ExecutionActivityWireEvent
-  | TaskExecutionQueuedWireEvent;
+  | TaskExecutionQueuedWireEvent
+  | ExecutionInterruptRequestWireEvent;
 
 /**
  * Type guards for event identification


### PR DESCRIPTION
## Summary
- Implements the ability to interrupt/cancel running agent executions from the UI
- Backend API endpoint to request execution interrupts
- WebSocket-based real-time interrupt signaling to workers
- Agent runner support for abort signals (Claude, OpenCode, GitHub Copilot, ADK)

## Backend Changes
- Added `INTERRUPTED` error code to execution history
- Created interrupt endpoint: `POST /executions/active/:executionId/interrupt`
- Gateway tracks worker sockets and routes interrupt events to specific workers
- Internal event system for pub/sub between service and gateway

## Worker Changes
- Global abort controller registry for active executions
- All agent runners updated to handle abort signals gracefully
- New error type: `InterruptedExecutionError` for proper status tracking
- Executions marked as `CANCELLED` with `INTERRUPTED` error code

## Agent Runner Support
- **Claude**: Native abort controller support via SDK
- **OpenCode**: Calls `shutdown()` method on abort
- **GitHub Copilot**: Calls `session.abort()` method
- **ADK**: Breaks out of message loop (lacks native abort support)

## Technical Debt
- ADK runner doesn't have native abort support, so it breaks the loop which may not clean up resources optimally
- UI interrupt button not implemented (backend/worker ready for it)

## Test Plan
- [x] `npm run build:dev` passes
- [x] `npm run dev` starts successfully
- [ ] Manual test: Start an execution, call interrupt endpoint, verify execution stops
- [ ] Verify interrupted executions show up in history with correct status

🤖 Generated with [Claude Code](https://claude.com/claude-code)