### PR TITLE
fix: Rework mobile threads UI to fix layout issues

### DIFF
--- a/apps/ui/src/features/threads/ThreadDetailPage.css
+++ b/apps/ui/src/features/threads/ThreadDetailPage.css
@@ -187,24 +187,63 @@
 
 /* Mobile layout */
 .thread-detail-page--mobile {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   background-color: var(--bg);
   display: flex;
   flex-direction: column;
-  min-height: 0;
+  overflow: hidden;
 }
 
-.thread-detail-page__mobile-thread-meta {
+/* Mobile header */
+.thread-detail-page__mobile-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  padding-top: calc(env(safe-area-inset-top) + var(--space-3));
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.thread-detail-page__mobile-burger {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: var(--text);
+  cursor: pointer;
+  padding: var(--space-2);
+  margin: calc(var(--space-2) * -1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-2);
+  flex-shrink: 0;
+}
+
+.thread-detail-page__mobile-header-content {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  padding: var(--space-3) var(--space-3) var(--space-2);
-  background: var(--bg);
+  min-width: 0;
+  flex: 1;
 }
 
-.thread-detail-page__mobile-view-toggle {
-  position: sticky;
-  top: 0;
-  z-index: 5;
+/* Mobile tabs */
+.thread-detail-page__mobile-tabs {
+  position: fixed;
+  top: calc(env(safe-area-inset-top) + 60px);
+  left: 0;
+  right: 0;
+  z-index: 9;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
   gap: var(--space-2);
@@ -228,19 +267,25 @@
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
 }
 
-.thread-detail-page__mobile-view-content {
-  flex: 1;
-  min-height: 0;
+/* Mobile content area */
+.thread-detail-page__mobile-content {
+  position: fixed;
+  top: calc(env(safe-area-inset-top) + 120px);
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
-.thread-detail-page__mobile-chat-view {
+.thread-detail-page__mobile-chat-container {
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
   padding: 0 var(--space-3);
+  overflow: hidden;
 }
 
 .thread-detail-page__mobile-scrollable {
@@ -290,4 +335,96 @@
 
 .thread-detail-page__mobile-delete-action .btn {
   width: 100%;
+}
+
+/* Mobile drawer */
+.thread-detail-page__mobile-drawer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 50;
+}
+
+.thread-detail-page__mobile-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 280px;
+  max-width: 80vw;
+  background-color: var(--nav-bar);
+  border-right: 1px solid var(--border);
+  z-index: 51;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+}
+
+.thread-detail-page__mobile-drawer--open {
+  transform: translateX(0);
+}
+
+.thread-detail-page__mobile-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4);
+  padding-top: calc(env(safe-area-inset-top) + var(--space-4));
+  border-bottom: 1px solid var(--border);
+}
+
+.thread-detail-page__mobile-drawer-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--space-2);
+  margin: calc(var(--space-2) * -1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-2);
+}
+
+.thread-detail-page__mobile-drawer-nav {
+  flex: 1;
+  padding: var(--space-2);
+  overflow-y: auto;
+}
+
+.thread-detail-page__mobile-drawer-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  text-decoration: none;
+  color: var(--text);
+  border-radius: var(--r-2);
+  margin-bottom: var(--space-1);
+  background: none;
+  border: none;
+  width: 100%;
+  cursor: pointer;
+  text-align: left;
+}
+
+.thread-detail-page__mobile-drawer-item--active {
+  background-color: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: var(--fw-medium);
+}
+
+.thread-detail-page__mobile-drawer-icon {
+  font-size: 20px;
+  width: 24px;
+  text-align: center;
+}
+
+.thread-detail-page__mobile-drawer-label {
+  font-size: var(--fs-2);
 }

--- a/apps/ui/src/features/threads/ThreadDetailPage.tsx
+++ b/apps/ui/src/features/threads/ThreadDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { io } from "socket.io-client";
 import {
   TaskAssignedWireEvent,
@@ -429,21 +429,34 @@ function ThreadDetailPageMobile({
   const taskGroups = groupTasksByStatus(thread);
   const contextBlocks = getContextBlocksForDisplay(thread);
   const [mobileView, setMobileView] = useState<"chat" | "tasks" | "context" | "more">("chat");
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   return (
     <div className="thread-detail-page thread-detail-page--mobile">
-      {/* Thread info header */}
-      <div className="thread-detail-page__mobile-thread-meta">
-        <Text size="2" weight="semibold">
-          {thread.title}
-        </Text>
-        <Text size="1" tone="muted">
-          #{thread.id.slice(0, 6)} · {thread.participants.length} participants
-        </Text>
-      </div>
+      {/* Mobile drawer */}
+      <MobileDrawer isOpen={isDrawerOpen} onClose={() => setIsDrawerOpen(false)} />
 
-      {/* Tab navigation - fixed */}
-      <div className="thread-detail-page__mobile-view-toggle" role="tablist" aria-label="Thread mobile views">
+      {/* Fixed header with burger menu */}
+      <header className="thread-detail-page__mobile-header">
+        <button
+          className="thread-detail-page__mobile-burger"
+          onClick={() => setIsDrawerOpen(true)}
+          aria-label="Open menu"
+        >
+          ☰
+        </button>
+        <div className="thread-detail-page__mobile-header-content">
+          <Text size="2" weight="semibold">
+            {thread.title}
+          </Text>
+          <Text size="1" tone="muted">
+            #{thread.id.slice(0, 6)} · {thread.participants.length} participants
+          </Text>
+        </div>
+      </header>
+
+      {/* Fixed tab navigation */}
+      <div className="thread-detail-page__mobile-tabs" role="tablist" aria-label="Thread mobile views">
         <button
           type="button"
           role="tab"
@@ -482,10 +495,10 @@ function ThreadDetailPageMobile({
         </button>
       </div>
 
-      {/* Scrollable content area */}
-      <div className="thread-detail-page__mobile-view-content">
+      {/* Main content area - scrollable or fixed depending on view */}
+      <div className="thread-detail-page__mobile-content">
         {mobileView === "chat" && (
-          <div className="thread-detail-page__mobile-chat-view">
+          <div className="thread-detail-page__mobile-chat-container">
             <ThreadChat threadId={thread.id} />
           </div>
         )}
@@ -589,5 +602,55 @@ function ThreadDetailPageMobile({
         )}
       </div>
     </div>
+  );
+}
+
+// Mobile drawer component
+function MobileDrawer({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const MAIN_NAV_ITEMS = [
+    { path: "/dashboard", icon: "🏠", label: "Dashboard" },
+    { path: "/threads", icon: "💬", label: "Threads" },
+    { path: "/tasks", icon: "✓", label: "Tasks" },
+    { path: "/context", icon: "📄", label: "Context" },
+  ];
+
+  return (
+    <>
+      {isOpen && (
+        <div className="thread-detail-page__mobile-drawer-overlay" onClick={onClose} />
+      )}
+      <aside className={`thread-detail-page__mobile-drawer ${isOpen ? "thread-detail-page__mobile-drawer--open" : ""}`}>
+        <div className="thread-detail-page__mobile-drawer-header">
+          <Text size="4" weight="bold">taico</Text>
+          <button
+            className="thread-detail-page__mobile-drawer-close"
+            onClick={onClose}
+            aria-label="Close menu"
+          >
+            ✕
+          </button>
+        </div>
+        <nav className="thread-detail-page__mobile-drawer-nav">
+          {MAIN_NAV_ITEMS.map((item) => {
+            const isActive = location.pathname === item.path || location.pathname.startsWith(item.path + '/');
+            return (
+              <button
+                key={item.path}
+                className={`thread-detail-page__mobile-drawer-item ${isActive ? "thread-detail-page__mobile-drawer-item--active" : ""}`}
+                onClick={() => {
+                  navigate(item.path);
+                  onClose();
+                }}
+              >
+                <span className="thread-detail-page__mobile-drawer-icon">{item.icon}</span>
+                <span className="thread-detail-page__mobile-drawer-label">{item.label}</span>
+              </button>
+            );
+          })}
+        </nav>
+      </aside>
+    </>
   );
 }

--- a/apps/ui/src/features/threads/ThreadsLayout.tsx
+++ b/apps/ui/src/features/threads/ThreadsLayout.tsx
@@ -23,13 +23,19 @@ export function ThreadsLayout(): React.JSX.Element {
           <Outlet />
         </DesktopShell>)
         :
-        <IosShell
-          appTitle="Threads"
-          sectionTitle={sectionTitle}
-          navItems={navItems}
-        >
+        isThreadDetailRoute ? (
+          // Thread detail on mobile: bypass IosShell, use custom layout
           <Outlet />
-        </IosShell>}
+        ) : (
+          // Thread list on mobile: use IosShell with bottom nav
+          <IosShell
+            appTitle="Threads"
+            sectionTitle={sectionTitle}
+            navItems={navItems}
+          >
+            <Outlet />
+          </IosShell>
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the three critical issues with the mobile threads UI:

1. **Removed unwanted bottom navigation**: The IosShell was showing the bottom nav bar with dashboard/tasks/context links. Now thread detail pages bypass IosShell completely on mobile.

2. **Fixed double scrolling**: Created a proper fixed-position layout hierarchy:
   - Fixed header at top with burger menu
   - Fixed tabs below header (Chat, Tasks, Context, More)
   - Content area fills remaining space
   - Each view manages its own scrolling

3. **Chat input pinned to bottom**: The chat input form is now always visible at the bottom of the screen and doesn't scroll away.

## Technical Changes

- `ThreadsLayout.tsx`: Added conditional logic to bypass IosShell for thread detail pages on mobile
- `ThreadDetailPageMobile`: Complete rewrite with custom fixed-position layout
- Added `MobileDrawer` component for navigation (replicates IosShell drawer)
- Updated CSS to use position: fixed for header, tabs, and proper flex layout for content

## Testing

- ✅ `npm run build:dev` passes
- ✅ `npm run dev:2` starts successfully
- ✅ Mobile layout no longer shows bottom navigation
- ✅ Single scroll container, no double scrolling
- ✅ Chat input always visible at bottom

🤖 Generated with Claude Code