### PR TITLE
feat: Add exponential backoff for task execution retries

### DIFF
--- a/apps/backend/src/executions/history/task-execution-history.service.spec.ts
+++ b/apps/backend/src/executions/history/task-execution-history.service.spec.ts
@@ -1,0 +1,256 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TaskExecutionHistoryService } from './task-execution-history.service';
+import { TaskExecutionHistoryEntity } from './task-execution-history.entity';
+import { TaskExecutionHistoryStatus } from './task-execution-history-status.enum';
+import { TaskExecutionHistoryErrorCode } from './task-execution-history-error-code.enum';
+
+describe('TaskExecutionHistoryService', () => {
+  let service: TaskExecutionHistoryService;
+  let repository: jest.Mocked<Repository<TaskExecutionHistoryEntity>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TaskExecutionHistoryService,
+        {
+          provide: getRepositoryToken(TaskExecutionHistoryEntity),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<TaskExecutionHistoryService>(
+      TaskExecutionHistoryService,
+    );
+    repository = module.get(getRepositoryToken(TaskExecutionHistoryEntity));
+  });
+
+  describe('getLatestHistoryForTask', () => {
+    it('should return the latest history entry for a task', async () => {
+      const taskId = 'test-task-id';
+      const mockHistory = {
+        taskId,
+        status: TaskExecutionHistoryStatus.SUCCEEDED,
+        transitionedAt: new Date(),
+      } as TaskExecutionHistoryEntity;
+
+      repository.findOne.mockResolvedValue(mockHistory);
+
+      const result = await service.getLatestHistoryForTask(taskId);
+
+      expect(result).toBe(mockHistory);
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { taskId },
+        order: { transitionedAt: 'DESC' },
+      });
+    });
+
+    it('should return null when no history exists', async () => {
+      const taskId = 'test-task-id';
+
+      repository.findOne.mockResolvedValue(null);
+
+      const result = await service.getLatestHistoryForTask(taskId);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('countConsecutiveQuotaErrors', () => {
+    const taskId = 'test-task-id';
+
+    const createHistoryEntry = (
+      status: TaskExecutionHistoryStatus,
+      errorCode: TaskExecutionHistoryErrorCode | null,
+      minutesAgo: number,
+    ): TaskExecutionHistoryEntity => ({
+      taskId,
+      status,
+      errorCode,
+      transitionedAt: new Date(Date.now() - minutesAgo * 60 * 1000),
+    } as TaskExecutionHistoryEntity);
+
+    it('should count consecutive quota errors from most recent execution', async () => {
+      const histories = [
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          1,
+        ), // Most recent
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          2,
+        ),
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          3,
+        ),
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.SUCCEEDED,
+          null,
+          4,
+        ), // Non-quota execution - should stop counting here
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          5,
+        ), // Should not be counted
+      ];
+
+      repository.find.mockResolvedValue(histories);
+
+      const result = await service.countConsecutiveQuotaErrors(taskId);
+
+      expect(result).toBe(3);
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { taskId },
+        order: { transitionedAt: 'DESC' },
+      });
+    });
+
+    it('should return 0 when latest execution is not a quota error', async () => {
+      const histories = [
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.SUCCEEDED,
+          null,
+          1,
+        ), // Most recent
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          2,
+        ), // Should not be counted
+      ];
+
+      repository.find.mockResolvedValue(histories);
+
+      const result = await service.countConsecutiveQuotaErrors(taskId);
+
+      expect(result).toBe(0);
+    });
+
+    it('should return 0 when no history exists', async () => {
+      repository.find.mockResolvedValue([]);
+
+      const result = await service.countConsecutiveQuotaErrors(taskId);
+
+      expect(result).toBe(0);
+    });
+
+    it('should count all quota errors if all executions are quota errors', async () => {
+      const histories = [
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          1,
+        ),
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          2,
+        ),
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          3,
+        ),
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          4,
+        ),
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          5,
+        ),
+      ];
+
+      repository.find.mockResolvedValue(histories);
+
+      const result = await service.countConsecutiveQuotaErrors(taskId);
+
+      expect(result).toBe(5);
+    });
+
+    it('should stop counting at first non-quota failure', async () => {
+      const histories = [
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          1,
+        ),
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          2,
+        ),
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.UNKNOWN,
+          3,
+        ), // Different error - should stop here
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          4,
+        ), // Should not be counted
+      ];
+
+      repository.find.mockResolvedValue(histories);
+
+      const result = await service.countConsecutiveQuotaErrors(taskId);
+
+      expect(result).toBe(2);
+    });
+
+    it('should stop counting at CANCELLED status', async () => {
+      const histories = [
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          1,
+        ),
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.CANCELLED,
+          null,
+          2,
+        ), // CANCELLED - should stop here
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          3,
+        ), // Should not be counted
+      ];
+
+      repository.find.mockResolvedValue(histories);
+
+      const result = await service.countConsecutiveQuotaErrors(taskId);
+
+      expect(result).toBe(1);
+    });
+
+    it('should return 1 for single quota error', async () => {
+      const histories = [
+        createHistoryEntry(
+          TaskExecutionHistoryStatus.FAILED,
+          TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          1,
+        ),
+      ];
+
+      repository.find.mockResolvedValue(histories);
+
+      const result = await service.countConsecutiveQuotaErrors(taskId);
+
+      expect(result).toBe(1);
+    });
+  });
+});

--- a/apps/backend/src/executions/history/task-execution-history.service.ts
+++ b/apps/backend/src/executions/history/task-execution-history.service.ts
@@ -16,4 +16,36 @@ export class TaskExecutionHistoryService {
       order: { taskId: 'ASC' },
     });
   }
+
+  async getLatestHistoryForTask(
+    taskId: string,
+  ): Promise<TaskExecutionHistoryEntity | null> {
+    return this.taskExecutionHistoryRepository.findOne({
+      where: { taskId },
+      order: { transitionedAt: 'DESC' },
+    });
+  }
+
+  async countConsecutiveQuotaErrors(taskId: string): Promise<number> {
+    // Get all history entries for this task, ordered by time
+    const histories = await this.taskExecutionHistoryRepository.find({
+      where: { taskId },
+      order: { transitionedAt: 'DESC' },
+    });
+
+    // Count consecutive quota errors from the most recent execution
+    let count = 0;
+    for (const history of histories) {
+      if (
+        history.status === 'FAILED' &&
+        history.errorCode === 'OUT_OF_QUOTA'
+      ) {
+        count++;
+      } else {
+        break; // Stop at first non-quota error
+      }
+    }
+
+    return count;
+  }
 }

--- a/apps/backend/src/executions/readiness/task-execution-queue-populator.service.spec.ts
+++ b/apps/backend/src/executions/readiness/task-execution-queue-populator.service.spec.ts
@@ -7,6 +7,11 @@ import { TaskExecutionQueueEntity } from '../queue/task-execution-queue.entity';
 import { TaskExecutionQueuedEvent } from '../queue/task-execution-queued.event';
 import { AgentsService } from '../../agents/agents.service';
 import { ReadinessCandidateRepository } from './readiness-candidate.repository';
+import { TaskExecutionHistoryService } from '../history/task-execution-history.service';
+import { TaskExecutionHistoryStatus } from '../history/task-execution-history-status.enum';
+import { TaskExecutionHistoryErrorCode } from '../history/task-execution-history-error-code.enum';
+import { TaskEntity } from '../../tasks/task.entity';
+import { TaskStatus } from '../../tasks/enums/task-status.enum';
 
 describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
   let service: TaskExecutionQueuePopulatorService;
@@ -14,6 +19,7 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
   let eventEmitter: jest.Mocked<EventEmitter2>;
   let agentsService: jest.Mocked<AgentsService>;
   let readinessCandidateRepository: jest.Mocked<ReadinessCandidateRepository>;
+  let taskExecutionHistoryService: jest.Mocked<TaskExecutionHistoryService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -47,6 +53,13 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
             emit: jest.fn(),
           },
         },
+        {
+          provide: TaskExecutionHistoryService,
+          useValue: {
+            getLatestHistoryForTask: jest.fn(),
+            countConsecutiveQuotaErrors: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -57,6 +70,7 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
     eventEmitter = module.get(EventEmitter2);
     agentsService = module.get(AgentsService);
     readinessCandidateRepository = module.get(ReadinessCandidateRepository);
+    taskExecutionHistoryService = module.get(TaskExecutionHistoryService);
   });
 
   describe('upsertQueueEntry', () => {
@@ -147,6 +161,268 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
 
       // Verify the event was NOT emitted
       expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('shouldQueueTask - Delay Retry Logic', () => {
+    const createMockTask = (overrides: Partial<TaskEntity> = {}): TaskEntity => {
+      return {
+        id: 'test-task-id',
+        name: 'Test Task',
+        status: TaskStatus.NOT_STARTED,
+        assigneeActorId: 'agent-actor-id',
+        tags: [],
+        ...overrides,
+      } as TaskEntity;
+    };
+
+    const createMockAgent = (overrides = {}) => {
+      return {
+        actorId: 'agent-actor-id',
+        slug: 'test-agent',
+        statusTriggers: [TaskStatus.NOT_STARTED],
+        tagTriggers: [],
+        concurrencyLimit: null,
+        ...overrides,
+      } as any;
+    };
+
+    beforeEach(() => {
+      // Reset all mocks before each test
+      jest.clearAllMocks();
+
+      // Default mock implementations
+      agentsService.getActiveAgentsByActorIds.mockResolvedValue([
+        createMockAgent(),
+      ]);
+      readinessCandidateRepository.countActiveExecutionsForAgent.mockResolvedValue(
+        0,
+      );
+      taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue(
+        null,
+      );
+      taskExecutionHistoryService.countConsecutiveQuotaErrors.mockResolvedValue(
+        0,
+      );
+    });
+
+    describe('CANCELLED delay', () => {
+      it('should NOT queue task when cancelled less than 10 minutes ago', async () => {
+        const task = createMockTask();
+        const cancelledAt = new Date(Date.now() - 5 * 60 * 1000); // 5 minutes ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.CANCELLED,
+          errorCode: null,
+          transitionedAt: cancelledAt,
+        } as any);
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(false);
+        expect(
+          taskExecutionHistoryService.getLatestHistoryForTask,
+        ).toHaveBeenCalledWith(task.id);
+      });
+
+      it('should queue task when cancelled 10 minutes ago or more', async () => {
+        const task = createMockTask();
+        const cancelledAt = new Date(Date.now() - 10 * 60 * 1000); // exactly 10 minutes ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.CANCELLED,
+          errorCode: null,
+          transitionedAt: cancelledAt,
+        } as any);
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(true);
+      });
+
+      it('should queue task when cancelled more than 10 minutes ago', async () => {
+        const task = createMockTask();
+        const cancelledAt = new Date(Date.now() - 15 * 60 * 1000); // 15 minutes ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.CANCELLED,
+          errorCode: null,
+          transitionedAt: cancelledAt,
+        } as any);
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('OUT_OF_QUOTA delay', () => {
+      it('should NOT queue task with 1 quota error less than 10 minutes ago', async () => {
+        const task = createMockTask();
+        const errorAt = new Date(Date.now() - 5 * 60 * 1000); // 5 minutes ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.FAILED,
+          errorCode: TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          transitionedAt: errorAt,
+        } as any);
+        taskExecutionHistoryService.countConsecutiveQuotaErrors.mockResolvedValue(
+          1,
+        );
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(false);
+        expect(
+          taskExecutionHistoryService.countConsecutiveQuotaErrors,
+        ).toHaveBeenCalledWith(task.id);
+      });
+
+      it('should queue task with 1 quota error 10 minutes ago or more', async () => {
+        const task = createMockTask();
+        const errorAt = new Date(Date.now() - 10 * 60 * 1000); // exactly 10 minutes ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.FAILED,
+          errorCode: TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          transitionedAt: errorAt,
+        } as any);
+        taskExecutionHistoryService.countConsecutiveQuotaErrors.mockResolvedValue(
+          1,
+        );
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(true);
+      });
+
+      it('should NOT queue task with 3 quota errors less than 30 minutes ago', async () => {
+        const task = createMockTask();
+        const errorAt = new Date(Date.now() - 20 * 60 * 1000); // 20 minutes ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.FAILED,
+          errorCode: TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          transitionedAt: errorAt,
+        } as any);
+        taskExecutionHistoryService.countConsecutiveQuotaErrors.mockResolvedValue(
+          3,
+        ); // 3 * 10 = 30 minutes
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(false);
+      });
+
+      it('should queue task with 3 quota errors 30 minutes ago or more', async () => {
+        const task = createMockTask();
+        const errorAt = new Date(Date.now() - 30 * 60 * 1000); // exactly 30 minutes ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.FAILED,
+          errorCode: TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          transitionedAt: errorAt,
+        } as any);
+        taskExecutionHistoryService.countConsecutiveQuotaErrors.mockResolvedValue(
+          3,
+        );
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(true);
+      });
+
+      it('should cap delay at 1 hour for many consecutive quota errors', async () => {
+        const task = createMockTask();
+        const errorAt = new Date(Date.now() - 50 * 60 * 1000); // 50 minutes ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.FAILED,
+          errorCode: TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          transitionedAt: errorAt,
+        } as any);
+        taskExecutionHistoryService.countConsecutiveQuotaErrors.mockResolvedValue(
+          10,
+        ); // 10 * 10 = 100 minutes, capped at 60
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        // Should not queue because 50 minutes < 60 minutes (max cap)
+        expect(result).toBe(false);
+      });
+
+      it('should queue task with many consecutive quota errors after 1 hour', async () => {
+        const task = createMockTask();
+        const errorAt = new Date(Date.now() - 60 * 60 * 1000); // exactly 60 minutes ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.FAILED,
+          errorCode: TaskExecutionHistoryErrorCode.OUT_OF_QUOTA,
+          transitionedAt: errorAt,
+        } as any);
+        taskExecutionHistoryService.countConsecutiveQuotaErrors.mockResolvedValue(
+          10,
+        ); // Would be 100 minutes but capped at 60
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('Non-delay scenarios', () => {
+      it('should queue task with no execution history', async () => {
+        const task = createMockTask();
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue(
+          null,
+        );
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(true);
+      });
+
+      it('should queue task with SUCCEEDED latest history', async () => {
+        const task = createMockTask();
+        const successAt = new Date(Date.now() - 1 * 60 * 1000); // 1 minute ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.SUCCEEDED,
+          errorCode: null,
+          transitionedAt: successAt,
+        } as any);
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(true);
+      });
+
+      it('should queue task with FAILED latest history (non-quota error)', async () => {
+        const task = createMockTask();
+        const failedAt = new Date(Date.now() - 1 * 60 * 1000); // 1 minute ago
+
+        taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue({
+          taskId: task.id,
+          status: TaskExecutionHistoryStatus.FAILED,
+          errorCode: TaskExecutionHistoryErrorCode.UNKNOWN,
+          transitionedAt: failedAt,
+        } as any);
+
+        const result = await (service as any).shouldQueueTask(task);
+
+        expect(result).toBe(true);
+      });
     });
   });
 });

--- a/apps/backend/src/executions/readiness/task-execution-queue-populator.service.ts
+++ b/apps/backend/src/executions/readiness/task-execution-queue-populator.service.ts
@@ -8,6 +8,9 @@ import { TaskEntity } from '../../tasks/task.entity';
 import { TaskExecutionQueueEntity } from '../queue/task-execution-queue.entity';
 import { ReadinessCandidateRepository } from './readiness-candidate.repository';
 import { TaskExecutionQueuedEvent } from '../queue/task-execution-queued.event';
+import { TaskExecutionHistoryService } from '../history/task-execution-history.service';
+import { TaskExecutionHistoryStatus } from '../history/task-execution-history-status.enum';
+import { TaskExecutionHistoryErrorCode } from '../history/task-execution-history-error-code.enum';
 
 @Injectable()
 export class TaskExecutionQueuePopulatorService {
@@ -19,6 +22,7 @@ export class TaskExecutionQueuePopulatorService {
     private readonly agentsService: AgentsService,
     private readonly readinessCandidateRepository: ReadinessCandidateRepository,
     private readonly eventEmitter: EventEmitter2,
+    private readonly taskExecutionHistoryService: TaskExecutionHistoryService,
   ) { }
 
   async populateTask(taskId: string): Promise<void> {
@@ -123,7 +127,64 @@ export class TaskExecutionQueuePopulatorService {
       return false;
     }
 
+    // Check if task should be delayed due to recent errors or cancellation
+    if (await this.shouldDelayTask(task.id)) {
+      return false;
+    }
+
     return true;
+  }
+
+  private async shouldDelayTask(taskId: string): Promise<boolean> {
+    const latestHistory =
+      await this.taskExecutionHistoryService.getLatestHistoryForTask(taskId);
+
+    if (!latestHistory) {
+      return false; // No history, no delay needed
+    }
+
+    const now = new Date();
+    const timeSinceLastExecution =
+      now.getTime() - latestHistory.transitionedAt.getTime();
+
+    // Check if task was cancelled
+    if (latestHistory.status === TaskExecutionHistoryStatus.CANCELLED) {
+      const delayMs = 10 * 60 * 1000; // 10 minutes
+      if (timeSinceLastExecution < delayMs) {
+        const remainingMs = delayMs - timeSinceLastExecution;
+        const remainingMinutes = Math.ceil(remainingMs / 60000);
+        this.logger.debug(
+          `Task ${taskId} is not queueable: cancelled ${Math.floor(timeSinceLastExecution / 60000)} minutes ago, waiting ${remainingMinutes} more minutes`,
+        );
+        return true;
+      }
+    }
+
+    // Check if task failed with OUT_OF_QUOTA error
+    if (
+      latestHistory.status === TaskExecutionHistoryStatus.FAILED &&
+      latestHistory.errorCode === TaskExecutionHistoryErrorCode.OUT_OF_QUOTA
+    ) {
+      const quotaErrorCount =
+        await this.taskExecutionHistoryService.countConsecutiveQuotaErrors(
+          taskId,
+        );
+
+      const baseDelayMs = 10 * 60 * 1000; // 10 minutes
+      const maxDelayMs = 60 * 60 * 1000; // 1 hour
+      const delayMs = Math.min(baseDelayMs * quotaErrorCount, maxDelayMs);
+
+      if (timeSinceLastExecution < delayMs) {
+        const remainingMs = delayMs - timeSinceLastExecution;
+        const remainingMinutes = Math.ceil(remainingMs / 60000);
+        this.logger.debug(
+          `Task ${taskId} is not queueable: has ${quotaErrorCount} consecutive quota errors, waiting ${remainingMinutes} more minutes`,
+        );
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private matchesTagTriggers(task: TaskEntity, agent: AgentResult): boolean {


### PR DESCRIPTION
## Summary

Implements delayed retry logic for task execution to prevent overwhelming rate limits and improve retry behavior:

- Tasks that were **cancelled** wait 10 minutes before being queued again
- Tasks that failed with **OUT_OF_QUOTA** errors use exponential backoff (10 minutes × consecutive error count, max 1 hour)
- The delay is implemented as a **logical queuing criteria**, not a database field

## Key Implementation Details

1. **TaskExecutionHistoryService**: Added methods to fetch latest execution history and count consecutive quota errors
2. **TaskExecutionQueuePopulatorService**: Added `shouldDelayTask()` check that examines execution history before queueing
3. **No database changes**: Following the principle that items in the queue are ready to be picked up immediately

## Technical Design

The delay logic checks execution history during the `shouldQueueTask()` phase:
- If latest execution was CANCELLED and within 10 minutes → don't queue
- If latest execution was OUT_OF_QUOTA and within delay window → don't queue
- Otherwise → proceed with normal queuing logic

This ensures that:
- Queue items are always ready for immediate pickup
- Rate limit errors result in automatic backoff
- Cancelled tasks get a cooling-off period

## Test Plan

- [x] `npm run build:dev` passes
- [x] `npm run dev:1` starts successfully
- [ ] Test cancellation delay by cancelling a task and verifying it doesn't re-queue for 10 minutes
- [ ] Test quota error backoff by simulating quota errors and verifying increasing delays
- [ ] Verify normal tasks without errors queue immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)