### PR TITLE
Cleanup run view header

### DIFF
--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -23,7 +23,6 @@ export function ExecutionsPage() {
     active,
     history,
     isLoading,
-    isRefreshing,
     hasLoadedOnce,
     error,
     loadExecutions,
@@ -112,10 +111,10 @@ export function ExecutionsPage() {
             </Text>
           </div>
         </div>
-        {error || isRefreshing ? (
+        {error ? (
           <div className="executions-hero__actions">
-            <span className={`executions-pill ${error ? "executions-pill--danger" : "executions-pill--success"}`}>
-              {error ? "Fetch failed" : "Refreshing"}
+            <span className="executions-pill executions-pill--danger">
+              Fetch failed
             </span>
           </div>
         ) : null}

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -89,9 +89,6 @@ export function ExecutionsPage() {
     <div className="executions-page">
       <div className="executions-hero">
         <div className="executions-hero__copy">
-          <Text as="div" size="3" tone="muted" wrap>
-            Queue, active work, and recent history in one place. The view refreshes automatically every 5 seconds.
-          </Text>
           <div className="executions-worker-status">
             <span
               className="executions-worker-status__indicator"
@@ -115,14 +112,13 @@ export function ExecutionsPage() {
             </Text>
           </div>
         </div>
-        <div className="executions-hero__actions">
-          <span className={`executions-pill ${error ? "executions-pill--danger" : "executions-pill--success"}`}>
-            {error ? "Fetch failed" : isRefreshing ? "Refreshing" : "Polling"}
-          </span>
-          <Button variant="secondary" onClick={() => void loadExecutions()} disabled={isRefreshing}>
-            Refresh now
-          </Button>
-        </div>
+        {error || isRefreshing ? (
+          <div className="executions-hero__actions">
+            <span className={`executions-pill ${error ? "executions-pill--danger" : "executions-pill--success"}`}>
+              {error ? "Fetch failed" : "Refreshing"}
+            </span>
+          </div>
+        ) : null}
       </div>
 
 


### PR DESCRIPTION
## Summary
- remove the executions hero helper copy and manual refresh button
- stop showing the idle polling pill so the header only surfaces refreshing and error states

## Validation
- `npm run build:dev`
- `npm run dev:1` *(backend started; ui and ui-v1 hit ENOSPC file-watcher limits in this environment)*

## Technical Debt
- Local dev startup in this environment is constrained by Vite file-watcher limits, so full stack startup could not be kept running end-to-end.