### PR TITLE
Fix agent creation wizard tag input font size to prevent iOS zoom

### DIFF
--- a/apps/ui/src/features/agents/NewAgentWizardPage.css
+++ b/apps/ui/src/features/agents/NewAgentWizardPage.css
@@ -94,6 +94,7 @@
   border: 1px solid var(--border);
   border-radius: var(--r-2);
   font: inherit;
+  font-size: var(--fs-input-mobile-safe); /* Prevent iOS zoom on focus */
 }
 
 .new-agent-wizard__field input:focus {


### PR DESCRIPTION
## Summary
- Fixed tag input field in agent creation wizard to use mobile-safe font size (16px)
- Prevents iOS from auto-zooming when the input is focused
- Applied existing CSS token `var(--fs-input-mobile-safe)` to `.new-agent-wizard__field input`

## Context
When entering tags in the agent creation wizard on iOS, the browser was zooming in because the font size was below 16px (the iOS-safe minimum). This fix applies the existing mobile-safe font size token that's already defined in the design system.

## Changes
- Added `font-size: var(--fs-input-mobile-safe);` to the tag input field styles in `NewAgentWizardPage.css`

## Test plan
- [x] Ran `npm run build:dev` - builds successfully
- [x] Ran `npm run dev:1` - app starts correctly with no errors
- [ ] Manual testing: Create new agent on iOS device and verify tag input doesn't cause zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)