### PR TITLE
Improve mobile UI for thread detail page

### DIFF
--- a/apps/ui/src/features/threads/ThreadChat.css
+++ b/apps/ui/src/features/threads/ThreadChat.css
@@ -4,6 +4,7 @@
   height: 100%;
   gap: var(--space-3);
   min-height: 0;
+  flex: 1;
 }
 
 .thread-chat__messages {
@@ -12,12 +13,26 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  padding: var(--space-2) 0;
-  scrollbar-width: none; /* Firefox */
+  padding: var(--space-3) 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-subtle) transparent;
 }
 
 .thread-chat__messages::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Edge */
+  width: 6px;
+}
+
+.thread-chat__messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.thread-chat__messages::-webkit-scrollbar-thumb {
+  background: var(--border-subtle);
+  border-radius: 3px;
+}
+
+.thread-chat__messages::-webkit-scrollbar-thumb:hover {
+  background: var(--border);
 }
 
 .thread-chat__message {

--- a/apps/ui/src/features/threads/ThreadDetailPage.css
+++ b/apps/ui/src/features/threads/ThreadDetailPage.css
@@ -211,6 +211,29 @@
   border-bottom: 1px solid var(--border-subtle);
 }
 
+.thread-detail-page__mobile-nav {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--space-1);
+}
+
+.thread-detail-page__mobile-back {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: var(--fs-2);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  padding: var(--space-1) 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.thread-detail-page__mobile-back:hover {
+  opacity: 0.8;
+}
+
 .thread-detail-page__mobile-thread-meta {
   display: flex;
   flex-direction: column;

--- a/apps/ui/src/features/threads/ThreadDetailPage.css
+++ b/apps/ui/src/features/threads/ThreadDetailPage.css
@@ -188,21 +188,27 @@
 /* Mobile layout */
 .thread-detail-page--mobile {
   background-color: var(--bg);
-  overflow-y: auto;
-}
-
-.thread-detail-page__mobile-content {
+  height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
-  padding: var(--space-3) 0 var(--space-4);
+  overflow: hidden;
+}
+
+.thread-detail-page__mobile-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
 }
 
 .thread-detail-page__mobile-topbar {
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  padding: 0 var(--space-3);
+  padding: var(--space-3) var(--space-3) var(--space-2);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .thread-detail-page__mobile-thread-meta {
@@ -211,9 +217,27 @@
   gap: var(--space-1);
 }
 
+.thread-detail-page__mobile-thread-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.thread-detail-page__mobile-delete {
+  flex-shrink: 0;
+}
+
+.thread-detail-page__mobile-delete .btn {
+  min-width: auto;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--fs-4);
+  line-height: 1;
+}
+
 .thread-detail-page__mobile-view-toggle {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: var(--space-2);
 }
 
@@ -232,58 +256,35 @@
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
 }
 
-.thread-detail-page__mobile-insights {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--space-2);
-  padding: 0 var(--space-3);
-}
-
-.thread-detail-page__mobile-insight-card {
+.thread-detail-page__mobile-view-content {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-1);
-  border: 1px solid var(--border-subtle);
-  background: color-mix(in srgb, var(--card-bg) 94%, var(--surface));
-  padding: var(--space-3);
-  text-align: left;
-  cursor: pointer;
 }
 
-.thread-detail-page__mobile-status-strip {
+.thread-detail-page__mobile-chat-view {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
   display: flex;
-  gap: var(--space-2);
-  overflow-x: auto;
+  flex-direction: column;
   padding: 0 var(--space-3);
 }
 
-.thread-detail-page__mobile-status-chip {
-  border: 1px solid var(--border-subtle);
-  background: var(--surface);
-  color: var(--text);
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-1) var(--space-2);
-  white-space: nowrap;
-  cursor: pointer;
-}
-
-.thread-detail-page__mobile-chat-shell {
-  border-top: 1px solid var(--border-subtle);
-  border-bottom: 1px solid var(--border-subtle);
-  min-height: 56vh;
-  max-height: 72vh;
-  padding: 0 var(--space-3);
+.thread-detail-page__mobile-scrollable {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-3);
 }
 
 .thread-detail-page__mobile-section {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  padding: 0 var(--space-3);
+  margin-bottom: var(--space-3);
 }
 
 .thread-detail-page__mobile-list {
@@ -292,8 +293,10 @@
   gap: var(--space-2);
 }
 
-.thread-detail-page__mobile-jump-row {
+.thread-detail-page__mobile-empty {
   display: flex;
-  justify-content: flex-end;
-  padding: 0 var(--space-3);
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6) var(--space-3);
+  border: 1px dashed var(--border-subtle);
 }

--- a/apps/ui/src/features/threads/ThreadDetailPage.tsx
+++ b/apps/ui/src/features/threads/ThreadDetailPage.tsx
@@ -435,6 +435,15 @@ function ThreadDetailPageMobile({
       <div className="thread-detail-page__mobile-wrapper">
         {/* Fixed top section with tabs */}
         <div className="thread-detail-page__mobile-topbar">
+          <div className="thread-detail-page__mobile-nav">
+            <button
+              className="thread-detail-page__mobile-back"
+              onClick={() => navigate('/threads')}
+              aria-label="Back to threads"
+            >
+              ← Back
+            </button>
+          </div>
           <div className="thread-detail-page__mobile-thread-meta">
             <div className="thread-detail-page__mobile-thread-header">
               <Text size="2" weight="semibold">

--- a/apps/ui/src/features/threads/ThreadDetailPage.tsx
+++ b/apps/ui/src/features/threads/ThreadDetailPage.tsx
@@ -456,17 +456,26 @@ function ThreadDetailPageMobile({
   const navigate = useNavigate();
   const taskGroups = groupTasksByStatus(thread);
   const contextBlocks = getContextBlocksForDisplay(thread);
-  const taskStatusSummary = getTaskStatusSummary(thread);
-  const [mobileView, setMobileView] = useState<"chat" | "details">("chat");
+  const [mobileView, setMobileView] = useState<"chat" | "tasks" | "context">("chat");
 
   return (
     <div className="thread-detail-page thread-detail-page--mobile">
-      <div className="thread-detail-page__mobile-content">
+      <div className="thread-detail-page__mobile-wrapper">
+        {/* Fixed top section with tabs */}
         <div className="thread-detail-page__mobile-topbar">
           <div className="thread-detail-page__mobile-thread-meta">
-            <Text size="2" weight="semibold">
-              {thread.title}
-            </Text>
+            <div className="thread-detail-page__mobile-thread-header">
+              <Text size="2" weight="semibold">
+                {thread.title}
+              </Text>
+              <DeleteWithConfirmation
+                className="thread-detail-page__mobile-delete"
+                onDelete={onDelete}
+                size="sm"
+                deleteLabel="×"
+                confirmLabel="Delete forever"
+              />
+            </div>
             <Text size="1" tone="muted">
               #{thread.id.slice(0, 6)} · {thread.participants.length} participants
             </Text>
@@ -484,134 +493,82 @@ function ThreadDetailPageMobile({
             <button
               type="button"
               role="tab"
-              aria-selected={mobileView === "details"}
-              className={`thread-detail-page__mobile-tab ${mobileView === "details" ? "thread-detail-page__mobile-tab--active" : ""}`}
-              onClick={() => setMobileView("details")}
+              aria-selected={mobileView === "tasks"}
+              className={`thread-detail-page__mobile-tab ${mobileView === "tasks" ? "thread-detail-page__mobile-tab--active" : ""}`}
+              onClick={() => setMobileView("tasks")}
             >
-              Details
+              Tasks
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={mobileView === "context"}
+              className={`thread-detail-page__mobile-tab ${mobileView === "context" ? "thread-detail-page__mobile-tab--active" : ""}`}
+              onClick={() => setMobileView("context")}
+            >
+              Context
             </button>
           </div>
         </div>
 
-        <div className="thread-detail-page__mobile-insights">
-          <button
-            type="button"
-            className="thread-detail-page__mobile-insight-card"
-            onClick={() => setMobileView("details")}
-          >
-            <Text size="1" tone="muted">
-              Tasks
-            </Text>
-            <Text size="3" weight="bold">
-              {thread.tasks.length}
-            </Text>
-          </button>
-          <button
-            type="button"
-            className="thread-detail-page__mobile-insight-card"
-            onClick={() => setMobileView("details")}
-          >
-            <Text size="1" tone="muted">
-              Context blocks
-            </Text>
-            <Text size="3" weight="bold">
-              {contextBlocks.length}
-            </Text>
-          </button>
+        {/* Scrollable content area */}
+        <div className="thread-detail-page__mobile-view-content">
+          {mobileView === "chat" && (
+            <div className="thread-detail-page__mobile-chat-view">
+              <ThreadChat threadId={thread.id} />
+            </div>
+          )}
+
+          {mobileView === "tasks" && (
+            <div className="thread-detail-page__mobile-scrollable">
+              {taskGroups.length > 0 ? (
+                taskGroups.map((group) => (
+                  <div key={group.status} className="thread-detail-page__mobile-section">
+                    <DataRowContainer title={group.label}>
+                      {group.tasks.map((task) => (
+                        <ThreadTaskRow
+                          key={task.id}
+                          task={task}
+                          onClick={() => navigate(`/tasks/task/${task.id}`)}
+                        />
+                      ))}
+                    </DataRowContainer>
+                  </div>
+                ))
+              ) : (
+                <div className="thread-detail-page__mobile-empty">
+                  <Text size="2" tone="muted">
+                    No tasks attached
+                  </Text>
+                </div>
+              )}
+            </div>
+          )}
+
+          {mobileView === "context" && (
+            <div className="thread-detail-page__mobile-scrollable">
+              {contextBlocks.length > 0 ? (
+                <div className="thread-detail-page__mobile-section">
+                  <div className="thread-detail-page__mobile-list">
+                    {contextBlocks.map((contextBlock) => (
+                      <ThreadContextCard
+                        key={`${contextBlock.id}-${contextBlock.isStateMemory ? "state" : "reference"}`}
+                        contextBlock={contextBlock}
+                        isStateMemory={contextBlock.isStateMemory}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="thread-detail-page__mobile-empty">
+                  <Text size="2" tone="muted">
+                    No context blocks attached
+                  </Text>
+                </div>
+              )}
+            </div>
+          )}
         </div>
-
-        {taskStatusSummary.length > 0 && (
-          <div className="thread-detail-page__mobile-status-strip">
-            {taskStatusSummary.map((item) => (
-              <button
-                type="button"
-                key={item.status}
-                className="thread-detail-page__mobile-status-chip"
-                onClick={() => setMobileView("details")}
-              >
-                <Text size="1">{item.label}</Text>
-                <Text size="1" weight="semibold">
-                  {item.count}
-                </Text>
-              </button>
-            ))}
-          </div>
-        )}
-
-        {mobileView === "chat" && (
-          <div className="thread-detail-page__mobile-chat-shell">
-            <ThreadChat threadId={thread.id} />
-          </div>
-        )}
-
-        {mobileView === "details" && (
-          <>
-            {/* Tasks grouped by status using TaskRow */}
-            {taskGroups.map((group) => (
-              <div key={group.status} className="thread-detail-page__mobile-section">
-                <DataRowContainer title={group.label}>
-                  {group.tasks.map((task) => (
-                    <ThreadTaskRow
-                      key={task.id}
-                      task={task}
-                      onClick={() => navigate(`/tasks/task/${task.id}`)}
-                    />
-                  ))}
-                </DataRowContainer>
-              </div>
-            ))}
-
-            {/* Context section */}
-            {contextBlocks.length > 0 && (
-              <div className="thread-detail-page__mobile-section">
-                <Text size="2" weight="semibold">
-                  Context ({contextBlocks.length})
-                </Text>
-                <div className="thread-detail-page__mobile-list">
-                  {contextBlocks.map((contextBlock) => (
-                    <ThreadContextCard
-                      key={`${contextBlock.id}-${contextBlock.isStateMemory ? "state" : "reference"}`}
-                      contextBlock={contextBlock}
-                      isStateMemory={contextBlock.isStateMemory}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Participants section */}
-            {thread.participants.length > 0 && (
-              <div className="thread-detail-page__mobile-section">
-                <Text size="2" weight="semibold">
-                  Participants ({thread.participants.length})
-                </Text>
-                <div className="thread-detail-page__mobile-list">
-                  {thread.participants.map((participant) => (
-                    <Text key={participant.id} size="2">
-                      {participant.displayName} (@{participant.slug})
-                    </Text>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            <DeleteWithConfirmation
-              className="thread-detail-page__actions"
-              onDelete={onDelete}
-              size="sm"
-              deleteLabel="Delete thread"
-              confirmLabel="Delete forever"
-            />
-          </>
-        )}
-
-        {mobileView === "chat" && (
-          <div className="thread-detail-page__mobile-jump-row">
-            <Button variant="secondary" onClick={() => setMobileView("details")}>
-              View tasks and context
-            </Button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/apps/ui/src/features/threads/ThreadDetailPage.tsx
+++ b/apps/ui/src/features/threads/ThreadDetailPage.tsx
@@ -33,12 +33,6 @@ type DisplayContextBlock = {
   isStateMemory: boolean;
 };
 
-type TaskStatusSummary = {
-  status: TaskStatus;
-  label: string;
-  count: number;
-};
-
 const THREADS_SOCKET_URL = getUIWebSocketUrl('/threads');
 const TASKS_SOCKET_URL = getUIWebSocketUrl('/tasks');
 
@@ -125,28 +119,6 @@ const getContextBlocksForDisplay = (thread: Thread): DisplayContextBlock[] => {
   });
 
   return allBlocks;
-};
-
-const getTaskStatusSummary = (thread: Thread): TaskStatusSummary[] => {
-  const counts: Record<TaskStatus, number> = {
-    [TaskStatus.DONE]: 0,
-    [TaskStatus.FOR_REVIEW]: 0,
-    [TaskStatus.IN_PROGRESS]: 0,
-    [TaskStatus.NOT_STARTED]: 0,
-  };
-
-  thread.tasks.forEach((task) => {
-    const status = task.status as TaskStatus;
-    if (status in counts) {
-      counts[status] += 1;
-    }
-  });
-
-  return STATUS_ORDER.map((status) => ({
-    status,
-    label: TASKS_STATUS[status].label,
-    count: counts[status],
-  })).filter((item) => item.count > 0);
 };
 
 export function ThreadDetailPage() {

--- a/apps/ui/src/features/threads/ThreadsLayout.tsx
+++ b/apps/ui/src/features/threads/ThreadsLayout.tsx
@@ -23,13 +23,16 @@ export function ThreadsLayout(): React.JSX.Element {
           <Outlet />
         </DesktopShell>)
         :
+        isThreadDetailRoute ? (
+          <Outlet />
+        ) : (
         <IosShell
           appTitle="Threads"
           sectionTitle={sectionTitle}
           navItems={navItems}
         >
           <Outlet />
-        </IosShell>}
+        </IosShell>)}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restructured mobile thread detail page with cleaner, more focused layout
- Added 3-tab navigation (Chat, Tasks, Context) replacing the previous 2-tab system
- Removed visual clutter: insight cards, status strips, and navigation buttons
- Moved delete button to thread header with minimal "×" icon
- Fixed chat scrolling behavior for better mobile UX

## Changes Made

### Layout Restructure
- **Fixed top section**: Thread metadata and 3-tab navigation
- **Scrollable content area**: Active tab content (chat messages, tasks list, or context blocks)
- **Removed elements**:
  - Task/block count insight cards
  - Status summary chips
  - "View tasks and context" button below chat

### Tab Navigation
- **Chat tab**: Shows thread messages (scrollable)
- **Tasks tab**: Shows tasks using existing ThreadTaskRow components
- **Context tab**: Shows context blocks

### Mobile UX Improvements
- Delete thread button integrated into header (non-intrusive)
- Better scrolling behavior for chat messages
- Cleaner visual hierarchy
- Empty states for tasks and context tabs

## Technical Details
- Modified `ThreadDetailPageMobile` component in `ThreadDetailPage.tsx`
- Updated CSS for new mobile layout structure
- Improved ThreadChat scrollbar styling (thin, styled scrollbar instead of hidden)

## Test Plan
- [x] Ran `npm run build:dev` - build successful
- [x] Ran `npm run dev:1` - app starts correctly
- [ ] Manual testing of mobile UI needed
- [ ] Verify all three tabs render correctly
- [ ] Test delete functionality from new location
- [ ] Verify scrolling works properly in all views

🤖 Generated with [Claude Code](https://claude.com/claude-code)