### PR TITLE
Add pagination to executions endpoints

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -5957,19 +5957,39 @@
     },
     "/api/v1/executions/queue": {
       "get": {
-        "description": "Returns the tasks currently present in the execution queue. Presence means the task is ready to be picked by the executor.",
+        "description": "Returns the tasks currently present in the execution queue with pagination. Presence means the task is ready to be picked by the executor.",
         "operationId": "TaskExecutionQueueController_listQueue",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Items per page (1-100)",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TaskExecutionQueueEntryResponseDto"
-                  }
+                  "$ref": "#/components/schemas/TaskExecutionQueueListResponseDto"
                 }
               }
             }
@@ -6026,19 +6046,39 @@
     },
     "/api/v1/executions/active": {
       "get": {
-        "description": "Returns the tasks currently being worked on in the execution system.",
+        "description": "Returns the tasks currently being worked on in the execution system with pagination.",
         "operationId": "ActiveTaskExecutionController_listActiveExecutions",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Items per page (1-100)",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActiveTaskExecutionResponseDto"
-                  }
+                  "$ref": "#/components/schemas/ActiveTaskExecutionListResponseDto"
                 }
               }
             }
@@ -6249,19 +6289,39 @@
     },
     "/api/v1/executions/history": {
       "get": {
-        "description": "Returns the persisted execution history rows in the execution system.",
+        "description": "Returns the persisted execution history rows in the execution system with pagination.",
         "operationId": "TaskExecutionHistoryController_listHistory",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Items per page (1-100)",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TaskExecutionHistoryResponseDto"
-                  }
+                  "$ref": "#/components/schemas/TaskExecutionHistoryListResponseDto"
                 }
               }
             }
@@ -11779,6 +11839,45 @@
           "taskStatus"
         ]
       },
+      "TaskExecutionQueueListResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of task execution queue entries",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskExecutionQueueEntryResponseDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "description": "Total number of queue entries",
+            "example": 42
+          },
+          "page": {
+            "type": "number",
+            "description": "Current page number",
+            "example": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of items per page",
+            "example": 50
+          },
+          "totalPages": {
+            "type": "number",
+            "description": "Total number of pages",
+            "example": 3
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "limit",
+          "totalPages"
+        ]
+      },
       "ActiveTaskExecutionTagSnapshotResponseDto": {
         "type": "object",
         "properties": {
@@ -11957,6 +12056,45 @@
           "taskAssigneeActorIdBeforeClaim",
           "agentActorId",
           "stats"
+        ]
+      },
+      "ActiveTaskExecutionListResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of active task executions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActiveTaskExecutionResponseDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "description": "Total number of active executions",
+            "example": 42
+          },
+          "page": {
+            "type": "number",
+            "description": "Current page number",
+            "example": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of items per page",
+            "example": 50
+          },
+          "totalPages": {
+            "type": "number",
+            "description": "Total number of pages",
+            "example": 3
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "limit",
+          "totalPages"
         ]
       },
       "StopActiveTaskExecutionDto": {
@@ -12170,6 +12308,45 @@
             "minimum": 0
           }
         }
+      },
+      "TaskExecutionHistoryListResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of task execution history entries",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskExecutionHistoryResponseDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "description": "Total number of history entries",
+            "example": 42
+          },
+          "page": {
+            "type": "number",
+            "description": "Current page number",
+            "example": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of items per page",
+            "example": 50
+          },
+          "totalPages": {
+            "type": "number",
+            "description": "Total number of pages",
+            "example": 3
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "limit",
+          "totalPages"
+        ]
       },
       "WorkerResponseDto": {
         "type": "object",

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -6070,6 +6070,16 @@
               "example": 50,
               "type": "number"
             }
+          },
+          {
+            "name": "taskId",
+            "required": false,
+            "in": "query",
+            "description": "Filter by task ID",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6312,6 +6322,16 @@
               "default": 50,
               "example": 50,
               "type": "number"
+            }
+          },
+          {
+            "name": "taskId",
+            "required": false,
+            "in": "query",
+            "description": "Filter by task ID",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
             }
           }
         ],

--- a/apps/backend/src/executions/active/active-task-execution.controller.ts
+++ b/apps/backend/src/executions/active/active-task-execution.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -30,6 +31,8 @@ import {
 } from '../errors/executions.errors';
 import { ActiveTaskExecutionService } from './active-task-execution.service';
 import { ActiveTaskExecutionResponseDto } from './dto/http/active-task-execution-response.dto';
+import { ActiveTaskExecutionListResponseDto } from './dto/http/active-task-execution-list-response.dto';
+import { ListActiveExecutionsQueryDto } from './dto/http/list-active-executions-query.dto';
 import { StopActiveTaskExecutionDto } from './dto/http/stop-active-task-execution.dto';
 import { UpdateRunnerSessionIdDto } from './dto/http/update-runner-session-id.dto';
 import { TaskExecutionHistoryResponseDto } from '../history/dto/http/task-execution-history-response.dto';
@@ -49,14 +52,26 @@ export class ActiveTaskExecutionController {
   @ApiOperation({
     summary: 'List active task executions',
     description:
-      'Returns the tasks currently being worked on in the execution system.',
+      'Returns the tasks currently being worked on in the execution system with pagination.',
   })
-  @ApiOkResponse({ type: [ActiveTaskExecutionResponseDto] })
-  async listActiveExecutions(): Promise<ActiveTaskExecutionResponseDto[]> {
-    const executions = await this.activeTaskExecutionService.listActiveExecutions();
-    return executions.map((execution) =>
-      ActiveTaskExecutionResponseDto.fromEntity(execution),
-    );
+  @ApiOkResponse({ type: ActiveTaskExecutionListResponseDto })
+  async listActiveExecutions(
+    @Query() query: ListActiveExecutionsQueryDto,
+  ): Promise<ActiveTaskExecutionListResponseDto> {
+    const result = await this.activeTaskExecutionService.listActiveExecutions({
+      page: query.page ?? 1,
+      limit: query.limit ?? 50,
+    });
+
+    return {
+      items: result.items.map((item) =>
+        ActiveTaskExecutionResponseDto.fromEntity(item),
+      ),
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
+      totalPages: Math.ceil(result.total / result.limit),
+    };
   }
 
   @Post(':executionId/stop')

--- a/apps/backend/src/executions/active/active-task-execution.controller.ts
+++ b/apps/backend/src/executions/active/active-task-execution.controller.ts
@@ -61,6 +61,7 @@ export class ActiveTaskExecutionController {
     const result = await this.activeTaskExecutionService.listActiveExecutions({
       page: query.page ?? 1,
       limit: query.limit ?? 50,
+      taskId: query.taskId,
     });
 
     return {

--- a/apps/backend/src/executions/active/active-task-execution.service.ts
+++ b/apps/backend/src/executions/active/active-task-execution.service.ts
@@ -71,11 +71,27 @@ export class ActiveTaskExecutionService {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
-  async listActiveExecutions(): Promise<ActiveTaskExecutionEntity[]> {
-    return this.activeTaskExecutionRepository.find({
+  async listActiveExecutions(options?: {
+    page?: number;
+    limit?: number;
+  }): Promise<{
+    items: ActiveTaskExecutionEntity[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const page = options?.page ?? 1;
+    const limit = options?.limit ?? 50;
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await this.activeTaskExecutionRepository.findAndCount({
       relations: ['task', 'stats'],
       order: { claimedAt: 'DESC' },
+      skip,
+      take: limit,
     });
+
+    return { items, total, page, limit };
   }
 
   async claimTask(

--- a/apps/backend/src/executions/active/active-task-execution.service.ts
+++ b/apps/backend/src/executions/active/active-task-execution.service.ts
@@ -74,6 +74,7 @@ export class ActiveTaskExecutionService {
   async listActiveExecutions(options?: {
     page?: number;
     limit?: number;
+    taskId?: string;
   }): Promise<{
     items: ActiveTaskExecutionEntity[];
     total: number;
@@ -84,7 +85,10 @@ export class ActiveTaskExecutionService {
     const limit = options?.limit ?? 50;
     const skip = (page - 1) * limit;
 
+    const where = options?.taskId ? { taskId: options.taskId } : {};
+
     const [items, total] = await this.activeTaskExecutionRepository.findAndCount({
+      where,
       relations: ['task', 'stats'],
       order: { claimedAt: 'DESC' },
       skip,

--- a/apps/backend/src/executions/active/dto/http/active-task-execution-list-response.dto.ts
+++ b/apps/backend/src/executions/active/dto/http/active-task-execution-list-response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+import { ActiveTaskExecutionResponseDto } from './active-task-execution-response.dto';
+
+export class ActiveTaskExecutionListResponseDto {
+  @ApiProperty({
+    description: 'List of active task executions',
+    type: () => [ActiveTaskExecutionResponseDto],
+  })
+  @ValidateNested({ each: true })
+  @Type(() => ActiveTaskExecutionResponseDto)
+  items!: ActiveTaskExecutionResponseDto[];
+
+  @ApiProperty({
+    description: 'Total number of active executions',
+    example: 42,
+  })
+  total!: number;
+
+  @ApiProperty({
+    description: 'Current page number',
+    example: 1,
+  })
+  page!: number;
+
+  @ApiProperty({
+    description: 'Number of items per page',
+    example: 50,
+  })
+  limit!: number;
+
+  @ApiProperty({
+    description: 'Total number of pages',
+    example: 3,
+  })
+  totalPages!: number;
+}

--- a/apps/backend/src/executions/active/dto/http/list-active-executions-query.dto.ts
+++ b/apps/backend/src/executions/active/dto/http/list-active-executions-query.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsInt, Min } from 'class-validator';
+import { IsOptional, IsInt, Min, IsUUID } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 
@@ -24,4 +24,12 @@ export class ListActiveExecutionsQueryDto {
   @IsInt()
   @Min(1)
   limit?: number = 50;
+
+  @ApiPropertyOptional({
+    description: 'Filter by task ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsOptional()
+  @IsUUID()
+  taskId?: string;
 }

--- a/apps/backend/src/executions/active/dto/http/list-active-executions-query.dto.ts
+++ b/apps/backend/src/executions/active/dto/http/list-active-executions-query.dto.ts
@@ -1,0 +1,27 @@
+import { IsOptional, IsInt, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+
+export class ListActiveExecutionsQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-indexed)',
+    example: 1,
+    default: 1,
+  })
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page (1-100)',
+    example: 50,
+    default: 50,
+  })
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsInt()
+  @Min(1)
+  limit?: number = 50;
+}

--- a/apps/backend/src/executions/history/dto/http/list-history-query.dto.ts
+++ b/apps/backend/src/executions/history/dto/http/list-history-query.dto.ts
@@ -1,0 +1,27 @@
+import { IsOptional, IsInt, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+
+export class ListHistoryQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-indexed)',
+    example: 1,
+    default: 1,
+  })
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page (1-100)',
+    example: 50,
+    default: 50,
+  })
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsInt()
+  @Min(1)
+  limit?: number = 50;
+}

--- a/apps/backend/src/executions/history/dto/http/list-history-query.dto.ts
+++ b/apps/backend/src/executions/history/dto/http/list-history-query.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsInt, Min } from 'class-validator';
+import { IsOptional, IsInt, Min, IsUUID } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 
@@ -24,4 +24,12 @@ export class ListHistoryQueryDto {
   @IsInt()
   @Min(1)
   limit?: number = 50;
+
+  @ApiPropertyOptional({
+    description: 'Filter by task ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsOptional()
+  @IsUUID()
+  taskId?: string;
 }

--- a/apps/backend/src/executions/history/dto/http/task-execution-history-list-response.dto.ts
+++ b/apps/backend/src/executions/history/dto/http/task-execution-history-list-response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+import { TaskExecutionHistoryResponseDto } from './task-execution-history-response.dto';
+
+export class TaskExecutionHistoryListResponseDto {
+  @ApiProperty({
+    description: 'List of task execution history entries',
+    type: () => [TaskExecutionHistoryResponseDto],
+  })
+  @ValidateNested({ each: true })
+  @Type(() => TaskExecutionHistoryResponseDto)
+  items!: TaskExecutionHistoryResponseDto[];
+
+  @ApiProperty({
+    description: 'Total number of history entries',
+    example: 42,
+  })
+  total!: number;
+
+  @ApiProperty({
+    description: 'Current page number',
+    example: 1,
+  })
+  page!: number;
+
+  @ApiProperty({
+    description: 'Number of items per page',
+    example: 50,
+  })
+  limit!: number;
+
+  @ApiProperty({
+    description: 'Total number of pages',
+    example: 3,
+  })
+  totalPages!: number;
+}

--- a/apps/backend/src/executions/history/task-execution-history.controller.ts
+++ b/apps/backend/src/executions/history/task-execution-history.controller.ts
@@ -37,6 +37,7 @@ export class TaskExecutionHistoryController {
     const result = await this.taskExecutionHistoryService.listHistory({
       page: query.page ?? 1,
       limit: query.limit ?? 50,
+      taskId: query.taskId,
     });
 
     return {

--- a/apps/backend/src/executions/history/task-execution-history.controller.ts
+++ b/apps/backend/src/executions/history/task-execution-history.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import {
   ApiCookieAuth,
   ApiOkResponse,
@@ -11,6 +11,8 @@ import { RequireScopes } from '../../auth/guards/decorators/require-scopes.decor
 import { TasksScopes } from '../../tasks/tasks.scopes';
 import { TaskExecutionHistoryService } from './task-execution-history.service';
 import { TaskExecutionHistoryResponseDto } from './dto/http/task-execution-history-response.dto';
+import { TaskExecutionHistoryListResponseDto } from './dto/http/task-execution-history-list-response.dto';
+import { ListHistoryQueryDto } from './dto/http/list-history-query.dto';
 
 @ApiTags('Executions')
 @ApiCookieAuth('JWT-Cookie')
@@ -26,13 +28,25 @@ export class TaskExecutionHistoryController {
   @ApiOperation({
     summary: 'List task execution history',
     description:
-      'Returns the persisted execution history rows in the execution system.',
+      'Returns the persisted execution history rows in the execution system with pagination.',
   })
-  @ApiOkResponse({ type: [TaskExecutionHistoryResponseDto] })
-  async listHistory(): Promise<TaskExecutionHistoryResponseDto[]> {
-    const history = await this.taskExecutionHistoryService.listHistory();
-    return history.map((entry) =>
-      TaskExecutionHistoryResponseDto.fromEntity(entry),
-    );
+  @ApiOkResponse({ type: TaskExecutionHistoryListResponseDto })
+  async listHistory(
+    @Query() query: ListHistoryQueryDto,
+  ): Promise<TaskExecutionHistoryListResponseDto> {
+    const result = await this.taskExecutionHistoryService.listHistory({
+      page: query.page ?? 1,
+      limit: query.limit ?? 50,
+    });
+
+    return {
+      items: result.items.map((item) =>
+        TaskExecutionHistoryResponseDto.fromEntity(item),
+      ),
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
+      totalPages: Math.ceil(result.total / result.limit),
+    };
   }
 }

--- a/apps/backend/src/executions/history/task-execution-history.service.ts
+++ b/apps/backend/src/executions/history/task-execution-history.service.ts
@@ -10,11 +10,27 @@ export class TaskExecutionHistoryService {
     private readonly taskExecutionHistoryRepository: Repository<TaskExecutionHistoryEntity>,
   ) {}
 
-  async listHistory(): Promise<TaskExecutionHistoryEntity[]> {
-    return this.taskExecutionHistoryRepository.find({
+  async listHistory(options?: {
+    page?: number;
+    limit?: number;
+  }): Promise<{
+    items: TaskExecutionHistoryEntity[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const page = options?.page ?? 1;
+    const limit = options?.limit ?? 50;
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await this.taskExecutionHistoryRepository.findAndCount({
       relations: ['task', 'stats'],
-      order: { taskId: 'ASC' },
+      order: { transitionedAt: 'DESC' },
+      skip,
+      take: limit,
     });
+
+    return { items, total, page, limit };
   }
 
   async getLatestHistoryForTask(

--- a/apps/backend/src/executions/history/task-execution-history.service.ts
+++ b/apps/backend/src/executions/history/task-execution-history.service.ts
@@ -13,6 +13,7 @@ export class TaskExecutionHistoryService {
   async listHistory(options?: {
     page?: number;
     limit?: number;
+    taskId?: string;
   }): Promise<{
     items: TaskExecutionHistoryEntity[];
     total: number;
@@ -23,7 +24,10 @@ export class TaskExecutionHistoryService {
     const limit = options?.limit ?? 50;
     const skip = (page - 1) * limit;
 
+    const where = options?.taskId ? { taskId: options.taskId } : {};
+
     const [items, total] = await this.taskExecutionHistoryRepository.findAndCount({
+      where,
       relations: ['task', 'stats'],
       order: { transitionedAt: 'DESC' },
       skip,

--- a/apps/backend/src/executions/queue/dto/http/list-queue-query.dto.ts
+++ b/apps/backend/src/executions/queue/dto/http/list-queue-query.dto.ts
@@ -1,0 +1,27 @@
+import { IsOptional, IsInt, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+
+export class ListQueueQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-indexed)',
+    example: 1,
+    default: 1,
+  })
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page (1-100)',
+    example: 50,
+    default: 50,
+  })
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsInt()
+  @Min(1)
+  limit?: number = 50;
+}

--- a/apps/backend/src/executions/queue/dto/http/task-execution-queue-list-response.dto.ts
+++ b/apps/backend/src/executions/queue/dto/http/task-execution-queue-list-response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+import { TaskExecutionQueueEntryResponseDto } from './task-execution-queue-entry-response.dto';
+
+export class TaskExecutionQueueListResponseDto {
+  @ApiProperty({
+    description: 'List of task execution queue entries',
+    type: () => [TaskExecutionQueueEntryResponseDto],
+  })
+  @ValidateNested({ each: true })
+  @Type(() => TaskExecutionQueueEntryResponseDto)
+  items!: TaskExecutionQueueEntryResponseDto[];
+
+  @ApiProperty({
+    description: 'Total number of queue entries',
+    example: 42,
+  })
+  total!: number;
+
+  @ApiProperty({
+    description: 'Current page number',
+    example: 1,
+  })
+  page!: number;
+
+  @ApiProperty({
+    description: 'Number of items per page',
+    example: 50,
+  })
+  limit!: number;
+
+  @ApiProperty({
+    description: 'Total number of pages',
+    example: 3,
+  })
+  totalPages!: number;
+}

--- a/apps/backend/src/executions/queue/task-execution-queue.controller.ts
+++ b/apps/backend/src/executions/queue/task-execution-queue.controller.ts
@@ -5,6 +5,7 @@ import {
   NotFoundException,
   Param,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -31,6 +32,8 @@ import {
 } from '../errors/executions.errors';
 import { TaskExecutionQueueService } from './task-execution-queue.service';
 import { TaskExecutionQueueEntryResponseDto } from './dto/http/task-execution-queue-entry-response.dto';
+import { TaskExecutionQueueListResponseDto } from './dto/http/task-execution-queue-list-response.dto';
+import { ListQueueQueryDto } from './dto/http/list-queue-query.dto';
 
 @ApiTags('Executions')
 @ApiCookieAuth('JWT-Cookie')
@@ -47,15 +50,27 @@ export class TaskExecutionQueueController {
   @ApiOperation({
     summary: 'List the current task execution work queue',
     description:
-      'Returns the tasks currently present in the execution queue. ' +
+      'Returns the tasks currently present in the execution queue with pagination. ' +
       'Presence means the task is ready to be picked by the executor.',
   })
-  @ApiOkResponse({ type: [TaskExecutionQueueEntryResponseDto] })
-  async listQueue(): Promise<TaskExecutionQueueEntryResponseDto[]> {
-    const queue = await this.taskExecutionQueueService.listQueue();
-    return queue.map((entry) =>
-      TaskExecutionQueueEntryResponseDto.fromEntity(entry),
-    );
+  @ApiOkResponse({ type: TaskExecutionQueueListResponseDto })
+  async listQueue(
+    @Query() query: ListQueueQueryDto,
+  ): Promise<TaskExecutionQueueListResponseDto> {
+    const result = await this.taskExecutionQueueService.listQueue({
+      page: query.page ?? 1,
+      limit: query.limit ?? 50,
+    });
+
+    return {
+      items: result.items.map((item) =>
+        TaskExecutionQueueEntryResponseDto.fromEntity(item),
+      ),
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
+      totalPages: Math.ceil(result.total / result.limit),
+    };
   }
 
   @Post(':taskId/claim')

--- a/apps/backend/src/executions/queue/task-execution-queue.service.ts
+++ b/apps/backend/src/executions/queue/task-execution-queue.service.ts
@@ -10,10 +10,26 @@ export class TaskExecutionQueueService {
     private readonly taskExecutionQueueRepository: Repository<TaskExecutionQueueEntity>,
   ) {}
 
-  async listQueue(): Promise<TaskExecutionQueueEntity[]> {
-    return this.taskExecutionQueueRepository.find({
+  async listQueue(options?: {
+    page?: number;
+    limit?: number;
+  }): Promise<{
+    items: TaskExecutionQueueEntity[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const page = options?.page ?? 1;
+    const limit = options?.limit ?? 50;
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await this.taskExecutionQueueRepository.findAndCount({
       relations: ['task'],
       order: { taskId: 'ASC' },
+      skip,
+      take: limit,
     });
+
+    return { items, total, page, limit };
   }
 }

--- a/apps/ui/src/features/executions/ExecutionsPage.css
+++ b/apps/ui/src/features/executions/ExecutionsPage.css
@@ -50,34 +50,6 @@
   background: color-mix(in srgb, var(--danger) 8%, var(--card-bg));
 }
 
-.executions-summary-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--space-3);
-}
-
-.executions-summary-card {
-  display: grid;
-  gap: var(--space-2);
-  border-top-width: 3px;
-}
-
-.executions-summary-card--accent {
-  border-top-color: var(--accent);
-}
-
-.executions-summary-card--warning {
-  border-top-color: var(--warning);
-}
-
-.executions-summary-card--success {
-  border-top-color: var(--success);
-}
-
-.executions-summary-card--danger {
-  border-top-color: var(--danger);
-}
-
 .executions-overview-card,
 .executions-empty-card {
   border-radius: var(--r-4);
@@ -403,7 +375,6 @@
 }
 
 @media (max-width: 980px) {
-  .executions-summary-grid,
   .executions-overview {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -419,7 +390,6 @@
     flex-direction: column;
   }
 
-  .executions-summary-grid,
   .executions-overview {
     grid-template-columns: 1fr;
   }

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -30,11 +30,6 @@ export function ExecutionsPage() {
 
   useDocumentTitle();
 
-  const historySuccessCount = useMemo(
-    () => history.filter((entry) => entry.status === "SUCCEEDED").length,
-    [history],
-  );
-  const historyFailureCount = history.length - historySuccessCount;
   const [expandedHistoryIds, setExpandedHistoryIds] = useState<Set<string>>(
     () => new Set(),
   );
@@ -81,7 +76,6 @@ export function ExecutionsPage() {
     <div className="executions-page">
       <div className="executions-hero">
         <div className="executions-hero__copy">
-          <Text as="div" size="6" weight="bold">Runs</Text>
           <Text as="div" size="3" tone="muted" wrap>
             Queue, active work, and recent history in one place. The view refreshes automatically every 5 seconds.
           </Text>
@@ -94,13 +88,6 @@ export function ExecutionsPage() {
             Refresh now
           </Button>
         </div>
-      </div>
-
-      <div className="executions-summary-grid">
-        <SummaryCard label="Queued" value={queue.length} tone="accent" />
-        <SummaryCard label="Active" value={active.length} tone="warning" />
-        <SummaryCard label="Succeeded" value={historySuccessCount} tone="success" />
-        <SummaryCard label="Failed" value={historyFailureCount} tone="danger" />
       </div>
 
 
@@ -304,32 +291,6 @@ export function ExecutionsPage() {
           />
         </div>
       ) : null}
-    </div>
-  );
-}
-
-function SummaryCard({
-  label,
-  value,
-  tone,
-}: {
-  label: string;
-  value: number;
-  tone: "accent" | "warning" | "success" | "danger";
-}) {
-  return (
-    <Card className={`executions-summary-card executions-summary-card--${tone}`}>
-      <Text as="div" size="2" tone="muted" weight="medium">{label}</Text>
-      <Text as="div" size="6" weight="bold">{value}</Text>
-    </Card>
-  );
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="executions-metric">
-      <Text as="div" size="1" tone="muted" weight="medium">{label}</Text>
-      <Text as="div" size="3" weight="semibold">{value}</Text>
     </div>
   );
 }

--- a/apps/ui/src/features/executions/useExecutions.ts
+++ b/apps/ui/src/features/executions/useExecutions.ts
@@ -41,15 +41,15 @@ export const useExecutions = () => {
     }
 
     try {
-      const [nextQueue, nextActive, nextHistory] = await Promise.all([
-        ExecutionsService.TaskExecutionQueueController_listQueue(),
-        ExecutionsService.ActiveTaskExecutionController_listActiveExecutions(),
-        ExecutionsService.TaskExecutionHistoryController_listHistory(),
+      const [queueResponse, activeResponse, historyResponse] = await Promise.all([
+        ExecutionsService.TaskExecutionQueueController_listQueue({ limit: 50 }),
+        ExecutionsService.ActiveTaskExecutionController_listActiveExecutions({ limit: 50 }),
+        ExecutionsService.TaskExecutionHistoryController_listHistory({ limit: 50 }),
       ]);
 
-      setQueue(nextQueue);
-      setActive(nextActive.sort((a, b) => b.claimedAt.localeCompare(a.claimedAt)));
-      setHistory(nextHistory.sort((a, b) => b.transitionedAt.localeCompare(a.transitionedAt)));
+      setQueue(queueResponse.items);
+      setActive(activeResponse.items);
+      setHistory(historyResponse.items);
       setLastUpdatedAt(new Date().toISOString());
       setError(null);
     } catch (err) {

--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -475,12 +475,12 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
   const loadExecutionsForTask = useCallback(async (taskId: string) => {
     setIsLoadingExecutions(true);
     try {
-      const [activeExecutions, historyExecutions] = await Promise.all([
-        ExecutionsService.ActiveTaskExecutionController_listActiveExecutions(),
-        ExecutionsService.TaskExecutionHistoryController_listHistory(),
+      const [activeResponse, historyResponse] = await Promise.all([
+        ExecutionsService.ActiveTaskExecutionController_listActiveExecutions({ limit: 100 }),
+        ExecutionsService.TaskExecutionHistoryController_listHistory({ limit: 100 }),
       ]);
 
-      const taskActiveItems = activeExecutions
+      const taskActiveItems = activeResponse.items
         .filter((entry: ActiveTaskExecutionResponseDto) => entry.taskId === taskId)
         .map((entry: ActiveTaskExecutionResponseDto): TaskExecutionListItem => ({
           id: `active-${entry.id}`,
@@ -495,7 +495,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
           errorMessage: null,
         }));
 
-      const taskHistoryItems = historyExecutions
+      const taskHistoryItems = historyResponse.items
         .filter((entry: TaskExecutionHistoryResponseDto) => entry.taskId === taskId)
         .map((entry: TaskExecutionHistoryResponseDto): TaskExecutionListItem => ({
           id: `history-${entry.id}`,

--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -476,12 +476,11 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
     setIsLoadingExecutions(true);
     try {
       const [activeResponse, historyResponse] = await Promise.all([
-        ExecutionsService.ActiveTaskExecutionController_listActiveExecutions({ limit: 100 }),
-        ExecutionsService.TaskExecutionHistoryController_listHistory({ limit: 100 }),
+        ExecutionsService.ActiveTaskExecutionController_listActiveExecutions({ taskId, limit: 100 }),
+        ExecutionsService.TaskExecutionHistoryController_listHistory({ taskId, limit: 100 }),
       ]);
 
       const taskActiveItems = activeResponse.items
-        .filter((entry: ActiveTaskExecutionResponseDto) => entry.taskId === taskId)
         .map((entry: ActiveTaskExecutionResponseDto): TaskExecutionListItem => ({
           id: `active-${entry.id}`,
           executionId: entry.id,
@@ -496,7 +495,6 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
         }));
 
       const taskHistoryItems = historyResponse.items
-        .filter((entry: TaskExecutionHistoryResponseDto) => entry.taskId === taskId)
         .map((entry: TaskExecutionHistoryResponseDto): TaskExecutionListItem => ({
           id: `history-${entry.id}`,
           executionId: entry.id,

--- a/apps/worker/src/task-claim-worker.ts
+++ b/apps/worker/src/task-claim-worker.ts
@@ -61,10 +61,10 @@ async function processNextQueuedTask(
   baseUrl: string,
   activityGatewayClient: ExecutionActivityGatewayClient,
 ): Promise<void> {
-  const queue = await client.executions.TaskExecutionQueueController_listQueue();
-  console.log(`[worker] Queue poll succeeded. ${queue.length} task(s) ready.`);
+  const queueResponse = await client.executions.TaskExecutionQueueController_listQueue({ limit: 1 });
+  console.log(`[worker] Queue poll succeeded. ${queueResponse.total} task(s) ready.`);
 
-  const nextTask = queue[0];
+  const nextTask = queueResponse.items[0];
   if (!nextTask) {
     return;
   }

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -5957,19 +5957,39 @@
     },
     "/api/v1/executions/queue": {
       "get": {
-        "description": "Returns the tasks currently present in the execution queue. Presence means the task is ready to be picked by the executor.",
+        "description": "Returns the tasks currently present in the execution queue with pagination. Presence means the task is ready to be picked by the executor.",
         "operationId": "TaskExecutionQueueController_listQueue",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Items per page (1-100)",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TaskExecutionQueueEntryResponseDto"
-                  }
+                  "$ref": "#/components/schemas/TaskExecutionQueueListResponseDto"
                 }
               }
             }
@@ -6026,19 +6046,39 @@
     },
     "/api/v1/executions/active": {
       "get": {
-        "description": "Returns the tasks currently being worked on in the execution system.",
+        "description": "Returns the tasks currently being worked on in the execution system with pagination.",
         "operationId": "ActiveTaskExecutionController_listActiveExecutions",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Items per page (1-100)",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActiveTaskExecutionResponseDto"
-                  }
+                  "$ref": "#/components/schemas/ActiveTaskExecutionListResponseDto"
                 }
               }
             }
@@ -6249,19 +6289,39 @@
     },
     "/api/v1/executions/history": {
       "get": {
-        "description": "Returns the persisted execution history rows in the execution system.",
+        "description": "Returns the persisted execution history rows in the execution system with pagination.",
         "operationId": "TaskExecutionHistoryController_listHistory",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Items per page (1-100)",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TaskExecutionHistoryResponseDto"
-                  }
+                  "$ref": "#/components/schemas/TaskExecutionHistoryListResponseDto"
                 }
               }
             }
@@ -11779,6 +11839,45 @@
           "taskStatus"
         ]
       },
+      "TaskExecutionQueueListResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of task execution queue entries",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskExecutionQueueEntryResponseDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "description": "Total number of queue entries",
+            "example": 42
+          },
+          "page": {
+            "type": "number",
+            "description": "Current page number",
+            "example": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of items per page",
+            "example": 50
+          },
+          "totalPages": {
+            "type": "number",
+            "description": "Total number of pages",
+            "example": 3
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "limit",
+          "totalPages"
+        ]
+      },
       "ActiveTaskExecutionTagSnapshotResponseDto": {
         "type": "object",
         "properties": {
@@ -11957,6 +12056,45 @@
           "taskAssigneeActorIdBeforeClaim",
           "agentActorId",
           "stats"
+        ]
+      },
+      "ActiveTaskExecutionListResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of active task executions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActiveTaskExecutionResponseDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "description": "Total number of active executions",
+            "example": 42
+          },
+          "page": {
+            "type": "number",
+            "description": "Current page number",
+            "example": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of items per page",
+            "example": 50
+          },
+          "totalPages": {
+            "type": "number",
+            "description": "Total number of pages",
+            "example": 3
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "limit",
+          "totalPages"
         ]
       },
       "StopActiveTaskExecutionDto": {
@@ -12170,6 +12308,45 @@
             "minimum": 0
           }
         }
+      },
+      "TaskExecutionHistoryListResponseDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "List of task execution history entries",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskExecutionHistoryResponseDto"
+            }
+          },
+          "total": {
+            "type": "number",
+            "description": "Total number of history entries",
+            "example": 42
+          },
+          "page": {
+            "type": "number",
+            "description": "Current page number",
+            "example": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of items per page",
+            "example": 50
+          },
+          "totalPages": {
+            "type": "number",
+            "description": "Total number of pages",
+            "example": 3
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "limit",
+          "totalPages"
+        ]
       },
       "WorkerResponseDto": {
         "type": "object",

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -6070,6 +6070,16 @@
               "example": 50,
               "type": "number"
             }
+          },
+          {
+            "name": "taskId",
+            "required": false,
+            "in": "query",
+            "description": "Filter by task ID",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6312,6 +6322,16 @@
               "default": 50,
               "example": 50,
               "type": "number"
+            }
+          },
+          {
+            "name": "taskId",
+            "required": false,
+            "in": "query",
+            "description": "Filter by task ID",
+            "schema": {
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
             }
           }
         ],

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -10180,6 +10180,8 @@ export interface operations {
                 page?: number;
                 /** @description Items per page (1-100) */
                 limit?: number;
+                /** @description Filter by task ID */
+                taskId?: string;
             };
             header?: never;
             path?: never;
@@ -10318,6 +10320,8 @@ export interface operations {
                 page?: number;
                 /** @description Items per page (1-100) */
                 limit?: number;
+                /** @description Filter by task ID */
+                taskId?: string;
             };
             header?: never;
             path?: never;

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -1689,7 +1689,7 @@ export interface paths {
         };
         /**
          * List the current task execution work queue
-         * @description Returns the tasks currently present in the execution queue. Presence means the task is ready to be picked by the executor.
+         * @description Returns the tasks currently present in the execution queue with pagination. Presence means the task is ready to be picked by the executor.
          */
         get: operations["TaskExecutionQueueController_listQueue"];
         put?: never;
@@ -1729,7 +1729,7 @@ export interface paths {
         };
         /**
          * List active task executions
-         * @description Returns the tasks currently being worked on in the execution system.
+         * @description Returns the tasks currently being worked on in the execution system with pagination.
          */
         get: operations["ActiveTaskExecutionController_listActiveExecutions"];
         put?: never;
@@ -1849,7 +1849,7 @@ export interface paths {
         };
         /**
          * List task execution history
-         * @description Returns the persisted execution history rows in the execution system.
+         * @description Returns the persisted execution history rows in the execution system with pagination.
          */
         get: operations["TaskExecutionHistoryController_listHistory"];
         put?: never;
@@ -5258,6 +5258,30 @@ export interface components {
              */
             taskStatus: "NOT_STARTED" | "IN_PROGRESS" | "FOR_REVIEW" | "DONE" | null;
         };
+        TaskExecutionQueueListResponseDto: {
+            /** @description List of task execution queue entries */
+            items: components["schemas"]["TaskExecutionQueueEntryResponseDto"][];
+            /**
+             * @description Total number of queue entries
+             * @example 42
+             */
+            total: number;
+            /**
+             * @description Current page number
+             * @example 1
+             */
+            page: number;
+            /**
+             * @description Number of items per page
+             * @example 50
+             */
+            limit: number;
+            /**
+             * @description Total number of pages
+             * @example 3
+             */
+            totalPages: number;
+        };
         ActiveTaskExecutionTagSnapshotResponseDto: {
             /**
              * @description Tag ID at the time the task was claimed
@@ -5367,6 +5391,30 @@ export interface components {
             agentActorId: string;
             /** @description Execution metadata and usage stats */
             stats: components["schemas"]["ExecutionStatsResponseDto"] | null;
+        };
+        ActiveTaskExecutionListResponseDto: {
+            /** @description List of active task executions */
+            items: components["schemas"]["ActiveTaskExecutionResponseDto"][];
+            /**
+             * @description Total number of active executions
+             * @example 42
+             */
+            total: number;
+            /**
+             * @description Current page number
+             * @example 1
+             */
+            page: number;
+            /**
+             * @description Number of items per page
+             * @example 50
+             */
+            limit: number;
+            /**
+             * @description Total number of pages
+             * @example 3
+             */
+            totalPages: number;
         };
         StopActiveTaskExecutionDto: {
             /**
@@ -5494,6 +5542,30 @@ export interface components {
              * @example 1580
              */
             totalTokens?: number | null;
+        };
+        TaskExecutionHistoryListResponseDto: {
+            /** @description List of task execution history entries */
+            items: components["schemas"]["TaskExecutionHistoryResponseDto"][];
+            /**
+             * @description Total number of history entries
+             * @example 42
+             */
+            total: number;
+            /**
+             * @description Current page number
+             * @example 1
+             */
+            page: number;
+            /**
+             * @description Number of items per page
+             * @example 50
+             */
+            limit: number;
+            /**
+             * @description Total number of pages
+             * @example 3
+             */
+            totalPages: number;
         };
         WorkerResponseDto: {
             /** Format: uuid */
@@ -10057,7 +10129,12 @@ export interface operations {
     };
     TaskExecutionQueueController_listQueue: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Page number (1-indexed) */
+                page?: number;
+                /** @description Items per page (1-100) */
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -10069,7 +10146,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TaskExecutionQueueEntryResponseDto"][];
+                    "application/json": components["schemas"]["TaskExecutionQueueListResponseDto"];
                 };
             };
         };
@@ -10098,7 +10175,12 @@ export interface operations {
     };
     ActiveTaskExecutionController_listActiveExecutions: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Page number (1-indexed) */
+                page?: number;
+                /** @description Items per page (1-100) */
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -10110,7 +10192,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ActiveTaskExecutionResponseDto"][];
+                    "application/json": components["schemas"]["ActiveTaskExecutionListResponseDto"];
                 };
             };
         };
@@ -10231,7 +10313,12 @@ export interface operations {
     };
     TaskExecutionHistoryController_listHistory: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Page number (1-indexed) */
+                page?: number;
+                /** @description Items per page (1-100) */
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -10243,7 +10330,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TaskExecutionHistoryResponseDto"][];
+                    "application/json": components["schemas"]["TaskExecutionHistoryListResponseDto"];
                 };
             };
         };

--- a/packages/client/src/v1/client/index.ts
+++ b/packages/client/src/v1/client/index.ts
@@ -7,6 +7,7 @@ export { CancelablePromise, CancelError } from './core/CancelablePromise.js';
 export { OpenAPI } from './core/OpenAPI.js';
 export type { OpenAPIConfig } from './core/OpenAPI.js';
 
+export type { ActiveTaskExecutionListResponseDto } from './models/ActiveTaskExecutionListResponseDto.js';
 export { ActiveTaskExecutionResponseDto } from './models/ActiveTaskExecutionResponseDto.js';
 export type { ActiveTaskExecutionTagSnapshotResponseDto } from './models/ActiveTaskExecutionTagSnapshotResponseDto.js';
 export { ActorResponseDto } from './models/ActorResponseDto.js';
@@ -115,8 +116,10 @@ export { StopActiveTaskExecutionDto } from './models/StopActiveTaskExecutionDto.
 export type { TagResponseDto } from './models/TagResponseDto.js';
 export type { TaskBlueprintListResponseDto } from './models/TaskBlueprintListResponseDto.js';
 export type { TaskBlueprintResponseDto } from './models/TaskBlueprintResponseDto.js';
+export type { TaskExecutionHistoryListResponseDto } from './models/TaskExecutionHistoryListResponseDto.js';
 export { TaskExecutionHistoryResponseDto } from './models/TaskExecutionHistoryResponseDto.js';
 export { TaskExecutionQueueEntryResponseDto } from './models/TaskExecutionQueueEntryResponseDto.js';
+export type { TaskExecutionQueueListResponseDto } from './models/TaskExecutionQueueListResponseDto.js';
 export type { TaskInfoDto } from './models/TaskInfoDto.js';
 export type { TaskListResponseDto } from './models/TaskListResponseDto.js';
 export { TaskResponseDto } from './models/TaskResponseDto.js';

--- a/packages/client/src/v1/client/models/ActiveTaskExecutionListResponseDto.ts
+++ b/packages/client/src/v1/client/models/ActiveTaskExecutionListResponseDto.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ActiveTaskExecutionResponseDto } from './ActiveTaskExecutionResponseDto.js';
+export type ActiveTaskExecutionListResponseDto = {
+    /**
+     * List of active task executions
+     */
+    items: Array<ActiveTaskExecutionResponseDto>;
+    /**
+     * Total number of active executions
+     */
+    total: number;
+    /**
+     * Current page number
+     */
+    page: number;
+    /**
+     * Number of items per page
+     */
+    limit: number;
+    /**
+     * Total number of pages
+     */
+    totalPages: number;
+};
+

--- a/packages/client/src/v1/client/models/TaskExecutionHistoryListResponseDto.ts
+++ b/packages/client/src/v1/client/models/TaskExecutionHistoryListResponseDto.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { TaskExecutionHistoryResponseDto } from './TaskExecutionHistoryResponseDto.js';
+export type TaskExecutionHistoryListResponseDto = {
+    /**
+     * List of task execution history entries
+     */
+    items: Array<TaskExecutionHistoryResponseDto>;
+    /**
+     * Total number of history entries
+     */
+    total: number;
+    /**
+     * Current page number
+     */
+    page: number;
+    /**
+     * Number of items per page
+     */
+    limit: number;
+    /**
+     * Total number of pages
+     */
+    totalPages: number;
+};
+

--- a/packages/client/src/v1/client/models/TaskExecutionQueueListResponseDto.ts
+++ b/packages/client/src/v1/client/models/TaskExecutionQueueListResponseDto.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { TaskExecutionQueueEntryResponseDto } from './TaskExecutionQueueEntryResponseDto.js';
+export type TaskExecutionQueueListResponseDto = {
+    /**
+     * List of task execution queue entries
+     */
+    items: Array<TaskExecutionQueueEntryResponseDto>;
+    /**
+     * Total number of queue entries
+     */
+    total: number;
+    /**
+     * Current page number
+     */
+    page: number;
+    /**
+     * Number of items per page
+     */
+    limit: number;
+    /**
+     * Total number of pages
+     */
+    totalPages: number;
+};
+

--- a/packages/client/src/v1/client/services/ExecutionsService.ts
+++ b/packages/client/src/v1/client/services/ExecutionsService.ts
@@ -2,10 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ActiveTaskExecutionListResponseDto } from '../models/ActiveTaskExecutionListResponseDto.js';
 import type { ActiveTaskExecutionResponseDto } from '../models/ActiveTaskExecutionResponseDto.js';
 import type { StopActiveTaskExecutionDto } from '../models/StopActiveTaskExecutionDto.js';
+import type { TaskExecutionHistoryListResponseDto } from '../models/TaskExecutionHistoryListResponseDto.js';
 import type { TaskExecutionHistoryResponseDto } from '../models/TaskExecutionHistoryResponseDto.js';
-import type { TaskExecutionQueueEntryResponseDto } from '../models/TaskExecutionQueueEntryResponseDto.js';
+import type { TaskExecutionQueueListResponseDto } from '../models/TaskExecutionQueueListResponseDto.js';
 import type { UpdateExecutionStatsDto } from '../models/UpdateExecutionStatsDto.js';
 import type { UpdateRunnerSessionIdDto } from '../models/UpdateRunnerSessionIdDto.js';
 import type { CancelablePromise } from '../core/CancelablePromise.js';
@@ -15,14 +17,24 @@ import { request as __request } from '../core/request.js';
 export class ExecutionsService {
     /**
      * List the current task execution work queue
-     * Returns the tasks currently present in the execution queue. Presence means the task is ready to be picked by the executor.
-     * @returns TaskExecutionQueueEntryResponseDto
+     * Returns the tasks currently present in the execution queue with pagination. Presence means the task is ready to be picked by the executor.
+     * @param page Page number (1-indexed)
+     * @param limit Items per page (1-100)
+     * @returns TaskExecutionQueueListResponseDto
      * @throws ApiError
      */
-    public static taskExecutionQueueControllerListQueue(config: OpenAPIConfig = OpenAPI): CancelablePromise<Array<TaskExecutionQueueEntryResponseDto>> {
+    public static taskExecutionQueueControllerListQueue(
+        page: number = 1,
+        limit: number = 50,
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<TaskExecutionQueueListResponseDto> {
         return __request(config, {
             method: 'GET',
             url: '/api/v1/executions/queue',
+            query: {
+                'page': page,
+                'limit': limit,
+            },
         });
     }
     /**
@@ -46,14 +58,24 @@ export class ExecutionsService {
     }
     /**
      * List active task executions
-     * Returns the tasks currently being worked on in the execution system.
-     * @returns ActiveTaskExecutionResponseDto
+     * Returns the tasks currently being worked on in the execution system with pagination.
+     * @param page Page number (1-indexed)
+     * @param limit Items per page (1-100)
+     * @returns ActiveTaskExecutionListResponseDto
      * @throws ApiError
      */
-    public static activeTaskExecutionControllerListActiveExecutions(config: OpenAPIConfig = OpenAPI): CancelablePromise<Array<ActiveTaskExecutionResponseDto>> {
+    public static activeTaskExecutionControllerListActiveExecutions(
+        page: number = 1,
+        limit: number = 50,
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<ActiveTaskExecutionListResponseDto> {
         return __request(config, {
             method: 'GET',
             url: '/api/v1/executions/active',
+            query: {
+                'page': page,
+                'limit': limit,
+            },
         });
     }
     /**
@@ -165,14 +187,24 @@ export class ExecutionsService {
     }
     /**
      * List task execution history
-     * Returns the persisted execution history rows in the execution system.
-     * @returns TaskExecutionHistoryResponseDto
+     * Returns the persisted execution history rows in the execution system with pagination.
+     * @param page Page number (1-indexed)
+     * @param limit Items per page (1-100)
+     * @returns TaskExecutionHistoryListResponseDto
      * @throws ApiError
      */
-    public static taskExecutionHistoryControllerListHistory(config: OpenAPIConfig = OpenAPI): CancelablePromise<Array<TaskExecutionHistoryResponseDto>> {
+    public static taskExecutionHistoryControllerListHistory(
+        page: number = 1,
+        limit: number = 50,
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<TaskExecutionHistoryListResponseDto> {
         return __request(config, {
             method: 'GET',
             url: '/api/v1/executions/history',
+            query: {
+                'page': page,
+                'limit': limit,
+            },
         });
     }
 }

--- a/packages/client/src/v1/client/services/ExecutionsService.ts
+++ b/packages/client/src/v1/client/services/ExecutionsService.ts
@@ -61,12 +61,14 @@ export class ExecutionsService {
      * Returns the tasks currently being worked on in the execution system with pagination.
      * @param page Page number (1-indexed)
      * @param limit Items per page (1-100)
+     * @param taskId Filter by task ID
      * @returns ActiveTaskExecutionListResponseDto
      * @throws ApiError
      */
     public static activeTaskExecutionControllerListActiveExecutions(
         page: number = 1,
         limit: number = 50,
+        taskId?: string,
         config: OpenAPIConfig = OpenAPI,
     ): CancelablePromise<ActiveTaskExecutionListResponseDto> {
         return __request(config, {
@@ -75,6 +77,7 @@ export class ExecutionsService {
             query: {
                 'page': page,
                 'limit': limit,
+                'taskId': taskId,
             },
         });
     }
@@ -190,12 +193,14 @@ export class ExecutionsService {
      * Returns the persisted execution history rows in the execution system with pagination.
      * @param page Page number (1-indexed)
      * @param limit Items per page (1-100)
+     * @param taskId Filter by task ID
      * @returns TaskExecutionHistoryListResponseDto
      * @throws ApiError
      */
     public static taskExecutionHistoryControllerListHistory(
         page: number = 1,
         limit: number = 50,
+        taskId?: string,
         config: OpenAPIConfig = OpenAPI,
     ): CancelablePromise<TaskExecutionHistoryListResponseDto> {
         return __request(config, {
@@ -204,6 +209,7 @@ export class ExecutionsService {
             query: {
                 'page': page,
                 'limit': limit,
+                'taskId': taskId,
             },
         });
     }

--- a/packages/client/src/v2/executions-resource.ts
+++ b/packages/client/src/v2/executions-resource.ts
@@ -1,5 +1,5 @@
 import { BaseClient, ClientConfig } from './base-client.js';
-import type { ActiveTaskExecutionResponseDto, StopActiveTaskExecutionDto, TaskExecutionHistoryResponseDto, TaskExecutionQueueEntryResponseDto, UpdateExecutionStatsDto, UpdateRunnerSessionIdDto } from './types.js';
+import type { ActiveTaskExecutionListResponseDto, ActiveTaskExecutionResponseDto, StopActiveTaskExecutionDto, TaskExecutionHistoryListResponseDto, TaskExecutionHistoryResponseDto, TaskExecutionQueueListResponseDto, UpdateExecutionStatsDto, UpdateRunnerSessionIdDto } from './types.js';
 
 export class ExecutionsResource extends BaseClient {
   constructor(config: ClientConfig) {
@@ -7,8 +7,8 @@ export class ExecutionsResource extends BaseClient {
   }
 
   /** List the current task execution work queue */
-  async TaskExecutionQueueController_listQueue(params?: { signal?: AbortSignal }): Promise<TaskExecutionQueueEntryResponseDto[]> {
-    return this.request('GET', '/api/v1/executions/queue', { signal: params?.signal });
+  async TaskExecutionQueueController_listQueue(params?: { page?: number; limit?: number; signal?: AbortSignal }): Promise<TaskExecutionQueueListResponseDto> {
+    return this.request('GET', '/api/v1/executions/queue', { params: { page: params?.page, limit: params?.limit }, signal: params?.signal });
   }
 
   /** Claim a specific task from the execution queue */
@@ -17,8 +17,8 @@ export class ExecutionsResource extends BaseClient {
   }
 
   /** List active task executions */
-  async ActiveTaskExecutionController_listActiveExecutions(params?: { signal?: AbortSignal }): Promise<ActiveTaskExecutionResponseDto[]> {
-    return this.request('GET', '/api/v1/executions/active', { signal: params?.signal });
+  async ActiveTaskExecutionController_listActiveExecutions(params?: { page?: number; limit?: number; signal?: AbortSignal }): Promise<ActiveTaskExecutionListResponseDto> {
+    return this.request('GET', '/api/v1/executions/active', { params: { page: params?.page, limit: params?.limit }, signal: params?.signal });
   }
 
   /** Stop an active task execution and move it to history */
@@ -47,8 +47,8 @@ export class ExecutionsResource extends BaseClient {
   }
 
   /** List task execution history */
-  async TaskExecutionHistoryController_listHistory(params?: { signal?: AbortSignal }): Promise<TaskExecutionHistoryResponseDto[]> {
-    return this.request('GET', '/api/v1/executions/history', { signal: params?.signal });
+  async TaskExecutionHistoryController_listHistory(params?: { page?: number; limit?: number; signal?: AbortSignal }): Promise<TaskExecutionHistoryListResponseDto> {
+    return this.request('GET', '/api/v1/executions/history', { params: { page: params?.page, limit: params?.limit }, signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/executions-resource.ts
+++ b/packages/client/src/v2/executions-resource.ts
@@ -17,8 +17,8 @@ export class ExecutionsResource extends BaseClient {
   }
 
   /** List active task executions */
-  async ActiveTaskExecutionController_listActiveExecutions(params?: { page?: number; limit?: number; signal?: AbortSignal }): Promise<ActiveTaskExecutionListResponseDto> {
-    return this.request('GET', '/api/v1/executions/active', { params: { page: params?.page, limit: params?.limit }, signal: params?.signal });
+  async ActiveTaskExecutionController_listActiveExecutions(params?: { page?: number; limit?: number; taskId?: string; signal?: AbortSignal }): Promise<ActiveTaskExecutionListResponseDto> {
+    return this.request('GET', '/api/v1/executions/active', { params: { page: params?.page, limit: params?.limit, taskId: params?.taskId }, signal: params?.signal });
   }
 
   /** Stop an active task execution and move it to history */
@@ -47,8 +47,8 @@ export class ExecutionsResource extends BaseClient {
   }
 
   /** List task execution history */
-  async TaskExecutionHistoryController_listHistory(params?: { page?: number; limit?: number; signal?: AbortSignal }): Promise<TaskExecutionHistoryListResponseDto> {
-    return this.request('GET', '/api/v1/executions/history', { params: { page: params?.page, limit: params?.limit }, signal: params?.signal });
+  async TaskExecutionHistoryController_listHistory(params?: { page?: number; limit?: number; taskId?: string; signal?: AbortSignal }): Promise<TaskExecutionHistoryListResponseDto> {
+    return this.request('GET', '/api/v1/executions/history', { params: { page: params?.page, limit: params?.limit, taskId: params?.taskId }, signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -947,6 +947,14 @@ export interface TaskExecutionQueueEntryResponseDto {
   taskStatus: 'NOT_STARTED' | 'IN_PROGRESS' | 'FOR_REVIEW' | 'DONE';
 }
 
+export interface TaskExecutionQueueListResponseDto {
+  items: TaskExecutionQueueEntryResponseDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
 export interface ActiveTaskExecutionTagSnapshotResponseDto {
   id: string;
   name: string;
@@ -976,6 +984,14 @@ export interface ActiveTaskExecutionResponseDto {
   taskAssigneeActorIdBeforeClaim: string | null;
   agentActorId: string;
   stats: ExecutionStatsResponseDto;
+}
+
+export interface ActiveTaskExecutionListResponseDto {
+  items: ActiveTaskExecutionResponseDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
 }
 
 export interface StopActiveTaskExecutionDto {
@@ -1012,6 +1028,14 @@ export interface UpdateExecutionStatsDto {
   inputTokens?: number | null;
   outputTokens?: number | null;
   totalTokens?: number | null;
+}
+
+export interface TaskExecutionHistoryListResponseDto {
+  items: TaskExecutionHistoryResponseDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
 }
 
 export interface WorkerResponseDto {


### PR DESCRIPTION
## Summary
- Implemented pagination for all three execution endpoints (active, queue, history) following the same pattern as the tasks endpoint
- Removed executions summary cards from UI (counts not accurate under paginated results)
- Removed "Runs" title from executions hero section as requested
- Updated frontend to fetch only 50 items per endpoint for improved performance

## Backend Changes
- Created pagination query DTOs with page and limit parameters
- Created paginated list response DTOs with items, total, page, limit, and totalPages
- Updated services to support pagination using TypeORM's `findAndCount` with skip/take
- Updated controllers to accept pagination query params and return paginated results
- Default limit set to 50 items per page across all endpoints

## Frontend Changes
- Updated `useExecutions` hook to pass `limit: 50` to all three endpoints
- Removed "Runs" title from `executions-hero` section
- Removed `executions-summary-grid` and `SummaryCard` components
- Updated `TaskDetailPage` to handle paginated responses
- Cleaned up related CSS for removed components

## Worker Changes
- Updated task-claim-worker to use paginated queue endpoint with `limit: 1`

## Test Plan
- [x] `npm run build:dev` completes successfully
- [x] All TypeScript compilation passes
- [x] Backend API types properly generated
- [x] Client SDK regenerated with new endpoints

## Technical Debt
None introduced. Changes follow existing patterns used in the tasks endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)