### PR TITLE
Add worker status banner to executions page

### DIFF
--- a/apps/ui/src/features/executions/ExecutionsPage.css
+++ b/apps/ui/src/features/executions/ExecutionsPage.css
@@ -4,6 +4,34 @@
   gap: var(--space-4);
 }
 
+.executions-workers-banner {
+  padding: var(--space-3);
+  border-radius: var(--r-3);
+  background: color-mix(in srgb, var(--accent) 4%, var(--card-bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border-subtle));
+  text-align: center;
+}
+
+.executions-workers-link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--accent);
+  font: inherit;
+  text-decoration: underline;
+}
+
+.executions-workers-link:hover {
+  color: color-mix(in srgb, var(--accent) 85%, var(--text));
+}
+
+.executions-workers-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--r-1);
+}
+
 .executions-hero {
   display: flex;
   justify-content: space-between;

--- a/apps/ui/src/features/executions/ExecutionsPage.css
+++ b/apps/ui/src/features/executions/ExecutionsPage.css
@@ -4,15 +4,18 @@
   gap: var(--space-4);
 }
 
-.executions-workers-banner {
-  padding: var(--space-3);
-  border-radius: var(--r-3);
-  background: color-mix(in srgb, var(--accent) 4%, var(--card-bg));
-  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border-subtle));
-  text-align: center;
+.executions-worker-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
 }
 
-.executions-workers-link {
+.executions-worker-status__indicator {
+  font-size: var(--fs-1);
+  line-height: 1;
+}
+
+.executions-worker-status__link {
   background: none;
   border: none;
   padding: 0;
@@ -22,11 +25,11 @@
   text-decoration: underline;
 }
 
-.executions-workers-link:hover {
+.executions-worker-status__link:hover {
   color: color-mix(in srgb, var(--accent) 85%, var(--text));
 }
 
-.executions-workers-link:focus-visible {
+.executions-worker-status__link:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: var(--r-1);

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -92,30 +92,28 @@ export function ExecutionsPage() {
           <Text as="div" size="3" tone="muted" wrap>
             Queue, active work, and recent history in one place. The view refreshes automatically every 5 seconds.
           </Text>
-          {workers.length > 0 && (
-            <div className="executions-worker-status">
-              <span
-                className="executions-worker-status__indicator"
-                style={{ color: connectedWorkersCount > 0 ? 'var(--success)' : 'var(--danger)' }}
-                aria-label={connectedWorkersCount > 0 ? 'Workers connected' : 'No workers connected'}
+          <div className="executions-worker-status">
+            <span
+              className="executions-worker-status__indicator"
+              style={{ color: connectedWorkersCount > 0 ? 'var(--success)' : 'var(--danger)' }}
+              aria-label={connectedWorkersCount > 0 ? 'Workers connected' : 'No workers connected'}
+            >
+              ●
+            </span>
+            <Text as="span" size="2" tone="muted">
+              {connectedWorkersCount > 0
+                ? `${connectedWorkersCount} worker${connectedWorkersCount !== 1 ? 's' : ''} connected`
+                : 'no worker connected'}
+              {' · '}
+              <button
+                type="button"
+                className="executions-worker-status__link"
+                onClick={() => navigate('/settings/workers')}
               >
-                ●
-              </span>
-              <Text as="span" size="2" tone="muted">
-                {connectedWorkersCount > 0
-                  ? `${connectedWorkersCount} worker${connectedWorkersCount !== 1 ? 's' : ''} connected`
-                  : 'no worker connected'}
-                {' · '}
-                <button
-                  type="button"
-                  className="executions-worker-status__link"
-                  onClick={() => navigate('/settings/workers')}
-                >
-                  configure
-                </button>
-              </Text>
-            </div>
-          )}
+                configure
+              </button>
+            </Text>
+          </div>
         </div>
         <div className="executions-hero__actions">
           <span className={`executions-pill ${error ? "executions-pill--danger" : "executions-pill--success"}`}>

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -87,29 +87,35 @@ export function ExecutionsPage() {
 
   return (
     <div className="executions-page">
-      {workers.length > 0 && (
-        <div className="executions-workers-banner">
-          <Text as="div" size="2" tone="muted">
-            {connectedWorkersCount > 0
-              ? `${connectedWorkersCount} worker${connectedWorkersCount !== 1 ? 's' : ''} connected`
-              : `${workers.length} worker${workers.length !== 1 ? 's' : ''} registered (none currently connected)`}
-            {' · '}
-            <button
-              type="button"
-              className="executions-workers-link"
-              onClick={() => navigate('/settings/workers')}
-            >
-              Configure workers
-            </button>
-          </Text>
-        </div>
-      )}
-
       <div className="executions-hero">
         <div className="executions-hero__copy">
           <Text as="div" size="3" tone="muted" wrap>
             Queue, active work, and recent history in one place. The view refreshes automatically every 5 seconds.
           </Text>
+          {workers.length > 0 && (
+            <div className="executions-worker-status">
+              <span
+                className="executions-worker-status__indicator"
+                style={{ color: connectedWorkersCount > 0 ? 'var(--success)' : 'var(--danger)' }}
+                aria-label={connectedWorkersCount > 0 ? 'Workers connected' : 'No workers connected'}
+              >
+                ●
+              </span>
+              <Text as="span" size="2" tone="muted">
+                {connectedWorkersCount > 0
+                  ? `${connectedWorkersCount} worker${connectedWorkersCount !== 1 ? 's' : ''} connected`
+                  : 'no worker connected'}
+                {' · '}
+                <button
+                  type="button"
+                  className="executions-worker-status__link"
+                  onClick={() => navigate('/settings/workers')}
+                >
+                  configure
+                </button>
+              </Text>
+            </div>
+          )}
         </div>
         <div className="executions-hero__actions">
           <span className={`executions-pill ${error ? "executions-pill--danger" : "executions-pill--success"}`}>

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -6,6 +6,7 @@ import { useActorsCtx } from "../actors";
 import { useExecutions } from "./useExecutions";
 import { ExecutionsService } from "./api";
 import { useToast } from "../../shared/context/ToastContext";
+import { useWorkers } from "../workers/useWorkers";
 import type {
   TaskExecutionQueueEntryResponseDto,
   ActiveTaskExecutionResponseDto,
@@ -27,8 +28,20 @@ export function ExecutionsPage() {
     error,
     loadExecutions,
   } = useExecutions();
+  const { workers } = useWorkers();
 
   useDocumentTitle();
+
+  // Calculate connected workers (seen in last 2 minutes)
+  const connectedWorkersCount = useMemo(() => {
+    const now = new Date();
+    const twoMinutesMs = 2 * 60 * 1000;
+    return workers.filter((worker) => {
+      const lastSeen = new Date(worker.lastSeenAt);
+      const diffMs = now.getTime() - lastSeen.getTime();
+      return diffMs <= twoMinutesMs;
+    }).length;
+  }, [workers]);
 
   const [expandedHistoryIds, setExpandedHistoryIds] = useState<Set<string>>(
     () => new Set(),
@@ -74,6 +87,24 @@ export function ExecutionsPage() {
 
   return (
     <div className="executions-page">
+      {workers.length > 0 && (
+        <div className="executions-workers-banner">
+          <Text as="div" size="2" tone="muted">
+            {connectedWorkersCount > 0
+              ? `${connectedWorkersCount} worker${connectedWorkersCount !== 1 ? 's' : ''} connected`
+              : `${workers.length} worker${workers.length !== 1 ? 's' : ''} registered (none currently connected)`}
+            {' · '}
+            <button
+              type="button"
+              className="executions-workers-link"
+              onClick={() => navigate('/settings/workers')}
+            >
+              Configure workers
+            </button>
+          </Text>
+        </div>
+      )}
+
       <div className="executions-hero">
         <div className="executions-hero__copy">
           <Text as="div" size="3" tone="muted" wrap>


### PR DESCRIPTION
## Summary

- Added a non-intrusive banner at the top of `/runs` showing connected worker count
- Banner displays number of connected workers (those seen in last 2 minutes)
- Shows total registered workers when none are currently connected
- Includes a link to `/settings/workers` for worker configuration
- Reuses existing `useWorkers` hook and WebSocket connection from workers feature
- Styled with subtle accent theming to avoid distraction from main content

## Implementation Details

**Files Changed:**
- `apps/ui/src/features/executions/ExecutionsPage.tsx` - Added useWorkers hook, worker count calculation, and banner component
- `apps/ui/src/features/executions/ExecutionsPage.css` - Added styling for worker banner and link

**Technical Decisions:**
- Reused existing `useWorkers` hook to avoid duplicate WebSocket connections
- Applied same 2-minute lastSeenAt logic used in settings page for consistency
- Banner only appears when workers are registered (conditional rendering)
- Used button element for link to maintain accessibility

## Test plan

- [x] Run `npm run build:dev` to verify build succeeds
- [x] Verify TypeScript compilation passes
- [ ] Start app and navigate to `/runs` page
- [ ] Verify banner appears when workers are registered
- [ ] Verify correct count shows for connected workers
- [ ] Verify link navigates to `/settings/workers`
- [ ] Test with no workers registered (banner should not appear)
- [ ] Test with workers registered but disconnected (shows "registered (none currently connected)")

🤖 Generated with [Claude Code](https://claude.com/claude-code)