### PR TITLE
Improve threads mobile UI with iOS shell integration

### DIFF
--- a/apps/ui/src/features/threads/ThreadDetailPage.css
+++ b/apps/ui/src/features/threads/ThreadDetailPage.css
@@ -188,87 +188,36 @@
 /* Mobile layout */
 .thread-detail-page--mobile {
   background-color: var(--bg);
-  height: 100vh;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-}
-
-.thread-detail-page__mobile-wrapper {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
   min-height: 0;
-}
-
-.thread-detail-page__mobile-topbar {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  padding: var(--space-3) var(--space-3) var(--space-2);
-  background: var(--bg);
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.thread-detail-page__mobile-nav {
-  display: flex;
-  align-items: center;
-  margin-bottom: var(--space-1);
-}
-
-.thread-detail-page__mobile-back {
-  background: none;
-  border: none;
-  color: var(--accent);
-  font-size: var(--fs-2);
-  font-weight: var(--fw-medium);
-  cursor: pointer;
-  padding: var(--space-1) 0;
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-}
-
-.thread-detail-page__mobile-back:hover {
-  opacity: 0.8;
 }
 
 .thread-detail-page__mobile-thread-meta {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-}
-
-.thread-detail-page__mobile-thread-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-}
-
-.thread-detail-page__mobile-delete {
-  flex-shrink: 0;
-}
-
-.thread-detail-page__mobile-delete .btn {
-  min-width: auto;
-  padding: var(--space-1) var(--space-2);
-  font-size: var(--fs-4);
-  line-height: 1;
+  padding: var(--space-3) var(--space-3) var(--space-2);
+  background: var(--bg);
 }
 
 .thread-detail-page__mobile-view-toggle {
+  position: sticky;
+  top: 0;
+  z-index: 5;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
   gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .thread-detail-page__mobile-tab {
   border: 1px solid var(--border);
   background: var(--surface);
   color: var(--text);
-  padding: var(--space-2) var(--space-3);
+  padding: var(--space-2) var(--space-2);
   cursor: pointer;
   font-size: var(--fs-2);
   font-weight: var(--fw-medium);
@@ -282,7 +231,6 @@
 .thread-detail-page__mobile-view-content {
   flex: 1;
   min-height: 0;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
 }
@@ -290,7 +238,6 @@
 .thread-detail-page__mobile-chat-view {
   flex: 1;
   min-height: 0;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
   padding: 0 var(--space-3);
@@ -322,4 +269,25 @@
   justify-content: center;
   padding: var(--space-6) var(--space-3);
   border: 1px dashed var(--border-subtle);
+}
+
+.thread-detail-page__mobile-settings-section {
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+}
+
+.thread-detail-page__mobile-settings-button {
+  width: 100%;
+}
+
+.thread-detail-page__mobile-delete-action {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.thread-detail-page__mobile-delete-action .btn {
+  width: 100%;
 }

--- a/apps/ui/src/features/threads/ThreadDetailPage.tsx
+++ b/apps/ui/src/features/threads/ThreadDetailPage.tsx
@@ -428,128 +428,165 @@ function ThreadDetailPageMobile({
   const navigate = useNavigate();
   const taskGroups = groupTasksByStatus(thread);
   const contextBlocks = getContextBlocksForDisplay(thread);
-  const [mobileView, setMobileView] = useState<"chat" | "tasks" | "context">("chat");
+  const [mobileView, setMobileView] = useState<"chat" | "tasks" | "context" | "more">("chat");
 
   return (
     <div className="thread-detail-page thread-detail-page--mobile">
-      <div className="thread-detail-page__mobile-wrapper">
-        {/* Fixed top section with tabs */}
-        <div className="thread-detail-page__mobile-topbar">
-          <div className="thread-detail-page__mobile-nav">
-            <button
-              className="thread-detail-page__mobile-back"
-              onClick={() => navigate('/threads')}
-              aria-label="Back to threads"
-            >
-              ← Back
-            </button>
-          </div>
-          <div className="thread-detail-page__mobile-thread-meta">
-            <div className="thread-detail-page__mobile-thread-header">
-              <Text size="2" weight="semibold">
-                {thread.title}
-              </Text>
-              <DeleteWithConfirmation
-                className="thread-detail-page__mobile-delete"
-                onDelete={onDelete}
-                size="sm"
-                deleteLabel="×"
-                confirmLabel="Delete forever"
-              />
-            </div>
-            <Text size="1" tone="muted">
-              #{thread.id.slice(0, 6)} · {thread.participants.length} participants
-            </Text>
-          </div>
-          <div className="thread-detail-page__mobile-view-toggle" role="tablist" aria-label="Thread mobile views">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={mobileView === "chat"}
-              className={`thread-detail-page__mobile-tab ${mobileView === "chat" ? "thread-detail-page__mobile-tab--active" : ""}`}
-              onClick={() => setMobileView("chat")}
-            >
-              Chat
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={mobileView === "tasks"}
-              className={`thread-detail-page__mobile-tab ${mobileView === "tasks" ? "thread-detail-page__mobile-tab--active" : ""}`}
-              onClick={() => setMobileView("tasks")}
-            >
-              Tasks
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={mobileView === "context"}
-              className={`thread-detail-page__mobile-tab ${mobileView === "context" ? "thread-detail-page__mobile-tab--active" : ""}`}
-              onClick={() => setMobileView("context")}
-            >
-              Context
-            </button>
-          </div>
-        </div>
+      {/* Thread info header */}
+      <div className="thread-detail-page__mobile-thread-meta">
+        <Text size="2" weight="semibold">
+          {thread.title}
+        </Text>
+        <Text size="1" tone="muted">
+          #{thread.id.slice(0, 6)} · {thread.participants.length} participants
+        </Text>
+      </div>
 
-        {/* Scrollable content area */}
-        <div className="thread-detail-page__mobile-view-content">
-          {mobileView === "chat" && (
-            <div className="thread-detail-page__mobile-chat-view">
-              <ThreadChat threadId={thread.id} />
-            </div>
-          )}
+      {/* Tab navigation - fixed */}
+      <div className="thread-detail-page__mobile-view-toggle" role="tablist" aria-label="Thread mobile views">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mobileView === "chat"}
+          className={`thread-detail-page__mobile-tab ${mobileView === "chat" ? "thread-detail-page__mobile-tab--active" : ""}`}
+          onClick={() => setMobileView("chat")}
+        >
+          Chat
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mobileView === "tasks"}
+          className={`thread-detail-page__mobile-tab ${mobileView === "tasks" ? "thread-detail-page__mobile-tab--active" : ""}`}
+          onClick={() => setMobileView("tasks")}
+        >
+          Tasks
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mobileView === "context"}
+          className={`thread-detail-page__mobile-tab ${mobileView === "context" ? "thread-detail-page__mobile-tab--active" : ""}`}
+          onClick={() => setMobileView("context")}
+        >
+          Context
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mobileView === "more"}
+          className={`thread-detail-page__mobile-tab ${mobileView === "more" ? "thread-detail-page__mobile-tab--active" : ""}`}
+          onClick={() => setMobileView("more")}
+        >
+          More
+        </button>
+      </div>
 
-          {mobileView === "tasks" && (
-            <div className="thread-detail-page__mobile-scrollable">
-              {taskGroups.length > 0 ? (
-                taskGroups.map((group) => (
-                  <div key={group.status} className="thread-detail-page__mobile-section">
-                    <DataRowContainer title={group.label}>
-                      {group.tasks.map((task) => (
-                        <ThreadTaskRow
-                          key={task.id}
-                          task={task}
-                          onClick={() => navigate(`/tasks/task/${task.id}`)}
-                        />
-                      ))}
-                    </DataRowContainer>
-                  </div>
-                ))
-              ) : (
-                <div className="thread-detail-page__mobile-empty">
-                  <Text size="2" tone="muted">
-                    No tasks attached
-                  </Text>
-                </div>
-              )}
-            </div>
-          )}
+      {/* Scrollable content area */}
+      <div className="thread-detail-page__mobile-view-content">
+        {mobileView === "chat" && (
+          <div className="thread-detail-page__mobile-chat-view">
+            <ThreadChat threadId={thread.id} />
+          </div>
+        )}
 
-          {mobileView === "context" && (
-            <div className="thread-detail-page__mobile-scrollable">
-              {contextBlocks.length > 0 ? (
-                <div className="thread-detail-page__mobile-section">
-                  <div className="thread-detail-page__mobile-list">
-                    {contextBlocks.map((contextBlock) => (
-                      <ThreadContextCard
-                        key={`${contextBlock.id}-${contextBlock.isStateMemory ? "state" : "reference"}`}
-                        contextBlock={contextBlock}
-                        isStateMemory={contextBlock.isStateMemory}
+        {mobileView === "tasks" && (
+          <div className="thread-detail-page__mobile-scrollable">
+            {taskGroups.length > 0 ? (
+              taskGroups.map((group) => (
+                <div key={group.status} className="thread-detail-page__mobile-section">
+                  <DataRowContainer title={group.label}>
+                    {group.tasks.map((task) => (
+                      <ThreadTaskRow
+                        key={task.id}
+                        task={task}
+                        onClick={() => navigate(`/tasks/task/${task.id}`)}
                       />
                     ))}
-                  </div>
+                  </DataRowContainer>
                 </div>
-              ) : (
-                <div className="thread-detail-page__mobile-empty">
-                  <Text size="2" tone="muted">
-                    No context blocks attached
+              ))
+            ) : (
+              <div className="thread-detail-page__mobile-empty">
+                <Text size="2" tone="muted">
+                  No tasks attached
+                </Text>
+              </div>
+            )}
+          </div>
+        )}
+
+        {mobileView === "context" && (
+          <div className="thread-detail-page__mobile-scrollable">
+            {contextBlocks.length > 0 ? (
+              <div className="thread-detail-page__mobile-section">
+                <div className="thread-detail-page__mobile-list">
+                  {contextBlocks.map((contextBlock) => (
+                    <ThreadContextCard
+                      key={`${contextBlock.id}-${contextBlock.isStateMemory ? "state" : "reference"}`}
+                      contextBlock={contextBlock}
+                      isStateMemory={contextBlock.isStateMemory}
+                    />
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="thread-detail-page__mobile-empty">
+                <Text size="2" tone="muted">
+                  No context blocks attached
+                </Text>
+              </div>
+            )}
+          </div>
+        )}
+
+        {mobileView === "more" && (
+          <div className="thread-detail-page__mobile-scrollable">
+            <div className="thread-detail-page__mobile-section">
+              <Stack spacing="4">
+                <Stack spacing="2">
+                  <Text size="2" weight="semibold">
+                    Thread Settings
                   </Text>
+                  <Text size="2" tone="muted">
+                    Manage this thread's settings and data.
+                  </Text>
+                </Stack>
+
+                <div className="thread-detail-page__mobile-settings-section">
+                  <Stack spacing="3">
+                    <Text size="2" weight="semibold">
+                      Attach Items (Coming Soon)
+                    </Text>
+                    <Stack spacing="2">
+                      <Button variant="secondary" disabled className="thread-detail-page__mobile-settings-button">
+                        Add Task
+                      </Button>
+                      <Button variant="secondary" disabled className="thread-detail-page__mobile-settings-button">
+                        Add Context Block
+                      </Button>
+                    </Stack>
+                  </Stack>
                 </div>
-              )}
+
+                <div className="thread-detail-page__mobile-settings-section">
+                  <Stack spacing="3">
+                    <Text size="2" weight="semibold">
+                      Danger Zone
+                    </Text>
+                    <DeleteWithConfirmation
+                      className="thread-detail-page__mobile-delete-action"
+                      onDelete={onDelete}
+                      size="md"
+                      deleteLabel="Delete Thread"
+                      confirmLabel="Delete Forever"
+                    />
+                  </Stack>
+                </div>
+              </Stack>
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/ui/src/features/threads/ThreadsLayout.tsx
+++ b/apps/ui/src/features/threads/ThreadsLayout.tsx
@@ -23,16 +23,13 @@ export function ThreadsLayout(): React.JSX.Element {
           <Outlet />
         </DesktopShell>)
         :
-        isThreadDetailRoute ? (
-          <Outlet />
-        ) : (
         <IosShell
           appTitle="Threads"
           sectionTitle={sectionTitle}
           navItems={navItems}
         >
           <Outlet />
-        </IosShell>)}
+        </IosShell>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ✅ Restored iOS Shell for mobile navigation with hamburger menu
- ✅ Added "More" tab for thread settings (delete + future add task/block features)
- ✅ Fixed double scrolling issue with proper CSS hierarchy

## Changes Made

### 1. iOS Shell Integration
- Modified `ThreadsLayout.tsx` to wrap mobile thread detail pages in `IosShell`
- This brings back the hamburger menu drawer for navigation
- Removed the redundant "Back" button that was previously in the header

### 2. Improved Tab Navigation
- Added a 4th tab "More" alongside Chat, Tasks, and Context
- More tab contains:
  - Thread settings section
  - Delete thread functionality (moved from header)
  - Placeholders for "Add Task" and "Add Context Block" (coming soon)

### 3. Fixed Layout & Scrolling
- Eliminated nested scroll containers causing double scrollbars
- Proper hierarchy now:
  - Fixed header with burger menu (from IosShell)
  - Thread metadata (title, ID, participants)
  - Sticky tabs (always visible while scrolling)
  - Single scrollable content area
  - Chat input pinned to bottom (in Chat view)

## Technical Details
- Used TypeScript-compliant Stack components instead of inline styles
- Removed fixed positioning that was creating layout conflicts
- Ensured proper integration with IosShell's scroll structure
- All changes are in the UI layer only (no backend changes)

## Test Plan
- [x] Build passes (`npm run build:dev`)
- [x] Dev server starts successfully (`npm run dev:2`)
- [ ] Manual testing on mobile viewport needed
- [ ] Test burger menu navigation
- [ ] Test all 4 tabs (Chat, Tasks, Context, More)
- [ ] Verify no double scrolling
- [ ] Test delete thread functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)