### PR TITLE
feat: Add UI for interrupting active executions

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -6175,6 +6175,37 @@
         ]
       }
     },
+    "/api/v1/executions/active/{executionId}/interrupt": {
+      "post": {
+        "description": "Signals the worker to abort the currently running agent execution.",
+        "operationId": "ActiveTaskExecutionController_interruptExecution",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to interrupt",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Request interruption of an active execution",
+        "tags": [
+          "Executions"
+        ]
+      }
+    },
     "/api/v1/executions/history": {
       "get": {
         "description": "Returns the persisted execution history rows in the execution system.",
@@ -11847,6 +11878,7 @@
             "description": "Optional error code for failed execution outcomes",
             "enum": [
               "OUT_OF_QUOTA",
+              "INTERRUPTED",
               "UNKNOWN"
             ],
             "nullable": true,
@@ -11940,6 +11972,7 @@
             "description": "Optional failure code when execution ended with an error",
             "enum": [
               "OUT_OF_QUOTA",
+              "INTERRUPTED",
               "UNKNOWN"
             ],
             "nullable": true

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -42,6 +42,7 @@ import { AddExecutionEnrichmentFieldsV21742100000000 } from './migrations/174210
 import { RenameExecutionTables1742200000000 } from './migrations/1742200000000-RenameExecutionTables';
 import { AddWorkersTable1742300000000 } from './migrations/1742300000000-AddWorkersTable';
 import { RenameHasSeenWalkthroughToOnboardingDisplayMode1742400000000 } from './migrations/1742400000000-RenameHasSeenWalkthroughToOnboardingDisplayMode';
+import { AllowInterruptedExecutionErrorCode1742500000000 } from './migrations/1742500000000-AllowInterruptedExecutionErrorCode';
 import { SecretsModule } from './secrets/secrets.module';
 import { ChatProvidersModule } from './chat-providers/chat-providers.module';
 import { ExecutionsModule } from './executions/executions.module';
@@ -82,6 +83,7 @@ import { WalkthroughModule } from './walkthrough/walkthrough.module';
         RenameExecutionTables1742200000000,
         AddWorkersTable1742300000000,
         RenameHasSeenWalkthroughToOnboardingDisplayMode1742400000000,
+        AllowInterruptedExecutionErrorCode1742500000000,
       ],
     }),
     EventEmitterModule.forRoot(),

--- a/apps/backend/src/executions/active/active-task-execution.controller.ts
+++ b/apps/backend/src/executions/active/active-task-execution.controller.ts
@@ -139,4 +139,31 @@ export class ActiveTaskExecutionController {
       throw error;
     }
   }
+
+  @Post(':executionId/interrupt')
+  @HttpCode(204)
+  @RequireScopes(TasksScopes.WRITE.id)
+  @ApiOperation({
+    summary: 'Request interruption of an active execution',
+    description:
+      'Signals the worker to abort the currently running agent execution.',
+  })
+  @ApiParam({ name: 'executionId', description: 'Execution ID to interrupt' })
+  async interruptExecution(
+    @Param('executionId') executionId: string,
+    @CurrentAuth() auth: AuthContext,
+  ): Promise<void> {
+    try {
+      await this.activeTaskExecutionService.interruptExecution(
+        { executionId },
+        auth.subject,
+      );
+    } catch (error) {
+      if (error instanceof ActiveTaskExecutionNotFoundError) {
+        throw new NotFoundException(error.message);
+      }
+
+      throw error;
+    }
+  }
 }

--- a/apps/backend/src/executions/active/active-task-execution.service.ts
+++ b/apps/backend/src/executions/active/active-task-execution.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   ActiveTaskExecutionEntity,
   type ActiveTaskExecutionTagSnapshot,
@@ -20,6 +21,7 @@ import {
   TaskExecutionQueueEntryNotFoundError,
 } from '../errors/executions.errors';
 import { ExecutionActivityService } from '../execution-activity.service';
+import { ExecutionInterruptEvent } from '../events/execution-interrupt.event';
 
 export type ClaimTaskExecutionInput = {
   taskId: string;
@@ -43,6 +45,10 @@ export type IncrementToolCallCountInput = {
   executionId: string;
 };
 
+export type InterruptExecutionInput = {
+  executionId: string;
+};
+
 @Injectable()
 export class ActiveTaskExecutionService {
   constructor(
@@ -50,6 +56,7 @@ export class ActiveTaskExecutionService {
     private readonly activeTaskExecutionRepository: Repository<ActiveTaskExecutionEntity>,
     private readonly dataSource: DataSource,
     private readonly executionActivityService: ExecutionActivityService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async listActiveExecutions(): Promise<ActiveTaskExecutionEntity[]> {
@@ -248,5 +255,39 @@ export class ActiveTaskExecutionService {
     if ((result.affected ?? 0) === 0) {
       throw new ActiveTaskExecutionNotFoundError(input.executionId);
     }
+  }
+
+  async interruptExecution(
+    input: InterruptExecutionInput,
+    actorId: string,
+  ): Promise<void> {
+    const execution = await this.activeTaskExecutionRepository.findOne({
+      where: { id: input.executionId },
+    });
+
+    if (!execution) {
+      throw new ActiveTaskExecutionNotFoundError(input.executionId);
+    }
+
+    // Emit internal event that will be picked up by the gateway
+    this.eventEmitter.emit(
+      ExecutionInterruptEvent.INTERNAL,
+      new ExecutionInterruptEvent(
+        { id: actorId },
+        {
+          executionId: execution.id,
+          workerClientId: execution.workerClientId,
+        },
+      ),
+    );
+
+    // Publish activity for visibility
+    this.executionActivityService.publishSystemActivity({
+      executionId: execution.id,
+      taskId: execution.taskId,
+      agentActorId: execution.agentActorId,
+      kind: 'execution.interrupt.requested',
+      message: 'Execution interrupt requested',
+    });
   }
 }

--- a/apps/backend/src/executions/events/execution-interrupt.event.ts
+++ b/apps/backend/src/executions/events/execution-interrupt.event.ts
@@ -1,0 +1,15 @@
+export type ExecutionInterruptPayload = {
+  executionId: string;
+  workerClientId: string;
+};
+
+export class ExecutionInterruptEvent {
+  static readonly INTERNAL = Symbol('executions.ExecutionInterruptEvent');
+
+  readonly occurredAt: Date = new Date();
+
+  constructor(
+    public readonly actor: { id: string },
+    public readonly payload: ExecutionInterruptPayload,
+  ) {}
+}

--- a/apps/backend/src/executions/executions-worker.gateway.ts
+++ b/apps/backend/src/executions/executions-worker.gateway.ts
@@ -17,6 +17,7 @@ import {
   type PostExecutionHeartbeatPayload,
   type PostExecutionActivityPayload,
   type TaskExecutionQueuedWireEvent,
+  type ExecutionInterruptRequestWireEvent,
 } from '@taico/events';
 import { WsAccessTokenGuard } from '../auth/guards/guards/ws-access-token-guard';
 import { WsScopesGuard } from '../auth/guards/guards/ws-scopes.guard';
@@ -30,6 +31,7 @@ import { AccessTokenValidationService } from '../auth/guards/validation/access-t
 import { tokenFromHeaders } from '../auth/guards/extractors/token-header.extractor';
 import { tokenFromCookies } from '../auth/guards/extractors/token-cookie.extractor';
 import { TaskExecutionQueuedEvent } from './queue/task-execution-queued.event';
+import { ExecutionInterruptEvent } from './events/execution-interrupt.event';
 
 const SOCKET_AUTH_EXPIRY_SKEW_MS = 1_000;
 
@@ -50,6 +52,7 @@ export class ExecutionsWorkerGateway
   private readonly logger = new Logger(ExecutionsWorkerGateway.name);
   private readonly socketExpiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly harnessReportRequestedSocketIds = new Set<string>();
+  private readonly workerSocketsByClientId = new Map<string, Set<string>>();
 
   constructor(
     private readonly executionActivityService: ExecutionActivityService,
@@ -75,6 +78,16 @@ export class ExecutionsWorkerGateway
 
   handleConnection(client: Socket) {
     this.logger.log(`Worker client connected: ${client.id}`);
+
+    // Track socket by worker client ID
+    const oauthClientId = this.getOauthClientId(client);
+    if (oauthClientId) {
+      if (!this.workerSocketsByClientId.has(oauthClientId)) {
+        this.workerSocketsByClientId.set(oauthClientId, new Set());
+      }
+      this.workerSocketsByClientId.get(oauthClientId)!.add(client.id);
+    }
+
     void this.recordAuthenticatedWorkerSeen(client).catch((error: unknown) => {
       this.logger.warn({
         message: 'Failed to record worker connection liveness',
@@ -88,6 +101,18 @@ export class ExecutionsWorkerGateway
     this.logger.log(`Worker client disconnected: ${client.id}`);
     this.clearTokenExpiryDisconnect(client.id);
     this.harnessReportRequestedSocketIds.delete(client.id);
+
+    // Remove socket from worker tracking
+    const oauthClientId = this.getOauthClientId(client);
+    if (oauthClientId) {
+      const sockets = this.workerSocketsByClientId.get(oauthClientId);
+      if (sockets) {
+        sockets.delete(client.id);
+        if (sockets.size === 0) {
+          this.workerSocketsByClientId.delete(oauthClientId);
+        }
+      }
+    }
   }
 
   @SubscribeMessage(ExecutionWireEvents.EXECUTION_ACTIVITY_POST)
@@ -278,5 +303,33 @@ export class ExecutionsWorkerGateway
     this.logger.debug(
       `Emitted ${ExecutionWireEvents.TASK_EXECUTION_QUEUED} for task ${event.taskId} to all workers`,
     );
+  }
+
+  @OnEvent(ExecutionInterruptEvent.INTERNAL)
+  handleExecutionInterrupt(event: ExecutionInterruptEvent) {
+    const wireEvent: ExecutionInterruptRequestWireEvent = {
+      executionId: event.payload.executionId,
+      requestedAt: event.occurredAt.toISOString(),
+    };
+
+    // Find the worker socket(s) for this worker client ID
+    const socketIds = this.workerSocketsByClientId.get(event.payload.workerClientId);
+    if (!socketIds || socketIds.size === 0) {
+      this.logger.warn(
+        `No connected sockets found for worker ${event.payload.workerClientId} when interrupting execution ${event.payload.executionId}`,
+      );
+      return;
+    }
+
+    // Emit to all sockets for this worker
+    for (const socketId of socketIds) {
+      const socket = this.server.sockets.sockets.get(socketId);
+      if (socket) {
+        socket.emit(ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST, wireEvent);
+        this.logger.log(
+          `Emitted ${ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST} for execution ${event.payload.executionId} to worker socket ${socketId}`,
+        );
+      }
+    }
   }
 }

--- a/apps/backend/src/executions/executions-worker.gateway.ts
+++ b/apps/backend/src/executions/executions-worker.gateway.ts
@@ -311,6 +311,9 @@ export class ExecutionsWorkerGateway
       executionId: event.payload.executionId,
       requestedAt: event.occurredAt.toISOString(),
     };
+    this.logger.debug(
+      `Handling interrupt for execution ${event.payload.executionId} requested by actor ${event.actor.id}`,
+    );
 
     // Find the worker socket(s) for this worker client ID
     const socketIds = this.workerSocketsByClientId.get(event.payload.workerClientId);
@@ -321,15 +324,16 @@ export class ExecutionsWorkerGateway
       return;
     }
 
-    // Emit to all sockets for this worker
-    for (const socketId of socketIds) {
-      const socket = this.server.sockets.sockets.get(socketId);
-      if (socket) {
-        socket.emit(ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST, wireEvent);
-        this.logger.log(
-          `Emitted ${ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST} for execution ${event.payload.executionId} to worker socket ${socketId}`,
-        );
-      }
-    }
+    this.logger.debug(
+      `Emitting ${ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST} for execution ${event.payload.executionId} to worker client ${event.payload.workerClientId} on sockets ${[...socketIds].join(',')}`,
+    );
+
+    this.server.to([...socketIds]).emit(ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST, wireEvent);
+    this.logger.log(
+      `Emitted ${ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST} for execution ${event.payload.executionId} to ${socketIds.size} worker socket(s)`,
+    );
+    this.logger.debug(
+      `Finished emitting ${ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST} for execution ${event.payload.executionId} to worker client ${event.payload.workerClientId}`,
+    );
   }
 }

--- a/apps/backend/src/executions/history/task-execution-history-error-code.enum.ts
+++ b/apps/backend/src/executions/history/task-execution-history-error-code.enum.ts
@@ -1,4 +1,5 @@
 export enum TaskExecutionHistoryErrorCode {
   OUT_OF_QUOTA = 'OUT_OF_QUOTA',
+  INTERRUPTED = 'INTERRUPTED',
   UNKNOWN = 'UNKNOWN',
 }

--- a/apps/backend/src/migrations/1742500000000-AllowInterruptedExecutionErrorCode.ts
+++ b/apps/backend/src/migrations/1742500000000-AllowInterruptedExecutionErrorCode.ts
@@ -1,0 +1,133 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AllowInterruptedExecutionErrorCode1742500000000
+  implements MigrationInterface
+{
+  name = 'AllowInterruptedExecutionErrorCode1742500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.rebuildTaskExecutionHistory(queryRunner, true);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE task_execution_history
+      SET error_code = 'UNKNOWN'
+      WHERE error_code = 'INTERRUPTED'
+    `);
+    await this.rebuildTaskExecutionHistory(queryRunner, false);
+  }
+
+  private async rebuildTaskExecutionHistory(
+    queryRunner: QueryRunner,
+    allowInterrupted: boolean,
+  ): Promise<void> {
+    const errorCodes = allowInterrupted
+      ? "'OUT_OF_QUOTA', 'INTERRUPTED', 'UNKNOWN'"
+      : "'OUT_OF_QUOTA', 'UNKNOWN'";
+
+    await queryRunner.query('PRAGMA foreign_keys=off');
+    try {
+      await queryRunner.query(
+        'DROP INDEX IF EXISTS idx_task_execution_history_v2_transitioned_at',
+      );
+      await queryRunner.query(
+        'DROP INDEX IF EXISTS idx_task_execution_history_v2_worker_client_id',
+      );
+      await queryRunner.query(
+        'DROP INDEX IF EXISTS idx_task_execution_history_v2_agent_actor_id',
+      );
+      await queryRunner.query(
+        'DROP INDEX IF EXISTS idx_task_execution_history_v2_task_id',
+      );
+
+      await queryRunner.query(`
+        CREATE TABLE task_execution_history_new (
+          id varchar PRIMARY KEY NOT NULL,
+          task_id text NOT NULL,
+          claimed_at datetime NOT NULL,
+          transitioned_at datetime NOT NULL,
+          agent_actor_id text NOT NULL,
+          worker_client_id text NOT NULL,
+          status text NOT NULL
+            CHECK (status IN ('SUCCEEDED', 'FAILED', 'STALE', 'CANCELLED')),
+          error_code text
+            CHECK (error_code IS NULL OR error_code IN (${errorCodes})),
+          row_version integer NOT NULL DEFAULT 1,
+          created_at datetime NOT NULL DEFAULT (datetime('now')),
+          updated_at datetime NOT NULL DEFAULT (datetime('now')),
+          deleted_at datetime,
+          error_message text,
+          runner_session_id text,
+          tool_call_count integer NOT NULL DEFAULT 0,
+          CONSTRAINT fk_task_execution_history_task_id
+            FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+          CONSTRAINT fk_task_execution_history_agent_actor_id
+            FOREIGN KEY (agent_actor_id) REFERENCES agents(actor_id)
+        )
+      `);
+
+      await queryRunner.query(`
+        INSERT INTO task_execution_history_new (
+          id,
+          task_id,
+          claimed_at,
+          transitioned_at,
+          agent_actor_id,
+          worker_client_id,
+          status,
+          error_code,
+          row_version,
+          created_at,
+          updated_at,
+          deleted_at,
+          error_message,
+          runner_session_id,
+          tool_call_count
+        )
+        SELECT
+          id,
+          task_id,
+          claimed_at,
+          transitioned_at,
+          agent_actor_id,
+          worker_client_id,
+          status,
+          error_code,
+          row_version,
+          created_at,
+          updated_at,
+          deleted_at,
+          error_message,
+          runner_session_id,
+          tool_call_count
+        FROM task_execution_history
+      `);
+
+      await queryRunner.query('DROP TABLE task_execution_history');
+      await queryRunner.query(`
+        ALTER TABLE task_execution_history_new
+        RENAME TO task_execution_history
+      `);
+
+      await queryRunner.query(`
+        CREATE INDEX IF NOT EXISTS idx_task_execution_history_v2_task_id
+        ON task_execution_history (task_id)
+      `);
+      await queryRunner.query(`
+        CREATE INDEX IF NOT EXISTS idx_task_execution_history_v2_agent_actor_id
+        ON task_execution_history (agent_actor_id)
+      `);
+      await queryRunner.query(`
+        CREATE INDEX IF NOT EXISTS idx_task_execution_history_v2_worker_client_id
+        ON task_execution_history (worker_client_id)
+      `);
+      await queryRunner.query(`
+        CREATE INDEX IF NOT EXISTS idx_task_execution_history_v2_transitioned_at
+        ON task_execution_history (transitioned_at)
+      `);
+    } finally {
+      await queryRunner.query('PRAGMA foreign_keys=on');
+    }
+  }
+}

--- a/apps/ui/src/features/executions/ExecutionsPage.css
+++ b/apps/ui/src/features/executions/ExecutionsPage.css
@@ -373,6 +373,13 @@
   gap: var(--space-3);
 }
 
+.executions-mobile-card__actions {
+  display: flex;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--border-subtle);
+}
+
 @media (max-width: 980px) {
   .executions-summary-grid,
   .executions-overview {

--- a/apps/ui/src/features/executions/ExecutionsPage.css
+++ b/apps/ui/src/features/executions/ExecutionsPage.css
@@ -361,6 +361,28 @@
   gap: var(--space-3);
 }
 
+.executions-mobile-card__header--clickable {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  transition: color 0.15s ease;
+}
+
+.executions-mobile-card__header--clickable:hover {
+  color: var(--accent);
+}
+
+.executions-mobile-card__header--clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--r-2);
+}
+
 .executions-mobile-card__body {
   display: grid;
   gap: var(--space-2);

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -586,6 +586,42 @@ function ExecutionMobileCard({
   onClick?: () => void;
   actionButton?: React.ReactNode;
 }) {
+  // When action button exists, render as div to avoid nested interactive elements
+  // Only the header becomes clickable for navigation
+  if (actionButton && onClick) {
+    return (
+      <div className="executions-mobile-card">
+        <button
+          type="button"
+          className="executions-mobile-card__header executions-mobile-card__header--clickable"
+          onClick={onClick}
+          aria-label={`Navigate to task: ${title}`}
+        >
+          <Text as="div" size="3" weight="semibold" wrap>{title}</Text>
+          <StatusPill tone={tone}>{badge}</StatusPill>
+        </button>
+        <div className="executions-mobile-card__body">
+          {lines.map((line) => (
+            <div key={`${badge}-${line.label}`} className="executions-mobile-card__row">
+              <Text as="span" size="1" tone="muted">{line.label}</Text>
+              <Text
+                as="span"
+                size="2"
+                style={line.mono ? "mono" : "sans"}
+                className={line.label === "Error" && line.value !== "None" ? "executions-error-copy" : ""}
+              >
+                {line.value}
+              </Text>
+            </div>
+          ))}
+        </div>
+        <div className="executions-mobile-card__actions">
+          {actionButton}
+        </div>
+      </div>
+    );
+  }
+
   const className = onClick
     ? "executions-mobile-card executions-mobile-card--clickable"
     : "executions-mobile-card";
@@ -611,11 +647,6 @@ function ExecutionMobileCard({
           </div>
         ))}
       </div>
-      {actionButton ? (
-        <div className="executions-mobile-card__actions">
-          {actionButton}
-        </div>
-      ) : null}
     </>
   );
 

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -4,6 +4,8 @@ import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
 import { Button, Card, Text } from "../../ui/primitives";
 import { useActorsCtx } from "../actors";
 import { useExecutions } from "./useExecutions";
+import { ExecutionsService } from "./api";
+import { useToast } from "../../shared/context/ToastContext";
 import type {
   TaskExecutionQueueEntryResponseDto,
   ActiveTaskExecutionResponseDto,
@@ -14,6 +16,7 @@ import "./ExecutionsPage.css";
 export function ExecutionsPage() {
   const navigate = useNavigate();
   const { actors } = useActorsCtx();
+  const { showToast, showError } = useToast();
   const {
     queue,
     active,
@@ -35,6 +38,9 @@ export function ExecutionsPage() {
   const [expandedHistoryIds, setExpandedHistoryIds] = useState<Set<string>>(
     () => new Set(),
   );
+  const [interruptingExecutions, setInterruptingExecutions] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const toggleHistoryMessage = (historyId: string) => {
     setExpandedHistoryIds((prev) => {
@@ -46,6 +52,29 @@ export function ExecutionsPage() {
       }
       return next;
     });
+  };
+
+  const handleInterruptExecution = async (executionId: string, taskName: string | null) => {
+    if (!confirm(`Are you sure you want to interrupt the execution for "${taskName ?? "Untitled task"}"?`)) {
+      return;
+    }
+
+    setInterruptingExecutions((prev) => new Set(prev).add(executionId));
+
+    try {
+      await ExecutionsService.ActiveTaskExecutionController_interruptExecution({ executionId });
+      showToast(`Interrupt signal sent for "${taskName ?? "Untitled task"}"`);
+      // Refresh executions to show updated state
+      await loadExecutions();
+    } catch (err) {
+      showError(err);
+    } finally {
+      setInterruptingExecutions((prev) => {
+        const next = new Set(prev);
+        next.delete(executionId);
+        return next;
+      });
+    }
   };
 
   return (
@@ -133,9 +162,10 @@ export function ExecutionsPage() {
             emptyMessage="No active executions right now."
             table={
               <ExecutionTable
-                columns={["State", "Task", "Worker", "Agent", "Session", "Tools", "Claimed", "Latest heartbeat", "Before claim"]}
+                columns={["State", "Task", "Worker", "Agent", "Session", "Tools", "Claimed", "Latest heartbeat", "Before claim", "Actions"]}
                 rows={active.map((entry) => {
                   const actor = actors.find((candidate) => candidate.id === entry.agentActorId);
+                  const isInterrupting = interruptingExecutions.has(entry.id);
 
                   return {
                     key: entry.id,
@@ -156,6 +186,15 @@ export function ExecutionsPage() {
                     <StatusPill key="before" tone={taskStatusTone(entry.taskStatusBeforeClaim)}>
                       {entry.taskStatusBeforeClaim}
                     </StatusPill>,
+                    <Button
+                      key="interrupt"
+                      variant="danger"
+                      size="sm"
+                      disabled={isInterrupting}
+                      onClick={() => void handleInterruptExecution(entry.id, entry.taskName)}
+                    >
+                      {isInterrupting ? "Interrupting…" : "Interrupt"}
+                    </Button>,
                     ],
                     mobile: (
                     <ExecutionMobileCard
@@ -172,6 +211,16 @@ export function ExecutionsPage() {
                         { label: "Tool calls", value: String(entry.toolCallCount) },
                         { label: "Before claim", value: entry.taskStatusBeforeClaim },
                       ]}
+                      actionButton={
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          disabled={isInterrupting}
+                          onClick={() => void handleInterruptExecution(entry.id, entry.taskName)}
+                        >
+                          {isInterrupting ? "Interrupting…" : "Interrupt"}
+                        </Button>
+                      }
                       onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
                     />
                     ),
@@ -528,12 +577,14 @@ function ExecutionMobileCard({
   tone,
   lines,
   onClick,
+  actionButton,
 }: {
   title: string;
   badge: string;
   tone: "accent" | "warning" | "success" | "danger";
   lines: Array<{ label: string; value: string; mono?: boolean }>;
   onClick?: () => void;
+  actionButton?: React.ReactNode;
 }) {
   const className = onClick
     ? "executions-mobile-card executions-mobile-card--clickable"
@@ -560,6 +611,11 @@ function ExecutionMobileCard({
           </div>
         ))}
       </div>
+      {actionButton ? (
+        <div className="executions-mobile-card__actions">
+          {actionButton}
+        </div>
+      ) : null}
     </>
   );
 

--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -905,7 +905,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
             execution.status === 'FAILED' && Boolean(execution.errorCode || execution.errorMessage);
           const isFailureDetailsExpanded = expandedExecutionErrorIds.has(execution.id);
           const isActive = execution.source === 'active';
-          const isInterrupting = interruptingExecutions.has(execution.id);
+          const isInterrupting = interruptingExecutions.has(execution.executionId);
           const sourceTag: DataRowTag = {
             label: isActive ? 'active' : 'history',
             color: 'gray',

--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -264,6 +264,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
   const [isLoadingExecutions, setIsLoadingExecutions] = useState(false);
   const [executionsError, setExecutionsError] = useState<string | null>(null);
   const [expandedExecutionErrorIds, setExpandedExecutionErrorIds] = useState<Set<string>>(new Set());
+  const [interruptingExecutions, setInterruptingExecutions] = useState<Set<string>>(new Set());
 
   const [showNewCommentPop, setShowNewCommentPop] = useState(false);
   const [showAssignPop, setShowAssignPop] = useState(false);
@@ -282,6 +283,27 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
       return next;
     });
   }, []);
+
+  const handleInterruptExecution = useCallback(async (executionId: string, taskName: string | undefined, taskId: string) => {
+    if (!confirm(`Are you sure you want to interrupt the active execution for "${taskName ?? "this task"}"?`)) {
+      return;
+    }
+
+    setInterruptingExecutions((prev) => new Set(prev).add(executionId));
+
+    try {
+      await ExecutionsService.ActiveTaskExecutionController_interruptExecution({ executionId });
+      showToast(`Interrupt signal sent for "${taskName ?? "this task"}"`);
+    } catch (err) {
+      showError(err);
+    } finally {
+      setInterruptingExecutions((prev) => {
+        const next = new Set(prev);
+        next.delete(executionId);
+        return next;
+      });
+    }
+  }, [showToast, showError]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -882,8 +904,10 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
           const hasFailureDetails =
             execution.status === 'FAILED' && Boolean(execution.errorCode || execution.errorMessage);
           const isFailureDetailsExpanded = expandedExecutionErrorIds.has(execution.id);
+          const isActive = execution.source === 'active';
+          const isInterrupting = interruptingExecutions.has(execution.id);
           const sourceTag: DataRowTag = {
-            label: execution.source === 'active' ? 'active' : 'history',
+            label: isActive ? 'active' : 'history',
             color: 'gray',
           };
 
@@ -892,7 +916,20 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
               key={execution.id}
               leading={<Avatar size={'sm'} name={actorName} src={actor?.avatarUrl || undefined} />}
               tags={[statusTag, sourceTag]}
-              topRight={<Text size='1' tone='muted'>{elapsedTime(execution.timestamp)}</Text>}
+              topRight={
+                isActive ? (
+                  <Button
+                    variant='danger'
+                    size='sm'
+                    disabled={isInterrupting}
+                    onClick={() => void handleInterruptExecution(execution.executionId, task?.name, task?.id ?? '')}
+                  >
+                    {isInterrupting ? 'Interrupting…' : 'Interrupt'}
+                  </Button>
+                ) : (
+                  <Text size='1' tone='muted'>{elapsedTime(execution.timestamp)}</Text>
+                )
+              }
             >
               <Stack spacing='1'>
                 <div>
@@ -925,6 +962,12 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
                     tools: {execution.toolCallCount}
                     <span className='task-detail-page__execution-stats-separator'>|</span>
                     session: {execution.runnerSessionId ? shortId(execution.runnerSessionId) : 'pending'}
+                    {isActive ? (
+                      <>
+                        <span className='task-detail-page__execution-stats-separator'>|</span>
+                        {elapsedTime(execution.timestamp)}
+                      </>
+                    ) : null}
                   </span>
                 </Text>
                 {hasFailureDetails && isFailureDetailsExpanded ? (

--- a/apps/worker/src/execution-activity-gateway-client.ts
+++ b/apps/worker/src/execution-activity-gateway-client.ts
@@ -4,6 +4,7 @@ import {
   type PostExecutionActivityPayload,
   type PostExecutionHeartbeatPayload,
   type TaskExecutionQueuedWireEvent,
+  type ExecutionInterruptRequestWireEvent,
 } from '@taico/events';
 import { WorkerAuth } from './auth/worker-auth.js';
 
@@ -27,6 +28,7 @@ export type ExecutionActivityGatewayClientOptions = {
   randomizationFactor?: number;
   tokenRefreshSkewMs?: number;
   onTaskQueued?: (event: TaskExecutionQueuedWireEvent) => void;
+  onExecutionInterruptRequest?: (event: ExecutionInterruptRequestWireEvent) => void;
 };
 
 export class ExecutionActivityGatewayClient {
@@ -218,6 +220,13 @@ export class ExecutionActivityGatewayClient {
         console.log('[execution-activity] task queued event received:', event);
       }
       this.options.onTaskQueued?.(event);
+    });
+
+    this.socket.on(ExecutionWireEvents.EXECUTION_INTERRUPT_REQUEST, (event: ExecutionInterruptRequestWireEvent) => {
+      if (this.options.debug) {
+        console.log('[execution-activity] execution interrupt request received:', event);
+      }
+      this.options.onExecutionInterruptRequest?.(event);
     });
 
     this.socket.on('connect_error', (err: Error) => {

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -152,7 +152,22 @@ export class ADKAgentRunner extends BaseAgentRunner {
       }
     });
 
+    // Set up abort signal handler if provided
+    // Note: ADK doesn't have native abort support, so we'll break out of the loop
+    let aborted = false;
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener('abort', () => {
+        console.log('[ADKAgentRunner] Abort signal received, will stop processing');
+        aborted = true;
+      });
+    }
+
     for await (const msg of stream) {
+      if (aborted) {
+        console.log('[ADKAgentRunner] Breaking out of message loop due to abort');
+        break;
+      }
+
       if (msg.content?.parts) {
         for (const part of msg.content.parts) {
           if (part.functionCall?.name) {

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -15,6 +15,7 @@ import {
   RuntimeMcpServerConfig,
 } from "./AgentRunner.js";
 import { randomUUID } from "node:crypto";
+import { InterruptedExecutionError } from "../task-execution-errors.js";
 
 class NamespacedTool extends BaseTool {
   constructor(
@@ -184,6 +185,11 @@ export class ADKAgentRunner extends BaseAgentRunner {
     }
 
     await Promise.all(toolsets.map((toolset) => toolset.close()));
+
+    // If we were aborted, throw an error instead of returning success
+    if (aborted) {
+      throw new InterruptedExecutionError('ADK agent execution was interrupted');
+    }
 
     return finalResult;
   }

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -157,6 +157,10 @@ export class ADKAgentRunner extends BaseAgentRunner {
     // Note: ADK doesn't have native abort support, so we'll break out of the loop
     let aborted = false;
     if (ctx.abortSignal) {
+      // Check if already aborted before we even started
+      if (ctx.abortSignal.aborted) {
+        throw new InterruptedExecutionError('ADK agent execution was interrupted before start');
+      }
       ctx.abortSignal.addEventListener('abort', () => {
         console.log('[ADKAgentRunner] Abort signal received, will stop processing');
         aborted = true;

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -86,6 +86,11 @@ export class ADKAgentRunner extends BaseAgentRunner {
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
     onToolCall?: (toolName: string) => void | Promise<void>,
   ): Promise<string> {
+    // Check if already aborted before creating any resources
+    if (ctx.abortSignal?.aborted) {
+      throw new InterruptedExecutionError('ADK agent execution was interrupted before start');
+    }
+
     const formatter = new ADKMessageFormatter(ctx.agentSlug);
 
     let finalResult = '';
@@ -124,78 +129,77 @@ export class ADKAgentRunner extends BaseAgentRunner {
       ),
     );
 
-    await this.preflightToolsets(toolsets, mcpServers);
+    try {
+      await this.preflightToolsets(toolsets, mcpServers);
 
-    const agent = new LlmAgent({
-      name: 'agent',
-      model: this.modelId,
-      description: '',
-      instruction: '',
-      tools: toolsets,
-    });
-
-    const runner = new Runner({
-      appName: 'app-123',
-      agent: agent,
-      sessionService: this.sessionService,
-    });
-
-    const stream = runner.runAsync({
-      userId: session.userId,
-      sessionId: session.id,
-      newMessage: {
-        parts: [
-          {
-            text: ctx.prompt,
-          }
-        ],
-        role: 'user',
-      }
-    });
-
-    // Set up abort signal handler if provided
-    // Note: ADK doesn't have native abort support, so we'll break out of the loop
-    let aborted = false;
-    if (ctx.abortSignal) {
-      // Check if already aborted before we even started
-      if (ctx.abortSignal.aborted) {
-        throw new InterruptedExecutionError('ADK agent execution was interrupted before start');
-      }
-      ctx.abortSignal.addEventListener('abort', () => {
-        console.log('[ADKAgentRunner] Abort signal received, will stop processing');
-        aborted = true;
+      const agent = new LlmAgent({
+        name: 'agent',
+        model: this.modelId,
+        description: '',
+        instruction: '',
+        tools: toolsets,
       });
-    }
 
-    for await (const msg of stream) {
-      if (aborted) {
-        console.log('[ADKAgentRunner] Breaking out of message loop due to abort');
-        break;
+      const runner = new Runner({
+        appName: 'app-123',
+        agent: agent,
+        sessionService: this.sessionService,
+      });
+
+      const stream = runner.runAsync({
+        userId: session.userId,
+        sessionId: session.id,
+        newMessage: {
+          parts: [
+            {
+              text: ctx.prompt,
+            }
+          ],
+          role: 'user',
+        }
+      });
+
+      // Set up abort signal handler if provided
+      // Note: ADK doesn't have native abort support, so we'll break out of the loop
+      let aborted = false;
+      if (ctx.abortSignal) {
+        ctx.abortSignal.addEventListener('abort', () => {
+          console.log('[ADKAgentRunner] Abort signal received, will stop processing');
+          aborted = true;
+        });
       }
 
-      if (msg.content?.parts) {
-        for (const part of msg.content.parts) {
-          if (part.functionCall?.name) {
-            await onToolCall?.(part.functionCall.name);
+      for await (const msg of stream) {
+        if (aborted) {
+          console.log('[ADKAgentRunner] Breaking out of message loop due to abort');
+          break;
+        }
+
+        if (msg.content?.parts) {
+          for (const part of msg.content.parts) {
+            if (part.functionCall?.name) {
+              await onToolCall?.(part.functionCall.name);
+            }
           }
         }
+
+        // map → string
+        const messages = formatter.format(msg);
+        messages.forEach(async (message) => {
+          await emit(message);
+        });
       }
 
-      // map → string
-      const messages = formatter.format(msg);
-      messages.forEach(async (message) => {
-        await emit(message);
-      });
+      // If we were aborted, throw an error instead of returning success
+      if (aborted) {
+        throw new InterruptedExecutionError('ADK agent execution was interrupted');
+      }
+
+      return finalResult;
+    } finally {
+      // Always close toolsets, even if we were interrupted or errored
+      await Promise.all(toolsets.map((toolset) => toolset.close()));
     }
-
-    await Promise.all(toolsets.map((toolset) => toolset.close()));
-
-    // If we were aborted, throw an error instead of returning success
-    if (aborted) {
-      throw new InterruptedExecutionError('ADK agent execution was interrupted');
-    }
-
-    return finalResult;
   }
 
   private toConnectionParams(serverConfig: RuntimeMcpServerConfig) {

--- a/apps/worker/src/runners/AgentRunner.ts
+++ b/apps/worker/src/runners/AgentRunner.ts
@@ -55,6 +55,9 @@ export type AgentRunContext = {
 
   /** Allowed tool list for SDKs that support tool filtering */
   allowedTools?: string[];
+
+  /** Abort signal for cancellation */
+  abortSignal?: AbortSignal;
 };
 
 export type AgentRunCallbacks = {

--- a/apps/worker/src/runners/AgentRunner.ts
+++ b/apps/worker/src/runners/AgentRunner.ts
@@ -86,6 +86,8 @@ export type AgentRunResult = {
 export interface AgentRunner {
   readonly kind: string;
 
+  cancel?(): void | Promise<void>;
+
   run(
     ctx: AgentRunContext,
     cb?: AgentRunCallbacks

--- a/apps/worker/src/runners/BaseAgentRunner.ts
+++ b/apps/worker/src/runners/BaseAgentRunner.ts
@@ -8,6 +8,10 @@ export abstract class BaseAgentRunner implements AgentRunner {
 
   abstract readonly kind: string;
 
+  cancel(): void | Promise<void> {
+    return undefined;
+  }
+
   async run(
     ctx: AgentRunContext,
     cb: AgentRunCallbacks = BaseAgentRunner.DEFAULT_CALLBACKS

--- a/apps/worker/src/runners/ClaudeAgentRunner.ts
+++ b/apps/worker/src/runners/ClaudeAgentRunner.ts
@@ -47,6 +47,10 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
     let abortController: AbortController | undefined;
     if (ctx.abortSignal) {
       abortController = new AbortController();
+      // Check if already aborted before we even started
+      if (ctx.abortSignal.aborted) {
+        abortController.abort();
+      }
       ctx.abortSignal.addEventListener('abort', () => {
         abortController?.abort();
       });

--- a/apps/worker/src/runners/ClaudeAgentRunner.ts
+++ b/apps/worker/src/runners/ClaudeAgentRunner.ts
@@ -43,6 +43,15 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
         },
       };
 
+    // Create abort controller if external signal is provided
+    let abortController: AbortController | undefined;
+    if (ctx.abortSignal) {
+      abortController = new AbortController();
+      ctx.abortSignal.addEventListener('abort', () => {
+        abortController?.abort();
+      });
+    }
+
     const stream = query({
       prompt: ctx.prompt,
       options: {
@@ -53,6 +62,7 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
         ...(ctx.options ?? {}),
         mcpServers,
         allowedTools: ctx.allowedTools ?? [...DEFAULT_AGENT_ALLOWED_TOOLS],
+        abortController,
       },
     });
 

--- a/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
@@ -11,6 +11,7 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
   readonly kind = 'githubcopilot';
   private client: CopilotClient | null = null;
   private model: string;
+  private currentSession: any = null;
 
   constructor(modelConfig: AgentModelConfig = {}) {
     super();
@@ -42,6 +43,17 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
           onPermissionRequest: approveAll,
           mcpServers,
         });
+        this.currentSession = session;
+
+        // Set up abort signal handler
+        if (ctx.abortSignal) {
+          ctx.abortSignal.addEventListener('abort', async () => {
+            console.log('[GitHubCopilotAgentRunner] Abort signal received, aborting session');
+            if (this.currentSession) {
+              await this.currentSession.abort();
+            }
+          });
+        }
 
         if (session?.sessionId) {
           await setSession(session.sessionId);

--- a/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
@@ -31,6 +31,11 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
     // Track abort state
     let aborted = false;
 
+    // Check if already aborted before we even started
+    if (ctx.abortSignal?.aborted) {
+      throw new InterruptedExecutionError('GitHub Copilot agent execution was interrupted before start');
+    }
+
     return new Promise(async (resolve, reject) => {
       try {
         // Init client

--- a/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
+++ b/apps/worker/src/runners/GitHubCopilotAgentRunner.ts
@@ -6,6 +6,7 @@ import {
   RuntimeMcpServerConfig,
 } from "./AgentRunner.js";
 import { approveAll, CopilotClient, MCPRemoteServerConfig, MCPLocalServerConfig } from "@github/copilot-sdk";
+import { InterruptedExecutionError } from "../task-execution-errors.js";
 
 export class GitHubCopilotAgentRunner extends BaseAgentRunner {
   readonly kind = 'githubcopilot';
@@ -26,6 +27,9 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
     onToolCall?: (toolName: string) => void | Promise<void>,
   ): Promise<string> {
     const agentLabel = ctx.agentSlug ? `@${ctx.agentSlug}` : 'Assistant';
+
+    // Track abort state
+    let aborted = false;
 
     return new Promise(async (resolve, reject) => {
       try {
@@ -49,6 +53,7 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
         if (ctx.abortSignal) {
           ctx.abortSignal.addEventListener('abort', async () => {
             console.log('[GitHubCopilotAgentRunner] Abort signal received, aborting session');
+            aborted = true;
             if (this.currentSession) {
               await this.currentSession.abort();
             }
@@ -69,7 +74,12 @@ export class GitHubCopilotAgentRunner extends BaseAgentRunner {
           if (this.client) {
             await this.client.stop();
           }
-          resolve(lastAssistantMessage);
+          // Check if we were aborted - if so, reject instead of resolve
+          if (aborted) {
+            reject(new InterruptedExecutionError('GitHub Copilot agent execution was interrupted'));
+          } else {
+            resolve(lastAssistantMessage);
+          }
         });
         session.on('assistant.reasoning', (reasoning) => {
           void emit(`💬 ${agentLabel} Thinking... ${reasoning.data.content}`);

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -4,6 +4,7 @@ import { createOpencode, OpencodeClient, TextPartInput } from "@opencode-ai/sdk"
 import { OpencodeAsyncMessageFormatter } from "../formatters/OpencodeMessageFormatter.js";
 import { EXECUTION_ID_HEADER } from "../helpers/config.js";
 import { AgentModelConfig, AgentRunContext, Model } from "./AgentRunner.js";
+import { InterruptedExecutionError } from "../task-execution-errors.js";
 
 type OpenCodeMcpServerConfig =
   | {
@@ -147,10 +148,14 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     const formatter = new OpencodeAsyncMessageFormatter(ctx.agentSlug);
     this.runtimeMcpServers = ctx.mcpServers;
 
+    // Track abort state
+    let aborted = false;
+
     // Set up abort signal handler if provided
     if (ctx.abortSignal) {
       ctx.abortSignal.addEventListener('abort', () => {
         console.log('[OpenCodeAgentRunner] Abort signal received, shutting down');
+        aborted = true;
         this.shutdown();
       });
     }
@@ -236,6 +241,12 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
       }
     } catch (error) {
       console.error(error);
+      // If we were aborted, this is expected - rethrow as interrupted error
+      if (aborted) {
+        throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
+      }
+      // Otherwise rethrow the original error
+      throw error;
     }
     console.log("--------- ENDING EVENT LOOP ---------");
 
@@ -243,6 +254,11 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     this.shutdown();
     this.runtimeMcpServers = undefined;
     console.log('returning final result');
+
+    // If we were aborted (but didn't error), still throw
+    if (aborted) {
+      throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
+    }
 
     return finalResult;
   }

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -147,6 +147,14 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     const formatter = new OpencodeAsyncMessageFormatter(ctx.agentSlug);
     this.runtimeMcpServers = ctx.mcpServers;
 
+    // Set up abort signal handler if provided
+    if (ctx.abortSignal) {
+      ctx.abortSignal.addEventListener('abort', () => {
+        console.log('[OpenCodeAgentRunner] Abort signal received, shutting down');
+        this.shutdown();
+      });
+    }
+
     // Start client
     await this.initBullshit({
       executionId: ctx.executionId,

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -153,6 +153,10 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
 
     // Set up abort signal handler if provided
     if (ctx.abortSignal) {
+      // Check if already aborted before we even started
+      if (ctx.abortSignal.aborted) {
+        throw new InterruptedExecutionError('OpenCode agent execution was interrupted before start');
+      }
       ctx.abortSignal.addEventListener('abort', () => {
         console.log('[OpenCodeAgentRunner] Abort signal received, shutting down');
         aborted = true;

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -1,6 +1,7 @@
 // OpenCodeAgentRunner.ts
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { BaseAgentRunner } from "./BaseAgentRunner.js";
-import { createOpencode, OpencodeClient, TextPartInput } from "@opencode-ai/sdk";
+import { createOpencodeClient, OpencodeClient, TextPartInput } from "@opencode-ai/sdk";
 import { OpencodeAsyncMessageFormatter } from "../formatters/OpencodeMessageFormatter.js";
 import { EXECUTION_ID_HEADER } from "../helpers/config.js";
 import { AgentModelConfig, AgentRunContext, Model } from "./AgentRunner.js";
@@ -19,6 +20,50 @@ type OpenCodeMcpServerConfig =
       enabled: true;
     };
 
+type ManagedOpencodeServer = {
+  client: OpencodeClient;
+  server: {
+    close(): void;
+  };
+};
+
+function stopProcessTree(proc: ChildProcessWithoutNullStreams): void {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return;
+  }
+
+  if (process.platform === 'win32' && proc.pid) {
+    const result = spawnSync('taskkill', ['/pid', String(proc.pid), '/T', '/F'], {
+      windowsHide: true,
+    });
+    if (!result.error && result.status === 0) {
+      return;
+    }
+  }
+
+  if (process.platform !== 'win32' && proc.pid) {
+    try {
+      process.kill(-proc.pid, 'SIGTERM');
+    } catch {
+      proc.kill('SIGTERM');
+    }
+
+    setTimeout(() => {
+      if (proc.exitCode !== null || proc.signalCode !== null || !proc.pid) {
+        return;
+      }
+      try {
+        process.kill(-proc.pid, 'SIGKILL');
+      } catch {
+        proc.kill('SIGKILL');
+      }
+    }, 1_000).unref();
+    return;
+  }
+
+  proc.kill('SIGTERM');
+}
+
 export class OpencodeAgentRunner extends BaseAgentRunner {
   readonly kind = 'opencode';
 
@@ -30,6 +75,11 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
   private abortController: AbortController = new AbortController();
   private close: () => void = () => {};
   private model: Model;
+  private activeSessionId: string | null = null;
+  private activeSessionDirectory: string | null = null;
+  private interruptRequested = false;
+  private abortConfirmed = false;
+  private abortPromise: Promise<boolean> | undefined;
 
   constructor(modelConfig: AgentModelConfig = {}) {
     super();
@@ -88,11 +138,61 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
   }
 
   private shutdown() {
-    // Belt and suspenders: abort signal + close().
-    // close() alone is broken (https://github.com/anomalyco/opencode/issues/3841)
-    // but we keep it for when they fix it.
     this.abortController.abort();
     this.close();
+  }
+
+  private async abortActiveSession(): Promise<boolean> {
+    if (!this.client || !this.activeSessionId) {
+      return false;
+    }
+
+    try {
+      const result = await this.client.session.abort({
+        path: {
+          id: this.activeSessionId,
+        },
+        query: this.activeSessionDirectory
+          ? {
+              directory: this.activeSessionDirectory,
+            }
+          : undefined,
+      });
+
+      if (result.error) {
+        console.warn('[OpenCodeAgentRunner] Failed to abort session:', result.error);
+        return false;
+      }
+
+      return result.data === true;
+    } catch (error) {
+      console.warn('[OpenCodeAgentRunner] Failed to abort session:', error);
+      return false;
+    }
+  }
+
+  cancel(): void {
+    this.requestInterrupt();
+  }
+
+  private requestInterrupt(): void {
+    if (this.interruptRequested) {
+      return;
+    }
+
+    this.interruptRequested = true;
+    console.log('[OpenCodeAgentRunner] Interrupt requested, aborting session');
+    this.abortPromise = this.abortActiveSession().then((confirmed) => {
+      this.abortConfirmed = confirmed;
+      if (confirmed) {
+        this.shutdown();
+      }
+      return confirmed;
+    });
+  }
+
+  private async wasAbortApplied(): Promise<boolean> {
+    return this.abortConfirmed || (this.abortPromise ? await this.abortPromise : false);
   }
 
   async init({
@@ -116,7 +216,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
         console.log(`Trying port ${port}...`);
 
         this.abortController = new AbortController();
-        const opencode = await createOpencode({
+        const opencode = await this.createManagedOpencode({
           port,
           timeout: 20 * 3600,
           signal: this.abortController.signal,
@@ -138,6 +238,110 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     throw new Error(`Failed to start Opencode on ports ${PORT_START}–${PORT_END}: ${String(lastError)}`);
   }
 
+  private async createManagedOpencode({
+    port,
+    timeout,
+    signal,
+    config,
+  }: {
+    port: number;
+    timeout: number;
+    signal: AbortSignal;
+    config: {
+      mcp: Record<string, OpenCodeMcpServerConfig>;
+    };
+  }): Promise<ManagedOpencodeServer> {
+    const proc = spawn(
+      'opencode',
+      ['serve', '--hostname=127.0.0.1', `--port=${port}`],
+      {
+        detached: process.platform !== 'win32',
+        env: {
+          ...process.env,
+          OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
+        },
+      },
+    );
+    let closed = false;
+    let output = '';
+
+    const close = () => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      stopProcessTree(proc);
+    };
+
+    const clearAbort = () => signal.removeEventListener('abort', close);
+    signal.addEventListener('abort', close, { once: true });
+    proc.once('exit', clearAbort);
+    proc.once('error', clearAbort);
+
+    try {
+      const url = await new Promise<string>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          close();
+          reject(new Error(`Timeout waiting for OpenCode server to start after ${timeout}ms`));
+        }, timeout);
+
+        const fail = (error: unknown) => {
+          clearTimeout(timeoutId);
+          close();
+          reject(error);
+        };
+
+        proc.stdout.on('data', (chunk) => {
+          output += chunk.toString();
+          for (const line of output.split('\n')) {
+            if (!line.startsWith('opencode server listening')) {
+              continue;
+            }
+
+            const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
+            if (!match) {
+              fail(new Error(`Failed to parse OpenCode server url from output: ${line}`));
+              return;
+            }
+
+            clearTimeout(timeoutId);
+            resolve(match[1]);
+            return;
+          }
+        });
+
+        proc.stderr.on('data', (chunk) => {
+          output += chunk.toString();
+        });
+
+        proc.once('exit', (code, signalCode) => {
+          fail(
+            new Error(
+              `OpenCode server exited before startup (code=${code}, signal=${signalCode})${output.trim() ? `\n${output}` : ''}`,
+            ),
+          );
+        });
+        proc.once('error', fail);
+
+        if (signal.aborted) {
+          fail(signal.reason ?? new Error('OpenCode server startup aborted'));
+        }
+      });
+
+      return {
+        client: createOpencodeClient({
+          baseUrl: url,
+        }),
+        server: {
+          close,
+        },
+      };
+    } catch (error) {
+      clearAbort();
+      throw error;
+    }
+  }
+
   protected async runInternal(
     ctx: AgentRunContext,
     emit: (msg: string) => Promise<void>,
@@ -148,85 +352,106 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     const formatter = new OpencodeAsyncMessageFormatter(ctx.agentSlug);
     this.runtimeMcpServers = ctx.mcpServers;
 
-    // Track abort state
-    let aborted = false;
+    let removeAbortListener: (() => void) | undefined;
+    this.interruptRequested = false;
+    this.abortConfirmed = false;
+    this.abortPromise = undefined;
 
-    // Set up abort signal handler if provided
     if (ctx.abortSignal) {
-      // Check if already aborted before we even started
       if (ctx.abortSignal.aborted) {
         throw new InterruptedExecutionError('OpenCode agent execution was interrupted before start');
       }
-      ctx.abortSignal.addEventListener('abort', () => {
-        console.log('[OpenCodeAgentRunner] Abort signal received, shutting down');
-        aborted = true;
-        this.shutdown();
-      });
+
+      const onAbort = () => {
+        this.requestInterrupt();
+      };
+      ctx.abortSignal.addEventListener('abort', onAbort, { once: true });
+      removeAbortListener = () => ctx.abortSignal?.removeEventListener('abort', onAbort);
     }
 
-    // Start client
-    await this.initBullshit({
-      executionId: ctx.executionId,
-      cwd: ctx.cwd,
-      baseUrl: ctx.baseUrl,
-      accessToken: ctx.accessToken,
-    });
-    // await this.init({ executionId: ctx.executionId });
-
-    if (!this.client) {
-      throw new Error("Failed to create Opencode client");
-    }
-
-    // Create a session for this work
-    const { data: session } = await this.client.session.create({
-      body: {
-        title: `Session ${new Date().toLocaleString()}`,
-      },
-      query: {
-        directory: ctx.cwd,
-      },
-
-    });
-    if (!session) {
-      this.shutdown();
-      throw new Error("Failed to create Opencode session");
-    }
-    await setSession(session.id);
-    console.log(`created session ${session.id} in ${session.directory}`);
-    // Session is created in the right dir ✅
-
-    const events = await this.client.event.subscribe(); // SSE stream
-
-    const prompt: TextPartInput = {
-      type: 'text',
-      text: ctx.prompt,
-    }
-    let finalResult = '';
-    this.client.session.promptAsync({
-      path: {
-        id: session.id,
-      },
-      // NOTE: adding a directory breaks realtime events 🤷🏻‍♂️: https://github.com/anomalyco/opencode/issues/11522
-      // NOTE: Good news is we don't need it because the session carries the dir.
-      // NOTE: Acutally we need to. I've implemented a horrible hack to CD before starting the server.
-      // query: {
-      //   directory: ctx.cwd,
-      // },
-      body: {
-        model: {
-          providerID: this.model.providerId,
-          modelID: this.model.modelId,
-        },
-        parts: [prompt],
-      }
-    })
-
-    console.log("--------- STARTING EVENT LOOP ---------");
     try {
+      await this.initBullshit({
+        executionId: ctx.executionId,
+        cwd: ctx.cwd,
+        baseUrl: ctx.baseUrl,
+        accessToken: ctx.accessToken,
+      });
+      // await this.init({ executionId: ctx.executionId });
+
+      if (!this.client) {
+        throw new Error("Failed to create Opencode client");
+      }
+
+      const { data: session } = await this.client.session.create({
+        body: {
+          title: `Session ${new Date().toLocaleString()}`,
+        },
+        query: {
+          directory: ctx.cwd,
+        },
+
+      });
+      if (!session) {
+        throw new Error("Failed to create Opencode session");
+      }
+      this.activeSessionId = session.id;
+      this.activeSessionDirectory = ctx.cwd;
+
+      if (this.interruptRequested) {
+        const confirmed = await this.abortActiveSession();
+        this.abortConfirmed = confirmed;
+        if (confirmed) {
+          this.shutdown();
+        }
+        throw new InterruptedExecutionError('OpenCode agent execution was interrupted before prompt start');
+      }
+
+      await setSession(session.id);
+      console.log(`created session ${session.id} in ${session.directory}`);
+      // Session is created in the right dir ✅
+
+      const events = await this.client.event.subscribe(); // SSE stream
+
+      const prompt: TextPartInput = {
+        type: 'text',
+        text: ctx.prompt,
+      }
+      let finalResult = '';
+      await this.client.session.promptAsync({
+        path: {
+          id: session.id,
+        },
+        // NOTE: adding a directory breaks realtime events 🤷🏻‍♂️: https://github.com/anomalyco/opencode/issues/11522
+        // NOTE: Good news is we don't need it because the session carries the dir.
+        // NOTE: Acutally we need to. I've implemented a horrible hack to CD before starting the server.
+        // query: {
+        //   directory: ctx.cwd,
+        // },
+        body: {
+          model: {
+            providerID: this.model.providerId,
+            modelID: this.model.modelId,
+          },
+          parts: [prompt],
+        }
+      })
+
+      if (this.interruptRequested && await this.wasAbortApplied()) {
+        throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
+      }
+
+      console.log("--------- STARTING EVENT LOOP ---------");
       for await (const event of events.stream) {
+        if (this.interruptRequested && await this.wasAbortApplied()) {
+          throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
+        }
+
         // Detect end of session
         if (event.type == 'session.idle') {
           console.log('session.idle');
+          if (this.interruptRequested && await this.wasAbortApplied()) {
+            throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
+          }
           break;
         }
 
@@ -240,31 +465,31 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
 
         const message = formatter.format(event);
         if (message) {
-          emit(message);
+          await emit(message);
+        }
+
+        if (this.interruptRequested && await this.wasAbortApplied()) {
+          throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
         }
       }
+      console.log("--------- ENDING EVENT LOOP ---------");
+      console.log('returning final result');
+      return finalResult;
     } catch (error) {
-      console.error(error);
-      // If we were aborted, this is expected - rethrow as interrupted error
-      if (aborted) {
+      if (this.interruptRequested && await this.wasAbortApplied()) {
+        console.log('[OpenCodeAgentRunner] Execution interrupted');
         throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
       }
-      // Otherwise rethrow the original error
+      console.error(error);
       throw error;
+    } finally {
+      removeAbortListener?.();
+      console.log('shutting down Opencode client');
+      this.shutdown();
+      this.activeSessionId = null;
+      this.activeSessionDirectory = null;
+      this.runtimeMcpServers = undefined;
     }
-    console.log("--------- ENDING EVENT LOOP ---------");
-
-    console.log('shutting down Opencode client');
-    this.shutdown();
-    this.runtimeMcpServers = undefined;
-    console.log('returning final result');
-
-    // If we were aborted (but didn't error), still throw
-    if (aborted) {
-      throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
-    }
-
-    return finalResult;
   }
 
   private buildMcpConfig({

--- a/apps/worker/src/task-execution-errors.ts
+++ b/apps/worker/src/task-execution-errors.ts
@@ -1,6 +1,6 @@
-export type ExecutionFailureKind = 'retryable' | 'terminal' | 'cancelled';
+export type ExecutionFailureKind = 'retryable' | 'terminal' | 'cancelled' | 'interrupted';
 
-export type ExecutionErrorCode = 'OUT_OF_QUOTA' | 'UNKNOWN';
+export type ExecutionErrorCode = 'OUT_OF_QUOTA' | 'INTERRUPTED' | 'UNKNOWN';
 
 const MAX_ERROR_MESSAGE_LENGTH = 1000;
 
@@ -70,6 +70,12 @@ export class TaskExecutionPreconditionError extends TerminalExecutionError {}
 
 export class StopRequestedError extends CancelledExecutionError {}
 
+export class InterruptedExecutionError extends TaskExecutionError {
+  constructor(message = 'Execution was interrupted.', cause?: unknown) {
+    super(message, 'interrupted', 'INTERRUPTED', cause);
+  }
+}
+
 export function classifyAgentError(input: {
   message: string;
   rawMessage?: unknown;
@@ -84,6 +90,13 @@ export function classifyAgentError(input: {
 export function classifyRunnerError(error: unknown): TaskExecutionError {
   if (error instanceof TaskExecutionError) {
     return error;
+  }
+
+  // Check if it's an abort error
+  if (error instanceof Error) {
+    if (error.name === 'AbortError' || error.message.includes('aborted')) {
+      return new InterruptedExecutionError(error.message, error);
+    }
   }
 
   return new RunnerProcessError(

--- a/apps/worker/src/task-picker.ts
+++ b/apps/worker/src/task-picker.ts
@@ -30,7 +30,7 @@ export async function pickTask({
   );
 
   let stopStatus: 'SUCCEEDED' | 'FAILED' | 'CANCELLED' = 'SUCCEEDED';
-  let stopErrorCode: 'OUT_OF_QUOTA' | 'UNKNOWN' | undefined;
+  let stopErrorCode: 'OUT_OF_QUOTA' | 'INTERRUPTED' | 'UNKNOWN' | undefined;
   let stopErrorMessage: string | undefined;
 
   try {
@@ -44,9 +44,19 @@ export async function pickTask({
     });
   } catch (error) {
     if (error instanceof TaskExecutionError) {
-      stopStatus = error.kind === 'cancelled' ? 'CANCELLED' : 'FAILED';
-      stopErrorCode = error.kind === 'cancelled' ? undefined : error.errorCode;
-      stopErrorMessage = error.displayMessage;
+      if (error.kind === 'interrupted') {
+        stopStatus = 'CANCELLED';
+        stopErrorCode = 'INTERRUPTED';
+        stopErrorMessage = error.displayMessage;
+      } else if (error.kind === 'cancelled') {
+        stopStatus = 'CANCELLED';
+        stopErrorCode = undefined;
+        stopErrorMessage = error.displayMessage;
+      } else {
+        stopStatus = 'FAILED';
+        stopErrorCode = error.errorCode;
+        stopErrorMessage = error.displayMessage;
+      }
     } else {
       stopStatus = 'FAILED';
       stopErrorCode = 'UNKNOWN';

--- a/apps/worker/src/task-picker.ts
+++ b/apps/worker/src/task-picker.ts
@@ -32,6 +32,8 @@ export async function pickTask({
   let stopStatus: 'SUCCEEDED' | 'FAILED' | 'CANCELLED' = 'SUCCEEDED';
   let stopErrorCode: 'OUT_OF_QUOTA' | 'INTERRUPTED' | 'UNKNOWN' | undefined;
   let stopErrorMessage: string | undefined;
+  let shouldRethrow = false;
+  let taskError: unknown;
 
   try {
     await executeTask({
@@ -56,14 +58,16 @@ export async function pickTask({
         stopStatus = 'FAILED';
         stopErrorCode = error.errorCode;
         stopErrorMessage = error.displayMessage;
+        shouldRethrow = true;
       }
     } else {
       stopStatus = 'FAILED';
       stopErrorCode = 'UNKNOWN';
       stopErrorMessage =
         error instanceof Error ? error.message : String(error);
+      shouldRethrow = true;
     }
-    throw error;
+    taskError = error;
   } finally {
     const historyEntry =
       await client.executions.ActiveTaskExecutionController_stopTaskExecution({
@@ -78,5 +82,9 @@ export async function pickTask({
     console.log(
       `[worker] Stopped execution ${execution.id} with status ${historyEntry.status}.`,
     );
+  }
+
+  if (shouldRethrow) {
+    throw taskError;
   }
 }

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -18,6 +18,7 @@ import {
   classifyAgentError,
   classifyRunnerError,
 } from './task-execution-errors.js';
+import { activeExecutionAbortControllers } from './worker-app.js';
 
 type ExecuteTaskParams = {
   taskId: string;
@@ -41,6 +42,10 @@ export async function executeTask({
   inputRequest,
 }: ExecuteTaskParams): Promise<void> {
   console.log(`[worker] Starting execution ${executionId} for task ${taskId}.`);
+
+  // Create and register abort controller for this execution
+  const abortController = new AbortController();
+  activeExecutionAbortControllers.set(executionId, abortController);
 
   // Get the task
   const task = await workerClient.task.TasksController_getTask({ id: taskId });
@@ -142,6 +147,7 @@ export async function executeTask({
         agentSlug: agent.slug,
         mcpServers: runtimeMcpServers,
         allowedTools,
+        abortSignal: abortController.signal,
       },
       {
         onHeartbeat: async () => {
@@ -194,6 +200,9 @@ export async function executeTask({
     );
   } catch (error) {
     throw classifyRunnerError(error);
+  } finally {
+    // Clean up abort controller
+    activeExecutionAbortControllers.delete(executionId);
   }
 }
 

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -13,12 +13,16 @@ import { buildPrompt } from './prompt.js';
 import { InputRequestLike, RunMode } from './types.js';
 import { ExecutionActivityGatewayClient } from './execution-activity-gateway-client.js';
 import {
+  InterruptedExecutionError,
   TaskExecutionPreconditionError,
   UnsupportedAgentTypeError,
   classifyAgentError,
   classifyRunnerError,
 } from './task-execution-errors.js';
-import { activeExecutionAbortControllers } from './worker-app.js';
+import {
+  activeExecutionAbortControllers,
+  activeExecutionInterruptHandlers,
+} from './worker-app.js';
 
 type ExecuteTaskParams = {
   taskId: string;
@@ -46,6 +50,11 @@ export async function executeTask({
   // Create and register abort controller for this execution
   const abortController = new AbortController();
   activeExecutionAbortControllers.set(executionId, abortController);
+  const throwIfInterrupted = () => {
+    if (abortController.signal.aborted) {
+      throw new InterruptedExecutionError('Execution was interrupted.');
+    }
+  };
 
   // Wrap entire execution in try/finally to ensure cleanup
   try {
@@ -133,79 +142,85 @@ export async function executeTask({
         `Agent type "${agent.type}" is not supported by this worker.`,
       );
     }
+    activeExecutionInterruptHandlers.set(executionId, () => runner?.cancel());
 
     // Run and pipe results
     try {
       let latestRunnerSessionId: string | null = null;
       await runner.run(
-      {
-        taskId,
-        prompt: buildPrompt(task, agent, mode, inputRequest, thread),
-        cwd: workDir,
-        baseUrl,
-        accessToken: agentToken.token,
-        executionId,
-        resume: undefined,
-        agentSlug: agent.slug,
-        mcpServers: runtimeMcpServers,
-        allowedTools,
-        abortSignal: abortController.signal,
-      },
-      {
-        onHeartbeat: async () => {
-          await activityGatewayClient.publishHeartbeat({ executionId });
+        {
+          taskId,
+          prompt: buildPrompt(task, agent, mode, inputRequest, thread),
+          cwd: workDir,
+          baseUrl,
+          accessToken: agentToken.token,
+          executionId,
+          resume: undefined,
+          agentSlug: agent.slug,
+          mcpServers: runtimeMcpServers,
+          allowedTools,
+          abortSignal: abortController.signal,
         },
-        onEvent: async (message: string) => {
-          console.log(`[agent message] ⤵️`);
-          console.log(message);
-          console.log('[end of agent message] ⤴️');
-          await activityGatewayClient.publishActivity({
-            executionId,
-            message,
-            ts: Date.now(),
-            runnerSessionId: latestRunnerSessionId,
-          });
-        },
-        onSession: (runnerSessionId: string) => {
-          latestRunnerSessionId = runnerSessionId;
-          return workerClient.executions
-            .ActiveTaskExecutionController_updateRunnerSessionId({
+        {
+          onHeartbeat: async () => {
+            throwIfInterrupted();
+            await activityGatewayClient.publishHeartbeat({ executionId });
+          },
+          onEvent: async (message: string) => {
+            throwIfInterrupted();
+            console.log(`[agent message] ⤵️`);
+            console.log(message);
+            console.log('[end of agent message] ⤴️');
+            await activityGatewayClient.publishActivity({
               executionId,
-              body: {
-                sessionId: runnerSessionId,
-              },
-            })
-            .catch((error) => {
-              console.warn(
-                `[worker] failed to persist runner session id for execution ${executionId}: ${error instanceof Error ? error.message : String(error)}`,
-              );
+              message,
+              ts: Date.now(),
+              runnerSessionId: latestRunnerSessionId,
             });
-        },
-        onToolCall: (toolName: string) => {
-          return workerClient.executions
-            .ActiveTaskExecutionController_incrementToolCallCount({
-              executionId,
-            })
-            .catch((error) => {
-              console.warn(
-                `[worker] failed to increment tool call count for execution ${executionId} (tool=${toolName}): ${error instanceof Error ? error.message : String(error)}`,
-              );
-            });
-        },
-        onError: (error: { message: string; rawMessage?: any }) => {
-          console.log('Error detected');
-          console.log('error message:', error.message);
-          console.log('raw message', error.rawMessage);
-          throw classifyAgentError(error);
+          },
+          onSession: (runnerSessionId: string) => {
+            throwIfInterrupted();
+            latestRunnerSessionId = runnerSessionId;
+            return workerClient.executions
+              .ActiveTaskExecutionController_updateRunnerSessionId({
+                executionId,
+                body: {
+                  sessionId: runnerSessionId,
+                },
+              })
+              .catch((error) => {
+                console.warn(
+                  `[worker] failed to persist runner session id for execution ${executionId}: ${error instanceof Error ? error.message : String(error)}`,
+                );
+              });
+          },
+          onToolCall: (toolName: string) => {
+            throwIfInterrupted();
+            return workerClient.executions
+              .ActiveTaskExecutionController_incrementToolCallCount({
+                executionId,
+              })
+              .catch((error) => {
+                console.warn(
+                  `[worker] failed to increment tool call count for execution ${executionId} (tool=${toolName}): ${error instanceof Error ? error.message : String(error)}`,
+                );
+              });
+          },
+          onError: (error: { message: string; rawMessage?: any }) => {
+            console.log('Error detected');
+            console.log('error message:', error.message);
+            console.log('raw message', error.rawMessage);
+            throw classifyAgentError(error);
+          }
         }
-      }
-    );
+      );
     } catch (error) {
       throw classifyRunnerError(error);
     }
   } finally {
     // Clean up abort controller - this now runs no matter where we fail
     activeExecutionAbortControllers.delete(executionId);
+    activeExecutionInterruptHandlers.delete(executionId);
   }
 }
 

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -47,95 +47,97 @@ export async function executeTask({
   const abortController = new AbortController();
   activeExecutionAbortControllers.set(executionId, abortController);
 
-  // Get the task
-  const task = await workerClient.task.TasksController_getTask({ id: taskId });
-  // TODO: We should validate dependencies are clear
-
-  // Get the agent assigned to the task
-  const actor = task.assigneeActor;
-  if (!actor?.slug) {
-    throw new TaskExecutionPreconditionError(
-      `Task ${task.id} is not assigned or is missing an assignee slug.`,
-    );
-  }
-  const agent = await workerClient.agent.AgentsController_getAgentBySlug({ slug: actor.slug });
-  if (!agent) {
-    throw new TaskExecutionPreconditionError(
-      `Assigned agent @${actor.slug} was not found for task ${task.id}.`,
-    );
-  }
-
-  // See if the task needs a repo cloned
-  let repoUrl: string | undefined = undefined;
-  const projectTag = task.tags?.find((tag) => tag.name.startsWith('project:'));
-  if (projectTag) {
-    const projectSlug = projectTag.name.replace('project:', '');
-    const project = await workerClient.metaProjects.ProjectsController_getProjectBySlug({ slug: projectSlug });
-    if (project) {
-      repoUrl = project.repoUrl;
-    }
-  }
-
-  // Prepare the workspace
-  const workDir = await prepareWorkspace({
-    taskId,
-    agentId: agent.actorId,
-    baseDir,
-    repoUrl: repoUrl,
-  });
-
-  const thread = await workerClient.threads.ThreadsController_getThreadByTaskId({ taskId });
-
-  const permissions =
-    await workerClient.agent.AgentToolPermissionsController_listAgentToolPermissions({
-      actorId: agent.actorId,
-    });
-  const serversById = await fetchMcpServersById(workerClient, permissions);
-  const runtimeMcpServers = buildRuntimeMcpServers(
-    permissions,
-    serversById,
-    executionId,
-  );
-  const allowedTools = deriveAllowedToolsFromProvidedIds(
-    Object.keys(runtimeMcpServers),
-  );
-
-  // Get an access token for the agent
-  const agentToken = await workerClient.agentExecutionTokens.AgentExecutionTokensController_requestExecutionToken({
-    slug: agent.slug,
-    body: {
-      expirationSeconds: 60 * 60, // 1 hour? what's a sensible ttl?
-    }
-  });
-
-  attachRuntimeAuthHeaders(runtimeMcpServers, agentToken.token);
-
-  // Create runner
-  let runner: BaseAgentRunner | null = null;
-  const modelConfig: AgentModelConfig = {
-    providerId: agent.providerId ?? undefined,
-    modelId: agent.modelId ?? undefined,
-  };
-  if (agent.type === 'claude') {
-    runner = new ClaudeAgentRunner(modelConfig);
-  } else if (agent.type === 'opencode') {
-    runner = new OpencodeAgentRunner(modelConfig);
-  } else if (agent.type === 'adk') {
-    runner = new ADKAgentRunner(modelConfig);
-  } else if (agent.type === 'githubcopilot') {
-    runner = new GitHubCopilotAgentRunner(modelConfig);
-  }
-
-  if (!runner) {
-    throw new UnsupportedAgentTypeError(
-      `Agent type "${agent.type}" is not supported by this worker.`,
-    );
-  }
-
-  // Run and pipe results
+  // Wrap entire execution in try/finally to ensure cleanup
   try {
-    let latestRunnerSessionId: string | null = null;
-    await runner.run(
+    // Get the task
+    const task = await workerClient.task.TasksController_getTask({ id: taskId });
+    // TODO: We should validate dependencies are clear
+
+    // Get the agent assigned to the task
+    const actor = task.assigneeActor;
+    if (!actor?.slug) {
+      throw new TaskExecutionPreconditionError(
+        `Task ${task.id} is not assigned or is missing an assignee slug.`,
+      );
+    }
+    const agent = await workerClient.agent.AgentsController_getAgentBySlug({ slug: actor.slug });
+    if (!agent) {
+      throw new TaskExecutionPreconditionError(
+        `Assigned agent @${actor.slug} was not found for task ${task.id}.`,
+      );
+    }
+
+    // See if the task needs a repo cloned
+    let repoUrl: string | undefined = undefined;
+    const projectTag = task.tags?.find((tag) => tag.name.startsWith('project:'));
+    if (projectTag) {
+      const projectSlug = projectTag.name.replace('project:', '');
+      const project = await workerClient.metaProjects.ProjectsController_getProjectBySlug({ slug: projectSlug });
+      if (project) {
+        repoUrl = project.repoUrl;
+      }
+    }
+
+    // Prepare the workspace
+    const workDir = await prepareWorkspace({
+      taskId,
+      agentId: agent.actorId,
+      baseDir,
+      repoUrl: repoUrl,
+    });
+
+    const thread = await workerClient.threads.ThreadsController_getThreadByTaskId({ taskId });
+
+    const permissions =
+      await workerClient.agent.AgentToolPermissionsController_listAgentToolPermissions({
+        actorId: agent.actorId,
+      });
+    const serversById = await fetchMcpServersById(workerClient, permissions);
+    const runtimeMcpServers = buildRuntimeMcpServers(
+      permissions,
+      serversById,
+      executionId,
+    );
+    const allowedTools = deriveAllowedToolsFromProvidedIds(
+      Object.keys(runtimeMcpServers),
+    );
+
+    // Get an access token for the agent
+    const agentToken = await workerClient.agentExecutionTokens.AgentExecutionTokensController_requestExecutionToken({
+      slug: agent.slug,
+      body: {
+        expirationSeconds: 60 * 60, // 1 hour? what's a sensible ttl?
+      }
+    });
+
+    attachRuntimeAuthHeaders(runtimeMcpServers, agentToken.token);
+
+    // Create runner
+    let runner: BaseAgentRunner | null = null;
+    const modelConfig: AgentModelConfig = {
+      providerId: agent.providerId ?? undefined,
+      modelId: agent.modelId ?? undefined,
+    };
+    if (agent.type === 'claude') {
+      runner = new ClaudeAgentRunner(modelConfig);
+    } else if (agent.type === 'opencode') {
+      runner = new OpencodeAgentRunner(modelConfig);
+    } else if (agent.type === 'adk') {
+      runner = new ADKAgentRunner(modelConfig);
+    } else if (agent.type === 'githubcopilot') {
+      runner = new GitHubCopilotAgentRunner(modelConfig);
+    }
+
+    if (!runner) {
+      throw new UnsupportedAgentTypeError(
+        `Agent type "${agent.type}" is not supported by this worker.`,
+      );
+    }
+
+    // Run and pipe results
+    try {
+      let latestRunnerSessionId: string | null = null;
+      await runner.run(
       {
         taskId,
         prompt: buildPrompt(task, agent, mode, inputRequest, thread),
@@ -198,10 +200,11 @@ export async function executeTask({
         }
       }
     );
-  } catch (error) {
-    throw classifyRunnerError(error);
+    } catch (error) {
+      throw classifyRunnerError(error);
+    }
   } finally {
-    // Clean up abort controller
+    // Clean up abort controller - this now runs no matter where we fail
     activeExecutionAbortControllers.delete(executionId);
   }
 }

--- a/apps/worker/src/worker-app.ts
+++ b/apps/worker/src/worker-app.ts
@@ -4,6 +4,9 @@ import { WorkerAuth } from './auth/worker-auth.js';
 import { runTaskClaimWorker, attemptClaimTask } from './task-claim-worker.js';
 import { ExecutionActivityGatewayClient } from './execution-activity-gateway-client.js';
 
+// Global map to track active execution abort controllers
+export const activeExecutionAbortControllers = new Map<string, AbortController>();
+
 const STARTUP_RETRY_DELAY_MS = 2_000;
 
 export type WorkerOptions = {
@@ -61,6 +64,16 @@ export async function startWorkerApp(options: WorkerOptions): Promise<void> {
         auth.serverUrl,
         activityGatewayClient,
       );
+    },
+    onExecutionInterruptRequest: (event) => {
+      console.log(`[worker] Received interrupt request for execution ${event.executionId}`);
+      const abortController = activeExecutionAbortControllers.get(event.executionId);
+      if (abortController) {
+        console.log(`[worker] Aborting execution ${event.executionId}`);
+        abortController.abort();
+      } else {
+        console.warn(`[worker] No active execution found for ${event.executionId}`);
+      }
     },
   });
 

--- a/apps/worker/src/worker-app.ts
+++ b/apps/worker/src/worker-app.ts
@@ -6,6 +6,7 @@ import { ExecutionActivityGatewayClient } from './execution-activity-gateway-cli
 
 // Global map to track active execution abort controllers
 export const activeExecutionAbortControllers = new Map<string, AbortController>();
+export const activeExecutionInterruptHandlers = new Map<string, () => void | Promise<void>>();
 
 const STARTUP_RETRY_DELAY_MS = 2_000;
 
@@ -71,6 +72,11 @@ export async function startWorkerApp(options: WorkerOptions): Promise<void> {
       if (abortController) {
         console.log(`[worker] Aborting execution ${event.executionId}`);
         abortController.abort();
+        void Promise.resolve(activeExecutionInterruptHandlers.get(event.executionId)?.()).catch((error) => {
+          console.warn(
+            `[worker] Failed to interrupt execution ${event.executionId}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        });
       } else {
         console.warn(`[worker] No active execution found for ${event.executionId}`);
       }

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -6175,6 +6175,37 @@
         ]
       }
     },
+    "/api/v1/executions/active/{executionId}/interrupt": {
+      "post": {
+        "description": "Signals the worker to abort the currently running agent execution.",
+        "operationId": "ActiveTaskExecutionController_interruptExecution",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to interrupt",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Request interruption of an active execution",
+        "tags": [
+          "Executions"
+        ]
+      }
+    },
     "/api/v1/executions/history": {
       "get": {
         "description": "Returns the persisted execution history rows in the execution system.",
@@ -11847,6 +11878,7 @@
             "description": "Optional error code for failed execution outcomes",
             "enum": [
               "OUT_OF_QUOTA",
+              "INTERRUPTED",
               "UNKNOWN"
             ],
             "nullable": true,
@@ -11940,6 +11972,7 @@
             "description": "Optional failure code when execution ended with an error",
             "enum": [
               "OUT_OF_QUOTA",
+              "INTERRUPTED",
               "UNKNOWN"
             ],
             "nullable": true

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -1800,6 +1800,26 @@ export interface paths {
         patch: operations["ActiveTaskExecutionController_incrementToolCallCount"];
         trace?: never;
     };
+    "/api/v1/executions/active/{executionId}/interrupt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request interruption of an active execution
+         * @description Signals the worker to abort the currently running agent execution.
+         */
+        post: operations["ActiveTaskExecutionController_interruptExecution"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/executions/history": {
         parameters: {
             query?: never;
@@ -5306,7 +5326,7 @@ export interface components {
              * @example OUT_OF_QUOTA
              * @enum {string|null}
              */
-            errorCode?: "OUT_OF_QUOTA" | "UNKNOWN" | null;
+            errorCode?: "OUT_OF_QUOTA" | "INTERRUPTED" | "UNKNOWN" | null;
             /**
              * @description Optional human-readable error message for failed or cancelled executions
              * @example ADK runner failed: 429 quota exceeded.
@@ -5373,7 +5393,7 @@ export interface components {
              * @description Optional failure code when execution ended with an error
              * @enum {string|null}
              */
-            errorCode: "OUT_OF_QUOTA" | "UNKNOWN" | null;
+            errorCode: "OUT_OF_QUOTA" | "INTERRUPTED" | "UNKNOWN" | null;
             /**
              * @description Optional human-readable error message for failed or cancelled executions
              * @example ADK runner failed: 429 quota exceeded.
@@ -10063,6 +10083,26 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Execution ID to update */
+                executionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ActiveTaskExecutionController_interruptExecution: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Execution ID to interrupt */
                 executionId: string;
             };
             cookie?: never;

--- a/packages/client/src/v1/client/models/StopActiveTaskExecutionDto.ts
+++ b/packages/client/src/v1/client/models/StopActiveTaskExecutionDto.ts
@@ -31,6 +31,7 @@ export namespace StopActiveTaskExecutionDto {
      */
     export enum errorCode {
         OUT_OF_QUOTA = 'OUT_OF_QUOTA',
+        INTERRUPTED = 'INTERRUPTED',
         UNKNOWN = 'UNKNOWN',
     }
 }

--- a/packages/client/src/v1/client/models/TaskExecutionHistoryResponseDto.ts
+++ b/packages/client/src/v1/client/models/TaskExecutionHistoryResponseDto.ts
@@ -80,6 +80,7 @@ export namespace TaskExecutionHistoryResponseDto {
      */
     export enum errorCode {
         OUT_OF_QUOTA = 'OUT_OF_QUOTA',
+        INTERRUPTED = 'INTERRUPTED',
         UNKNOWN = 'UNKNOWN',
     }
 }

--- a/packages/client/src/v1/client/services/ExecutionsService.ts
+++ b/packages/client/src/v1/client/services/ExecutionsService.ts
@@ -121,6 +121,25 @@ export class ExecutionsService {
         });
     }
     /**
+     * Request interruption of an active execution
+     * Signals the worker to abort the currently running agent execution.
+     * @param executionId Execution ID to interrupt
+     * @returns void
+     * @throws ApiError
+     */
+    public static activeTaskExecutionControllerInterruptExecution(
+        executionId: string,
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<void> {
+        return __request(config, {
+            method: 'POST',
+            url: '/api/v1/executions/active/{executionId}/interrupt',
+            path: {
+                'executionId': executionId,
+            },
+        });
+    }
+    /**
      * List task execution history
      * Returns the persisted execution history rows in the execution system.
      * @returns TaskExecutionHistoryResponseDto

--- a/packages/client/src/v2/executions-resource.ts
+++ b/packages/client/src/v2/executions-resource.ts
@@ -36,6 +36,11 @@ export class ExecutionsResource extends BaseClient {
     return this.request('PATCH', `/api/v1/executions/active/${params.executionId}/tool-calls/increment`, { responseType: 'void', signal: params?.signal });
   }
 
+  /** Request interruption of an active execution */
+  async ActiveTaskExecutionController_interruptExecution(params: { executionId: string; signal?: AbortSignal }): Promise<void> {
+    return this.request('POST', `/api/v1/executions/active/${params.executionId}/interrupt`, { responseType: 'void', signal: params?.signal });
+  }
+
   /** List task execution history */
   async TaskExecutionHistoryController_listHistory(params?: { signal?: AbortSignal }): Promise<TaskExecutionHistoryResponseDto[]> {
     return this.request('GET', '/api/v1/executions/history', { signal: params?.signal });

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -970,7 +970,7 @@ export interface ActiveTaskExecutionResponseDto {
 
 export interface StopActiveTaskExecutionDto {
   status: 'SUCCEEDED' | 'FAILED' | 'STALE' | 'CANCELLED';
-  errorCode?: 'OUT_OF_QUOTA' | 'UNKNOWN';
+  errorCode?: 'OUT_OF_QUOTA' | 'INTERRUPTED' | 'UNKNOWN';
   errorMessage?: string | null;
 }
 
@@ -986,7 +986,7 @@ export interface TaskExecutionHistoryResponseDto {
   runnerSessionId: string | null;
   toolCallCount: number;
   status: 'SUCCEEDED' | 'FAILED' | 'STALE' | 'CANCELLED';
-  errorCode: 'OUT_OF_QUOTA' | 'UNKNOWN';
+  errorCode: 'OUT_OF_QUOTA' | 'INTERRUPTED' | 'UNKNOWN';
   errorMessage: string | null;
 }
 

--- a/packages/events/src/types/execution-events.ts
+++ b/packages/events/src/types/execution-events.ts
@@ -25,6 +25,7 @@ export const ExecutionWireEvents = {
   WORKER_HEARTBEAT_POST: 'worker.heartbeat.post',
   WORKER_HARNESSES_REPORT_REQUESTED: 'worker.harnesses.report.requested',
   TASK_EXECUTION_QUEUED: 'task.execution.queued',
+  EXECUTION_INTERRUPT_REQUEST: 'execution.interrupt.request',
 } as const;
 
 export type ExecutionWireEventName =
@@ -126,6 +127,15 @@ export interface TaskExecutionQueuedWireEvent {
 }
 
 /**
+ * Execution interrupt request event
+ * Emitted when a user requests to interrupt/cancel an active execution
+ */
+export interface ExecutionInterruptRequestWireEvent {
+  executionId: string;
+  requestedAt: string;
+}
+
+/**
  * Union type of all execution wire events
  */
 export type ExecutionWireEvent =
@@ -133,7 +143,8 @@ export type ExecutionWireEvent =
   | ExecutionUpdatedWireEvent
   | ExecutionDeletedWireEvent
   | ExecutionActivityWireEvent
-  | TaskExecutionQueuedWireEvent;
+  | TaskExecutionQueuedWireEvent
+  | ExecutionInterruptRequestWireEvent;
 
 /**
  * Type guards for event identification


### PR DESCRIPTION
## Summary
Implements the user interface for interrupting active task executions. Users can now stop running executions from both the Executions page and the Task Detail page.

This PR builds on top of the backend interrupt infrastructure from PR #876 (which is currently open and merged into this branch).

## Changes

### Executions Page
- Added "Actions" column to Active executions table with interrupt button
- Mobile view: Added action button section in mobile cards
- Confirmation dialog before interrupting
- Loading state prevents double-clicks during interrupt request

### Task Detail Page
- Added interrupt button in DataRow `topRight` for active executions
- Button replaces the timestamp display when an execution is active
- Elapsed time moved inline with execution stats for active runs
- Same confirmation and loading state UX as Executions page

### User Experience
- Confirmation dialog: "Are you sure you want to interrupt..."
- Loading state: Button text changes to "Interrupting…" and disables
- Success: Toast notification confirms interrupt signal was sent
- Error handling: Toast displays error if interrupt fails
- Uses "danger" button variant to indicate destructive action

## Technical Details
- Calls `ExecutionsService.ActiveTaskExecutionController_interruptExecution()`
- Manages interrupt state with `Set<string>` to track in-progress interrupts
- Mobile-responsive design with dedicated actions section in mobile cards
- Added `.executions-mobile-card__actions` CSS for mobile button layout

## Testing
- ✅ Build: `npm run build` passes with no errors
- ✅ TypeScript: No type errors
- ✅ Runtime: Dev server starts successfully

## Dependencies
This PR depends on backend changes in #876. Both PRs should be reviewed and merged together.

## Test Plan
1. Start a task execution (assign an agent to a task)
2. Navigate to Executions page → Active section
3. Click "Interrupt" button on an active execution
4. Confirm the dialog
5. Verify toast notification appears
6. Verify execution moves to history with INTERRUPTED status
7. Repeat from Task Detail page
8. Test mobile view responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)