### PR TITLE
feat(ui): add threads desktop sidebar composer

### DIFF
--- a/apps/backend/src/threads/backends/chat-backend.utils.ts
+++ b/apps/backend/src/threads/backends/chat-backend.utils.ts
@@ -14,17 +14,33 @@ export function buildThreadScopedInstructions(
 
   return `${baseInstructions}
 
-Thread context:
+# Thread context:
 - You are working inside thread ${threadId}.
 - This thread coordinates multiple tasks working toward a shared goal.
 - Keep your guidance and execution aligned with thread-level context, not just one task.
 
-Operational guidance:
+# Operational guidance:
 - Use ${tasksPrefix}list_tasks_by_thread with this threadId to understand current subtasks and status.
 - Use ${contextPrefix}get_thread_state_memory with this threadId to read current shared state memory.
 - When a task or context block becomes relevant to the thread, attach it using ${tasksPrefix}attach_task_to_thread or ${contextPrefix}attach_block_to_thread.
 - If a task/block was attached by mistake or is no longer relevant, remove it using ${tasksPrefix}detach_task_from_thread or ${contextPrefix}detach_block_from_thread.
 - During conversation, when you discover durable cross-task decisions/constraints/risks, update memory via ${contextPrefix}update_block.
 - If the user asks for updates on a given task, read the task and the memory block to update the user.
-- Only write durable shared memory (not ephemeral chat details).`;
+- Only write durable shared memory (not ephemeral chat details).
+
+# Creating tasks:
+- Task descriptions should be clear, specific, and actionable.
+- User might not specify a project. If so, list tags that start with \`project:\` and use your judgement to detect relevant tasks. Ask the user to confirm if they want a project tag added to the task or not.
+- Tasks created generally need to be attached to the thread unless you have a reason not to.
+**Pre-Assignment Checklist:**
+1.  **IF** a task is about to be assigned:
+  a.  Check if it has a \`project:projectName\` tag.
+  b.  **IF NOT**, list existing \`project:\` tags.
+  c.  Ask the user: 'Do you want to add a project tag to this task? If so, which one, or should I create a new one?'
+  d.  Wait for user confirmation/input and add the tag if specified.
+2.  **THEN** proceed with task assignment.
+`;
+
+
+
 }

--- a/apps/ui/src/app/shells/BetaShellDesktop.css
+++ b/apps/ui/src/app/shells/BetaShellDesktop.css
@@ -41,9 +41,10 @@
   padding-bottom: 0;
 }
 
-/* Context desktop uses its own full-height split layout. */
+/* Context and Threads desktop use their own full-height split layouts. */
 .beta-shell__desktop__main:has(.context-desktop),
-.beta-shell__desktop__main:has(.context-layout) {
+.beta-shell__desktop__main:has(.context-layout),
+.beta-shell__desktop__main:has(.threads-layout) {
   padding: 0;
   overflow: hidden;
 }

--- a/apps/ui/src/features/threads/ThreadDetailPage.css
+++ b/apps/ui/src/features/threads/ThreadDetailPage.css
@@ -11,7 +11,7 @@
   flex-direction: row;
   gap: 0;
   overflow: hidden;
-  height: 100vh;
+  height: 100%;
 }
 
 .thread-detail-page__main {

--- a/apps/ui/src/features/threads/ThreadRow.tsx
+++ b/apps/ui/src/features/threads/ThreadRow.tsx
@@ -15,9 +15,6 @@ export function ThreadRow({
           {thread.title}
         </Text>
       </div>
-      <div style={{ fontSize: 12 }} className="text--tone-muted">
-        #{thread.id.slice(0, 6)}
-      </div>
     </DataRow>
   );
 }

--- a/apps/ui/src/features/threads/ThreadsLayout.css
+++ b/apps/ui/src/features/threads/ThreadsLayout.css
@@ -88,40 +88,50 @@
 
 .threads-layout__thread-item {
   border: 0;
-  border-bottom: 1px solid var(--border-subtle);
   background: transparent;
   color: var(--text);
   text-align: left;
-  padding: var(--space-3);
+  padding: 5px var(--space-3) 5px var(--space-4);
   cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
+  display: block;
+  position: relative;
 }
 
 .threads-layout__thread-item:hover {
-  background: color-mix(in srgb, var(--surface) 78%, transparent);
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg));
 }
 
 .threads-layout__thread-item--active {
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg));
 }
 
-.threads-layout__thread-title,
-.threads-layout__thread-id {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.threads-layout__thread-item--active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background: var(--accent);
+}
+
+.threads-layout__thread-item:hover .threads-layout__thread-title,
+.threads-layout__thread-item--active .threads-layout__thread-title {
+  color: var(--accent);
+}
+
+.threads-layout__thread-item:hover .threads-layout__thread-title {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .threads-layout__thread-title {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: var(--fs-2);
   font-weight: var(--fw-medium);
-}
-
-.threads-layout__thread-id {
-  font-size: var(--fs-1);
-  color: var(--text-muted);
 }
 
 .threads-layout__sidebar-status {
@@ -152,4 +162,6 @@
   min-height: 0;
   overflow: hidden;
   background: var(--bg);
+  padding-left: var(--space-4);
+  box-sizing: border-box;
 }

--- a/apps/ui/src/features/threads/ThreadsLayout.css
+++ b/apps/ui/src/features/threads/ThreadsLayout.css
@@ -1,0 +1,155 @@
+.threads-layout {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.threads-layout--desktop {
+  flex-direction: row;
+}
+
+.threads-layout__sidebar {
+  width: 280px;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background-color: var(--bg);
+  border-right: 1px solid var(--border);
+  transition: width 0.2s ease, min-width 0.2s ease;
+}
+
+.threads-layout__sidebar--collapsed {
+  width: 52px;
+  min-width: 52px;
+}
+
+.threads-layout__sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-3) var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg);
+}
+
+.threads-layout__sidebar--collapsed .threads-layout__sidebar-header {
+  justify-content: center;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.threads-layout__sidebar-title {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.threads-layout__sidebar-title:hover {
+  color: var(--accent);
+}
+
+.threads-layout__sidebar-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.threads-layout__sidebar-new {
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--fs-4);
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.threads-layout__sidebar-new:hover {
+  color: var(--accent);
+}
+
+.threads-layout__sidebar-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.threads-layout__thread-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.threads-layout__thread-item {
+  border: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  padding: var(--space-3);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.threads-layout__thread-item:hover {
+  background: color-mix(in srgb, var(--surface) 78%, transparent);
+}
+
+.threads-layout__thread-item--active {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.threads-layout__thread-title,
+.threads-layout__thread-id {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.threads-layout__thread-title {
+  font-size: var(--fs-2);
+  font-weight: var(--fw-medium);
+}
+
+.threads-layout__thread-id {
+  font-size: var(--fs-1);
+  color: var(--text-muted);
+}
+
+.threads-layout__sidebar-status {
+  padding: var(--space-4);
+  color: var(--text-muted);
+}
+
+.threads-layout__sidebar-toggle {
+  margin-top: auto;
+  padding: var(--space-2);
+  width: 100%;
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--fs-3);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.threads-layout__sidebar-toggle:hover {
+  background: color-mix(in srgb, var(--bg) 84%, var(--surface));
+}
+
+.threads-layout__main {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg);
+}

--- a/apps/ui/src/features/threads/ThreadsLayout.tsx
+++ b/apps/ui/src/features/threads/ThreadsLayout.tsx
@@ -11,7 +11,7 @@ export function ThreadsLayout(): React.JSX.Element {
   const { id: threadId } = useParams<{ id?: string }>();
   const isThreadDetailRoute = Boolean(threadId);
   const navigate = useNavigate();
-  const { threads, isLoading, error, sectionTitle, navItems } = useThreadsCtx();
+  const { threads, isLoading, error, sectionTitle, navItems, optimisticDraftThread } = useThreadsCtx();
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
   useEffect(() => {
@@ -67,6 +67,15 @@ export function ThreadsLayout(): React.JSX.Element {
                 <div className="threads-layout__sidebar-status">No threads yet</div>
               ) : (
                 <div className="threads-layout__thread-list">
+                  {optimisticDraftThread ? (
+                    <button
+                      type="button"
+                      className="threads-layout__thread-item threads-layout__thread-item--active"
+                      onClick={() => navigate("/threads")}
+                    >
+                      <span className="threads-layout__thread-title">{optimisticDraftThread.title}</span>
+                    </button>
+                  ) : null}
                   {threads.map((thread) => {
                     const isSelected = thread.id === threadId;
                     return (

--- a/apps/ui/src/features/threads/ThreadsLayout.tsx
+++ b/apps/ui/src/features/threads/ThreadsLayout.tsx
@@ -77,7 +77,6 @@ export function ThreadsLayout(): React.JSX.Element {
                         onClick={() => navigate(`/threads/${thread.id}`)}
                       >
                         <span className="threads-layout__thread-title">{thread.title}</span>
-                        <span className="threads-layout__thread-id">#{thread.id.slice(0, 6)}</span>
                       </button>
                     );
                   })}

--- a/apps/ui/src/features/threads/ThreadsLayout.tsx
+++ b/apps/ui/src/features/threads/ThreadsLayout.tsx
@@ -1,29 +1,111 @@
-import { Outlet, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Outlet, useNavigate, useParams } from "react-router-dom";
 import { useIsDesktop } from "../../app/hooks/useIsDesktop";
-import { DesktopShell } from "../../app/shells/DesktopShell";
 import { IosShell } from "../../app/shells/IosShell";
+import { Text } from "../../ui/primitives";
 import { useThreadsCtx } from "./ThreadsProvider";
-import { THREADS_NAVEGATION_ITEMS } from "./const";
+import "./ThreadsLayout.css";
 
 export function ThreadsLayout(): React.JSX.Element {
   const isDesktop = useIsDesktop();
   const { id: threadId } = useParams<{ id?: string }>();
   const isThreadDetailRoute = Boolean(threadId);
-  const { sectionTitle, navItems } = useThreadsCtx();
+  const navigate = useNavigate();
+  const { threads, isLoading, error, sectionTitle, navItems } = useThreadsCtx();
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+
+  useEffect(() => {
+    if (!isDesktop) return;
+    const stored = localStorage.getItem("threads-sidebar-collapsed");
+    setIsSidebarCollapsed(stored === "true");
+  }, [isDesktop]);
+
+  useEffect(() => {
+    if (!isDesktop) return;
+    localStorage.setItem("threads-sidebar-collapsed", String(isSidebarCollapsed));
+  }, [isDesktop, isSidebarCollapsed]);
+
+  if (isDesktop) {
+    return (
+      <div className="threads-layout threads-layout--desktop">
+        <aside className={`threads-layout__sidebar ${isSidebarCollapsed ? "threads-layout__sidebar--collapsed" : ""}`}>
+          <div className="threads-layout__sidebar-header">
+            {!isSidebarCollapsed ? (
+              <>
+                <button
+                  type="button"
+                  className="threads-layout__sidebar-title"
+                  onClick={() => navigate("/threads")}
+                >
+                  <Text as="span" size="2" weight="semibold">Threads</Text>
+                </button>
+                <div className="threads-layout__sidebar-header-actions">
+                  <Text as="div" size="1" tone="muted">{threads.length}</Text>
+                  <button
+                    type="button"
+                    className="threads-layout__sidebar-new"
+                    onClick={() => navigate("/threads")}
+                    aria-label="New thread"
+                    title="New thread"
+                  >
+                    +
+                  </button>
+                </div>
+              </>
+            ) : (
+              <Text as="div" size="1" tone="muted">{threads.length}</Text>
+            )}
+          </div>
+
+          <div className="threads-layout__sidebar-body">
+            {!isSidebarCollapsed ? (
+              isLoading ? (
+                <div className="threads-layout__sidebar-status">Loading threads...</div>
+              ) : error ? (
+                <div className="threads-layout__sidebar-status">Error: {error}</div>
+              ) : threads.length === 0 ? (
+                <div className="threads-layout__sidebar-status">No threads yet</div>
+              ) : (
+                <div className="threads-layout__thread-list">
+                  {threads.map((thread) => {
+                    const isSelected = thread.id === threadId;
+                    return (
+                      <button
+                        key={thread.id}
+                        type="button"
+                        className={`threads-layout__thread-item ${isSelected ? "threads-layout__thread-item--active" : ""}`}
+                        onClick={() => navigate(`/threads/${thread.id}`)}
+                      >
+                        <span className="threads-layout__thread-title">{thread.title}</span>
+                        <span className="threads-layout__thread-id">#{thread.id.slice(0, 6)}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )
+            ) : null}
+          </div>
+
+          <button
+            type="button"
+            className="threads-layout__sidebar-toggle"
+            onClick={() => setIsSidebarCollapsed((current) => !current)}
+            aria-label={isSidebarCollapsed ? "Expand threads sidebar" : "Collapse threads sidebar"}
+          >
+            {isSidebarCollapsed ? "→" : "←"}
+          </button>
+        </aside>
+
+        <main className="threads-layout__main">
+          <Outlet />
+        </main>
+      </div>
+    );
+  }
 
   return (
     <div style={{ minHeight: 0 }}>
-      {isDesktop ?
-        isThreadDetailRoute ? (
-          <Outlet />
-        ) : (
-        <DesktopShell
-          sectionTitle={sectionTitle}
-        >
-          <Outlet />
-        </DesktopShell>)
-        :
-        isThreadDetailRoute ? (
+      {isThreadDetailRoute ? (
           // Thread detail on mobile: bypass IosShell, use custom layout
           <Outlet />
         ) : (

--- a/apps/ui/src/features/threads/ThreadsPage.css
+++ b/apps/ui/src/features/threads/ThreadsPage.css
@@ -79,3 +79,27 @@
   font-weight: 600;
   white-space: nowrap;
 }
+
+.threads-page-desktop {
+  height: 100%;
+  min-height: 0;
+  padding: var(--space-5) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.threads-page-desktop__intro {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.threads-page-desktop__chat {
+  min-height: 0;
+}
+
+.threads-page-desktop__empty-state {
+  min-height: 220px;
+}

--- a/apps/ui/src/features/threads/ThreadsPage.css
+++ b/apps/ui/src/features/threads/ThreadsPage.css
@@ -91,3 +91,23 @@
 .threads-page-desktop__chat {
   min-height: 0;
 }
+
+.threads-page-desktop__optimistic {
+  height: 100%;
+}
+
+.threads-page-desktop__optimistic-sidebar {
+  animation: threads-optimistic-sidebar-enter 180ms ease-out;
+}
+
+@keyframes threads-optimistic-sidebar-enter {
+  from {
+    opacity: 0;
+    transform: translateX(-18px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/apps/ui/src/features/threads/ThreadsPage.css
+++ b/apps/ui/src/features/threads/ThreadsPage.css
@@ -83,23 +83,11 @@
 .threads-page-desktop {
   height: 100%;
   min-height: 0;
-  padding: var(--space-5) var(--space-6);
+  padding: var(--space-4) var(--space-4) var(--space-4) 0;
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
-}
-
-.threads-page-desktop__intro {
-  max-width: 720px;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
 }
 
 .threads-page-desktop__chat {
   min-height: 0;
-}
-
-.threads-page-desktop__empty-state {
-  min-height: 220px;
 }

--- a/apps/ui/src/features/threads/ThreadsPage.tsx
+++ b/apps/ui/src/features/threads/ThreadsPage.tsx
@@ -13,6 +13,8 @@ import { ChatSetupCallout } from "../chat-providers/ChatSetupCallout";
 import { useDraftState } from "../../shared/hooks/useDraftState";
 import { ThreadsService } from "./api";
 import { ThreadContextCard } from "./ThreadContextCard";
+import { useAuth } from "../../auth";
+import { useActorsCtx } from "../actors";
 import './ThreadsPage.css';
 
 export function ThreadsPage() {
@@ -241,6 +243,13 @@ function OptimisticDesktopThread({
   title: string;
   message: string;
 }) {
+  const { user } = useAuth();
+  const { actors } = useActorsCtx();
+  const currentActor = actors.find((actor) => actor.id === user?.actorId);
+  const authorName = currentActor?.displayName || user?.displayName || "You";
+  const authorSlug = currentActor?.slug;
+  const authorAvatarUrl = currentActor?.avatarUrl || undefined;
+
   return (
     <div className="thread-detail-page thread-detail-page--desktop threads-page-desktop__optimistic">
       <div className="thread-detail-page__main">
@@ -267,10 +276,15 @@ function OptimisticDesktopThread({
                 <div className="thread-chat__message thread-chat__message--mine">
                   <div className="thread-chat__message-header">
                     <div className="thread-chat__author">
-                      <Avatar name="You" size="xs" />
+                      <Avatar name={authorName} src={authorAvatarUrl} size="xs" />
                       <Text size="1" weight="semibold">
-                        You
+                        {authorName}
                       </Text>
+                      {authorSlug ? (
+                        <Text size="1" tone="muted">
+                          @{authorSlug}
+                        </Text>
+                      ) : null}
                     </div>
                     <Text size="1" tone="muted">
                       sending...

--- a/apps/ui/src/features/threads/ThreadsPage.tsx
+++ b/apps/ui/src/features/threads/ThreadsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button, DataRowContainer, Text } from "../../ui/primitives";
+import { Avatar, Chip } from "../../ui/primitives";
 import { useThreadsCtx } from "./ThreadsProvider";
 import { ThreadRow } from "./ThreadRow";
 import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
@@ -11,6 +12,7 @@ import { useChatReadiness } from "../chat-providers/useChatReadiness";
 import { ChatSetupCallout } from "../chat-providers/ChatSetupCallout";
 import { useDraftState } from "../../shared/hooks/useDraftState";
 import { ThreadsService } from "./api";
+import { ThreadContextCard } from "./ThreadContextCard";
 import './ThreadsPage.css';
 
 export function ThreadsPage() {
@@ -119,7 +121,7 @@ export function ThreadsPage() {
 
 function DesktopNewThreadPage() {
   const navigate = useNavigate();
-  const { createThread } = useThreadsCtx();
+  const { createThread, optimisticDraftThread, setOptimisticDraftThread } = useThreadsCtx();
   const { showError } = useToast();
   const [draftState, setDraftState, clearDraft] = useDraftState({
     key: 'thread-chat-draft-new',
@@ -144,6 +146,11 @@ function DesktopNewThreadPage() {
 
     setIsCreating(true);
     setCreateError(null);
+    setOptimisticDraftThread({
+      title: "New thread",
+      message: content,
+    });
+    setDraftState({ content: "" });
 
     try {
       const thread = await createThread();
@@ -152,15 +159,27 @@ function DesktopNewThreadPage() {
         body: { content },
       });
       clearDraft();
+      setOptimisticDraftThread(null);
       navigate(`/threads/${thread.id}`);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to start thread';
       setCreateError(message);
+      setDraftState({ content });
+      setOptimisticDraftThread(null);
       showError(error);
     } finally {
       setIsCreating(false);
     }
-  }, [clearDraft, createThread, draftState.content, isCreating, navigate, showError]);
+  }, [clearDraft, createThread, draftState.content, isCreating, navigate, setDraftState, setOptimisticDraftThread, showError]);
+
+  if (optimisticDraftThread) {
+    return (
+      <OptimisticDesktopThread
+        title={optimisticDraftThread.title}
+        message={optimisticDraftThread.message}
+      />
+    );
+  }
 
   return (
     <div className="threads-page-desktop">
@@ -210,6 +229,98 @@ function DesktopNewThreadPage() {
             ) : null}
           </form>
         )}
+      </div>
+    </div>
+  );
+}
+
+function OptimisticDesktopThread({
+  title,
+  message,
+}: {
+  title: string;
+  message: string;
+}) {
+  return (
+    <div className="thread-detail-page thread-detail-page--desktop threads-page-desktop__optimistic">
+      <div className="thread-detail-page__main">
+        <div className="thread-detail-page__content">
+          <div className="thread-detail-page__header">
+            <div className="thread-detail-page__header-top">
+              <div>
+                <Text size="5" weight="bold">
+                  {title}
+                </Text>
+                <div className="thread-detail-page__meta-row">
+                  <Chip color="gray">creating</Chip>
+                  <Text size="1" tone="muted">
+                    1 participant
+                  </Text>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="thread-detail-page__chat">
+            <div className="thread-chat">
+              <div className="thread-chat__messages">
+                <div className="thread-chat__message thread-chat__message--mine">
+                  <div className="thread-chat__message-header">
+                    <div className="thread-chat__author">
+                      <Avatar name="You" size="xs" />
+                      <Text size="1" weight="semibold">
+                        You
+                      </Text>
+                    </div>
+                    <Text size="1" tone="muted">
+                      sending...
+                    </Text>
+                  </div>
+
+                  <Text size="2">{message}</Text>
+                </div>
+              </div>
+
+              <form className="thread-chat__input-form">
+                <div className="thread-chat__composer-row">
+                  <textarea
+                    className="thread-chat__input"
+                    placeholder="Write a message..."
+                    rows={3}
+                    disabled
+                  />
+                  <Button
+                    type="submit"
+                    variant="secondary"
+                    className="thread-chat__send-btn"
+                    disabled
+                  >
+                    starting...
+                  </Button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="thread-detail-page__sidebar threads-page-desktop__optimistic-sidebar">
+        <div className="thread-detail-page__sidebar-scroll">
+          <div className="thread-detail-page__sidebar-section">
+            <Text size="2" weight="semibold" className="thread-detail-page__sidebar-header">
+              Context (1)
+            </Text>
+            <div className="thread-detail-page__sidebar-content">
+              <ThreadContextCard
+                contextBlock={{
+                  id: "creating",
+                  title: "Thread state memory",
+                }}
+                isStateMemory
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/ui/src/features/threads/ThreadsPage.tsx
+++ b/apps/ui/src/features/threads/ThreadsPage.tsx
@@ -185,6 +185,16 @@ function DesktopNewThreadPage() {
 
   return (
     <div className="threads-page-desktop">
+      <div className="thread-detail-page__header">
+        <div className="thread-detail-page__header-top">
+          <div>
+            <Text size="5" weight="bold">
+              New thread
+            </Text>
+          </div>
+        </div>
+      </div>
+
       <div className="thread-chat threads-page-desktop__chat">
         <div className="thread-chat__messages" aria-label="New thread messages" />
 

--- a/apps/ui/src/features/threads/ThreadsPage.tsx
+++ b/apps/ui/src/features/threads/ThreadsPage.tsx
@@ -164,21 +164,8 @@ function DesktopNewThreadPage() {
 
   return (
     <div className="threads-page-desktop">
-      <div className="threads-page-desktop__intro">
-        <Text size="5" weight="bold">Start a new thread</Text>
-        <Text size="2" tone="muted">
-          Send the first message and Taico will create the thread, switch the URL, and load the attached task and context sidebar.
-        </Text>
-      </div>
-
       <div className="thread-chat threads-page-desktop__chat">
-        <div className="thread-chat__messages">
-          <div className="thread-chat__empty-state threads-page-desktop__empty-state">
-            <Text size="2" tone="muted">
-              No thread selected yet. Kick things off here and the conversation will open in its own thread.
-            </Text>
-          </div>
-        </div>
+        <div className="thread-chat__messages" aria-label="New thread messages" />
 
         {!isChatReadinessLoading && readiness && !readiness.isReady ? (
           <div className="thread-chat__setup-callout">
@@ -197,7 +184,7 @@ function DesktopNewThreadPage() {
                 className="thread-chat__input"
                 value={draftState.content}
                 onChange={(event) => setDraftState({ content: event.target.value })}
-                placeholder="Write the first message for this thread..."
+                placeholder="Write a message..."
                 rows={3}
                 disabled={isCreating || isChatReadinessLoading}
                 onKeyDown={(event) => {

--- a/apps/ui/src/features/threads/ThreadsPage.tsx
+++ b/apps/ui/src/features/threads/ThreadsPage.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { DataRowContainer } from "../../ui/primitives";
+import { Button, DataRowContainer, Text } from "../../ui/primitives";
 import { useThreadsCtx } from "./ThreadsProvider";
 import { ThreadRow } from "./ThreadRow";
 import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
@@ -9,6 +9,8 @@ import { useToast } from "../../shared/context/ToastContext";
 import { useCommandPalette } from "../../ui/components";
 import { useChatReadiness } from "../chat-providers/useChatReadiness";
 import { ChatSetupCallout } from "../chat-providers/ChatSetupCallout";
+import { useDraftState } from "../../shared/hooks/useDraftState";
+import { ThreadsService } from "./api";
 import './ThreadsPage.css';
 
 export function ThreadsPage() {
@@ -32,6 +34,11 @@ export function ThreadsPage() {
   };
 
   const handleNewThread = useCallback(async () => {
+    if (isDesktop) {
+      navigate('/threads');
+      return;
+    }
+
     if (!isChatReady) {
       showToast('Thread chat unlocks in Chat Settings.', 'info');
       navigate('/settings/chat');
@@ -66,43 +73,157 @@ export function ThreadsPage() {
   }, [registerCommands, handleNewThread]);
 
   return (
-    <>
-      {!isChatReadinessLoading && readiness && !readiness.isReady ? (
-        <ChatSetupCallout
-          title={readiness.title}
-          description={readiness.description}
-          ctaLabel={readiness.ctaLabel}
-          onOpenSettings={() => navigate('/settings/chat')}
-        />
-      ) : null}
-
-      <DataRowContainer>
-        {threads.map((thread) => (
-          <ThreadRow
-            key={thread.id}
-            thread={thread}
-            onClick={() => handleThreadClick(thread.id)}
+    isDesktop ? (
+      <DesktopNewThreadPage />
+    ) : (
+      <>
+        {!isChatReadinessLoading && readiness && !readiness.isReady ? (
+          <ChatSetupCallout
+            title={readiness.title}
+            description={readiness.description}
+            ctaLabel={readiness.ctaLabel}
+            onOpenSettings={() => navigate('/settings/chat')}
           />
-        ))}
-      </DataRowContainer>
+        ) : null}
 
-      {/* Floating Action Button */}
-      <button
-        className={`threads-fab ${isDesktop ? 'threads-fab--desktop' : ''}`}
-        type="button"
-        onClick={handleNewThread}
-        disabled={!isChatReady || isChatReadinessLoading}
-        aria-label="Create new thread"
-      >
-        {isDesktop ? (
-          <>
-            <span className="threads-fab__plus">+</span>
-            <span className="threads-fab__label">New thread</span>
-          </>
+        <DataRowContainer>
+          {threads.map((thread) => (
+            <ThreadRow
+              key={thread.id}
+              thread={thread}
+              onClick={() => handleThreadClick(thread.id)}
+            />
+          ))}
+        </DataRowContainer>
+
+        <button
+          className={`threads-fab ${isDesktop ? 'threads-fab--desktop' : ''}`}
+          type="button"
+          onClick={handleNewThread}
+          disabled={!isChatReady || isChatReadinessLoading}
+          aria-label="Create new thread"
+        >
+          {isDesktop ? (
+            <>
+              <span className="threads-fab__plus">+</span>
+              <span className="threads-fab__label">New thread</span>
+            </>
+          ) : (
+            '+'
+          )}
+        </button>
+      </>
+    )
+  );
+}
+
+function DesktopNewThreadPage() {
+  const navigate = useNavigate();
+  const { createThread } = useThreadsCtx();
+  const { showError } = useToast();
+  const [draftState, setDraftState, clearDraft] = useDraftState({
+    key: 'thread-chat-draft-new',
+    defaultValue: { content: '' },
+  });
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const messageInputRef = useRef<HTMLTextAreaElement>(null);
+  const { readiness, isLoading: isChatReadinessLoading } = useChatReadiness();
+
+  useEffect(() => {
+    if (isChatReadinessLoading) return;
+    messageInputRef.current?.focus();
+  }, [isChatReadinessLoading]);
+
+  const handleSendMessage = useCallback(async (event: React.FormEvent) => {
+    event.preventDefault();
+    const content = draftState.content.trim();
+    if (!content || isCreating) {
+      return;
+    }
+
+    setIsCreating(true);
+    setCreateError(null);
+
+    try {
+      const thread = await createThread();
+      await ThreadsService.ThreadsController_createMessage({
+        id: thread.id,
+        body: { content },
+      });
+      clearDraft();
+      navigate(`/threads/${thread.id}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to start thread';
+      setCreateError(message);
+      showError(error);
+    } finally {
+      setIsCreating(false);
+    }
+  }, [clearDraft, createThread, draftState.content, isCreating, navigate, showError]);
+
+  return (
+    <div className="threads-page-desktop">
+      <div className="threads-page-desktop__intro">
+        <Text size="5" weight="bold">Start a new thread</Text>
+        <Text size="2" tone="muted">
+          Send the first message and Taico will create the thread, switch the URL, and load the attached task and context sidebar.
+        </Text>
+      </div>
+
+      <div className="thread-chat threads-page-desktop__chat">
+        <div className="thread-chat__messages">
+          <div className="thread-chat__empty-state threads-page-desktop__empty-state">
+            <Text size="2" tone="muted">
+              No thread selected yet. Kick things off here and the conversation will open in its own thread.
+            </Text>
+          </div>
+        </div>
+
+        {!isChatReadinessLoading && readiness && !readiness.isReady ? (
+          <div className="thread-chat__setup-callout">
+            <ChatSetupCallout
+              title={readiness.title}
+              description={readiness.description}
+              ctaLabel={readiness.ctaLabel}
+              onOpenSettings={() => navigate('/settings/chat')}
+            />
+          </div>
         ) : (
-          '+'
+          <form className="thread-chat__input-form" onSubmit={handleSendMessage}>
+            <div className="thread-chat__composer-row">
+              <textarea
+                ref={messageInputRef}
+                className="thread-chat__input"
+                value={draftState.content}
+                onChange={(event) => setDraftState({ content: event.target.value })}
+                placeholder="Write the first message for this thread..."
+                rows={3}
+                disabled={isCreating || isChatReadinessLoading}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !event.shiftKey) {
+                    event.preventDefault();
+                    void handleSendMessage(event);
+                  }
+                }}
+              />
+              <Button
+                type="submit"
+                variant="secondary"
+                className="thread-chat__send-btn"
+                disabled={!draftState.content.trim() || isCreating || isChatReadinessLoading}
+              >
+                {isCreating ? 'starting...' : 'send'}
+              </Button>
+            </div>
+            {createError ? (
+              <div className="thread-chat__status thread-chat__status--error">
+                <Text size="1">{createError}</Text>
+              </div>
+            ) : null}
+          </form>
         )}
-      </button>
-    </>
+      </div>
+    </div>
   );
 }

--- a/apps/ui/src/features/threads/ThreadsProvider.tsx
+++ b/apps/ui/src/features/threads/ThreadsProvider.tsx
@@ -3,6 +3,11 @@ import { useThreads } from "./useThreads";
 import type { ThreadListItem, Thread } from "./types";
 import { NavegationItem } from "src/shared/types/NavegationItem";
 
+export type OptimisticThreadDraft = {
+  title: string;
+  message: string;
+};
+
 // Shape this to match what pages/layout need.
 export type ThreadsContextValue = {
   threads: ThreadListItem[];
@@ -16,6 +21,8 @@ export type ThreadsContextValue = {
   getThread: (id: string) => Promise<Thread>;
   createThread: (title?: string) => Promise<Thread>;
   deleteThread: (id: string) => Promise<void>;
+  optimisticDraftThread: OptimisticThreadDraft | null;
+  setOptimisticDraftThread: (draft: OptimisticThreadDraft | null) => void;
 };
 
 const ThreadsContext = createContext<ThreadsContextValue | null>(null);
@@ -24,6 +31,7 @@ export function ThreadsProvider({ children }: { children: React.ReactNode }) {
   const { threads, isLoading, error, loadThreads, getThread, createThread, deleteThread } = useThreads();
   const [sectionTitle, setSectionTitle] = useState("");
   const [navItems, setNavItems] = useState<NavegationItem[]>([]);
+  const [optimisticDraftThread, setOptimisticDraftThread] = useState<OptimisticThreadDraft | null>(null);
 
   // Provide a stable reference to avoid pointless rerenders.
   const value = useMemo<ThreadsContextValue>(() => {
@@ -39,6 +47,8 @@ export function ThreadsProvider({ children }: { children: React.ReactNode }) {
       getThread,
       createThread,
       deleteThread,
+      optimisticDraftThread,
+      setOptimisticDraftThread,
     };
   }, [
     threads,
@@ -52,6 +62,8 @@ export function ThreadsProvider({ children }: { children: React.ReactNode }) {
     getThread,
     createThread,
     deleteThread,
+    optimisticDraftThread,
+    setOptimisticDraftThread,
   ]);
 
   return <ThreadsContext.Provider value={value}>{children}</ThreadsContext.Provider>;

--- a/apps/ui/src/features/threads/ThreadsProvider.tsx
+++ b/apps/ui/src/features/threads/ThreadsProvider.tsx
@@ -8,6 +8,7 @@ export type ThreadsContextValue = {
   threads: ThreadListItem[];
   isLoading: boolean;
   error: string | null;
+  loadThreads: () => Promise<void>;
   sectionTitle: string;
   setSectionTitle: (title: string) => void;
   navItems: NavegationItem[];
@@ -20,7 +21,7 @@ export type ThreadsContextValue = {
 const ThreadsContext = createContext<ThreadsContextValue | null>(null);
 
 export function ThreadsProvider({ children }: { children: React.ReactNode }) {
-  const { threads, isLoading, error, getThread, createThread, deleteThread } = useThreads();
+  const { threads, isLoading, error, loadThreads, getThread, createThread, deleteThread } = useThreads();
   const [sectionTitle, setSectionTitle] = useState("");
   const [navItems, setNavItems] = useState<NavegationItem[]>([]);
 
@@ -30,6 +31,7 @@ export function ThreadsProvider({ children }: { children: React.ReactNode }) {
       threads,
       isLoading,
       error,
+      loadThreads,
       sectionTitle,
       setSectionTitle,
       navItems,
@@ -42,6 +44,7 @@ export function ThreadsProvider({ children }: { children: React.ReactNode }) {
     threads,
     isLoading,
     error,
+    loadThreads,
     sectionTitle,
     setSectionTitle,
     navItems,

--- a/apps/ui/src/features/threads/useThreads.ts
+++ b/apps/ui/src/features/threads/useThreads.ts
@@ -27,15 +27,8 @@ export const useThreads = () => {
   const [socket, setSocket] = useState<Socket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
 
-  // Boot
-  useEffect(() => {
-    loadThreads();
-    const cleanup = setupWebsocket();
-    return cleanup;
-  }, []);
-
   // Load threads
-  const loadThreads = async () => {
+  const loadThreads = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
@@ -46,7 +39,7 @@ export const useThreads = () => {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
 
   // Get single thread with full details
   const getThread = useCallback(async (id: string): Promise<Thread> => {
@@ -111,6 +104,13 @@ export const useThreads = () => {
       setIsConnected(false);
     };
   }, []);
+
+  // Boot
+  useEffect(() => {
+    void loadThreads();
+    const cleanup = setupWebsocket();
+    return cleanup;
+  }, [loadThreads, setupWebsocket]);
 
   return {
     // UI feedback


### PR DESCRIPTION
## Summary
- turn the desktop threads feature into a two-sidebar layout so the thread list stays visible beside the active chat
- make `/threads` on desktop open a draft chat composer that creates the thread and first message on send before navigating to `/threads/:threadId`
- keep the thread detail panel working inside the new layout and adjust the desktop detail height so it fits the nested shell

## Validation
- `npm run build:dev`
- `npm run dev:1` (backend started, but both Vite frontends hit `ENOSPC` watcher limits in this environment)

## Technical Debt
- startup verification is still partially blocked by the local file watcher ceiling; once that environment limit is raised, the desktop flow should be rechecked in a live dev session