### PR TITLE
Fix comment order to display oldest first

### DIFF
--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -547,7 +547,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
         timestamp: new Date(inputRequest.createdAt).getTime(),
       })),
     ]
-      .sort((a, b) => b.timestamp - a.timestamp) as TimelineItem[];
+      .sort((a, b) => a.timestamp - b.timestamp) as TimelineItem[];
   }, [task]);
 
   const visibleTimelineItems = showAllTimelineItems


### PR DESCRIPTION
## Summary
Fixed the comment sorting order in the task detail view to display comments from oldest (top) to newest (bottom).

## Changes
- Changed timeline sorting in `TaskDetailPage.tsx` from descending (`b.timestamp - a.timestamp`) to ascending (`a.timestamp - b.timestamp`)
- This affects both comments and input requests in the Updates section

## Testing
- ✅ Ran `npm run build:dev` - build successful
- ✅ Ran `npm run dev:2` - app starts successfully

## Notes
The issue was introduced when the collapse feature was added to the comments section, which inadvertently reversed the sort order. This fix restores the expected chronological order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)