### PR TITLE
Revamp runs view

### DIFF
--- a/apps/ui/src/features/executions/ExecutionsPage.css
+++ b/apps/ui/src/features/executions/ExecutionsPage.css
@@ -59,7 +59,7 @@
   align-items: center;
   min-height: 36px;
   padding: 0 var(--space-3);
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid var(--border);
   background: var(--card-bg);
   color: var(--text);
@@ -81,21 +81,46 @@
   background: color-mix(in srgb, var(--danger) 8%, var(--card-bg));
 }
 
-.executions-overview-card,
 .executions-empty-card {
-  border-radius: var(--r-4);
-  box-shadow: var(--shadow-1);
+  border-radius: 0;
 }
 
 .executions-overview {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-4);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-3);
 }
 
 .executions-metric {
   display: grid;
   gap: var(--space-1);
+  border-radius: 0;
+  border-left: 4px solid var(--border);
+}
+
+.executions-metric--accent {
+  border-left-color: var(--accent);
+}
+
+.executions-metric--warning {
+  border-left-color: var(--warning);
+}
+
+.executions-metric--success {
+  border-left-color: var(--success);
+}
+
+.executions-metric--danger {
+  border-left-color: var(--danger);
+}
+
+.executions-metric__label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.executions-metric__value {
+  line-height: 1;
 }
 
 .executions-sections {
@@ -104,9 +129,8 @@
 }
 
 .executions-section-card {
-  border-radius: var(--r-4);
+  border-radius: 0;
   overflow: hidden;
-  box-shadow: var(--shadow-1);
 }
 
 .executions-section-card__header {
@@ -116,12 +140,7 @@
   gap: var(--space-4);
   padding: var(--space-4);
   border-bottom: 1px solid var(--border-subtle);
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--accent) 5%, var(--card-bg)),
-      var(--card-bg)
-    );
+  background: var(--card-bg);
 }
 
 .executions-count-pill {
@@ -131,7 +150,7 @@
   min-width: 40px;
   height: 32px;
   padding: 0 var(--space-2);
-  border-radius: 999px;
+  border-radius: 0;
   background: var(--surface);
   border: 1px solid var(--border);
   color: var(--text);
@@ -192,12 +211,24 @@
   justify-content: center;
   min-height: 26px;
   padding: 0 var(--space-2);
-  border-radius: 999px;
+  border-radius: 0;
   font-size: var(--fs-1);
   font-weight: var(--fw-semibold);
   letter-spacing: 0.02em;
   text-transform: uppercase;
   border: 1px solid transparent;
+  gap: var(--space-1);
+}
+
+.executions-status-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  line-height: 1;
+  font-size: var(--fs-1);
+  font-weight: var(--fw-bold);
 }
 
 .executions-status-pill--accent {
@@ -294,7 +325,7 @@
   width: 22px;
   height: 22px;
   border: 1px solid color-mix(in srgb, var(--danger) 25%, var(--border));
-  border-radius: 999px;
+  border-radius: 0;
   background: color-mix(in srgb, var(--danger) 10%, var(--card-bg));
   color: var(--danger);
   font-size: var(--fs-1);
@@ -315,7 +346,7 @@
   display: grid;
   gap: var(--space-2);
   padding: var(--space-3);
-  border-radius: var(--r-3);
+  border-radius: 0;
   background: color-mix(in srgb, var(--danger) 5%, var(--surface));
   border: 1px solid color-mix(in srgb, var(--danger) 12%, var(--border-subtle));
 }
@@ -333,6 +364,7 @@
   gap: var(--space-3);
   padding: var(--space-4);
   border-top: 1px solid var(--border-subtle);
+  border-left: 4px solid transparent;
 }
 
 .executions-mobile-card--clickable {
@@ -447,7 +479,7 @@
   width: 22px;
   height: 22px;
   border: 1px solid color-mix(in srgb, var(--danger) 25%, var(--border));
-  border-radius: 999px;
+  border-radius: 0;
   background: color-mix(in srgb, var(--danger) 10%, var(--card-bg));
   color: var(--danger);
   font-size: var(--fs-1);
@@ -488,7 +520,12 @@
 .executions-details-panel {
   padding: var(--space-4);
   background: color-mix(in srgb, var(--surface) 25%, var(--card-bg));
-  border-radius: var(--r-3);
+  border-radius: 0;
+  border: 1px solid var(--border-subtle);
+}
+
+.executions-details-panel--standalone {
+  margin-top: var(--space-4);
 }
 
 .executions-details-grid {
@@ -554,6 +591,32 @@
   border-radius: var(--r-2);
 }
 
+.executions-page--detail {
+  max-width: 1120px;
+}
+
+.executions-detail-card {
+  border-radius: 0;
+}
+
+.executions-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.executions-detail-title-group,
+.executions-detail-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.executions-detail-actions {
+  align-items: flex-end;
+}
+
 @media (max-width: 980px) {
   .executions-overview {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -572,6 +635,15 @@
 
   .executions-overview {
     grid-template-columns: 1fr;
+  }
+
+  .executions-detail-header {
+    flex-direction: column;
+  }
+
+  .executions-detail-actions {
+    width: 100%;
+    align-items: stretch;
   }
 
   .executions-table-wrap {

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
 import { Button, Card, Text } from "../../ui/primitives";
 import { useActorsCtx } from "../actors";
@@ -13,6 +13,11 @@ import type {
   TaskExecutionHistoryResponseDto,
 } from "./types";
 import "./ExecutionsPage.css";
+
+type ExecutionDetailResult =
+  | { kind: "queue"; entry: TaskExecutionQueueEntryResponseDto }
+  | { kind: "active"; entry: ActiveTaskExecutionResponseDto }
+  | { kind: "history"; entry: TaskExecutionHistoryResponseDto };
 
 export function ExecutionsPage() {
   const navigate = useNavigate();
@@ -48,6 +53,19 @@ export function ExecutionsPage() {
   const [interruptingExecutions, setInterruptingExecutions] = useState<Set<string>>(
     () => new Set(),
   );
+
+  const failedHistory = useMemo(
+    () => history.filter((entry) => entry.status !== "SUCCEEDED"),
+    [history],
+  );
+  const successRate = useMemo(() => {
+    if (history.length === 0) {
+      return "-";
+    }
+
+    const succeeded = history.filter((entry) => entry.status === "SUCCEEDED").length;
+    return `${Math.round((succeeded / history.length) * 100)}%`;
+  }, [history]);
 
   const toggleHistoryMessage = (historyId: string) => {
     setExpandedHistoryIds((prev) => {
@@ -120,6 +138,15 @@ export function ExecutionsPage() {
         ) : null}
       </div>
 
+      {hasLoadedOnce && !error ? (
+        <div className="executions-overview" aria-label="Runs overview">
+          <OverviewMetric label="Queued" value={String(queue.length)} detail="waiting for a worker" tone="accent" />
+          <OverviewMetric label="Active" value={String(active.length)} detail="currently executing" tone="warning" />
+          <OverviewMetric label="Failed" value={String(failedHistory.length)} detail="recent failed or cancelled runs" tone={failedHistory.length > 0 ? "danger" : "neutral"} />
+          <OverviewMetric label="Success rate" value={successRate} detail="across loaded history" tone="success" />
+        </div>
+      ) : null}
+
 
       {isLoading && !hasLoadedOnce ? (
         <Card className="executions-empty-card">
@@ -138,12 +165,12 @@ export function ExecutionsPage() {
         <div className="executions-sections">
           <ExecutionSection
             title="Queue"
-            subtitle=""
+            subtitle="Runs waiting to be claimed"
             count={queue.length}
             emptyMessage="Nothing is waiting in the queue."
             table={
               <ExecutionTable
-                columns={["State", "Task", "Task status", "Task ID"]}
+                columns={["State", "Task", "Task status", "Task ID", "Run"]}
                 rows={queue.map((entry) => ({
                   key: entry.taskId,
                   cells: [
@@ -153,6 +180,7 @@ export function ExecutionsPage() {
                       {entry.taskStatus ?? "Unknown"}
                     </StatusPill>,
                     <CodeCell key="id" value={entry.taskId} />,
+                    <RunLink key="run" label="Open run" onClick={() => navigate(`/runs/queue/${entry.taskId}`)} />,
                   ],
                   mobile: (
                     <ExecutionMobileCard
@@ -174,12 +202,12 @@ export function ExecutionsPage() {
 
           <ExecutionSection
             title="Active"
-            subtitle=""
+            subtitle="Live agent work with heartbeat and worker details"
             count={active.length}
             emptyMessage="No active executions right now."
             table={
               <ExecutionTable
-                columns={["Status", "Task", "Agent", "Heartbeat", "Details", "Actions"]}
+                columns={["Status", "Task", "Agent", "Heartbeat", "Run", "Actions"]}
                 rows={active.map((entry) => {
                   const actor = actors.find((candidate) => candidate.id === entry.agentActorId);
                   const isInterrupting = interruptingExecutions.has(entry.id);
@@ -193,7 +221,7 @@ export function ExecutionsPage() {
                       />
                     ) : null,
                     cells: [
-                    <StatusPill key="state" tone="warning">Active</StatusPill>,
+                    <StatusPill key="state" tone="warning"><StatusMark status="ACTIVE" /> Active</StatusPill>,
                     <TaskCellWithStatus
                       key="task"
                       taskId={entry.taskId}
@@ -208,18 +236,7 @@ export function ExecutionsPage() {
                       actorSlug={actor?.slug}
                     />,
                     <TimeCell key="heartbeat" value={entry.lastHeartbeatAt} />,
-                    <button
-                      key="details"
-                      type="button"
-                      className="executions-details-toggle"
-                      onClick={() => toggleHistoryMessage(entry.id)}
-                      aria-expanded={expandedHistoryIds.has(entry.id)}
-                      aria-label={expandedHistoryIds.has(entry.id) ? "Hide details" : "Show details"}
-                    >
-                      <Text as="span" size="2" weight="semibold">
-                        {expandedHistoryIds.has(entry.id) ? "Hide details" : "Show details"}
-                      </Text>
-                    </button>,
+                    <RunLink key="run" label="Open run" onClick={() => navigate(`/runs/active/${entry.id}`)} />,
                     <Button
                       key="interrupt"
                       variant="danger"
@@ -266,12 +283,12 @@ export function ExecutionsPage() {
 
           <ExecutionSection
             title="History"
-            subtitle=""
+            subtitle="Completed, failed, and cancelled runs"
             count={history.length}
             emptyMessage="No historical executions yet."
             table={
               <ExecutionTable
-                columns={["Status", "Task", "Agent", "Details"]}
+                columns={["Status", "Task", "Agent", "Duration", "Run"]}
                 rows={history.map((entry) => {
                   const actor = actors.find((candidate) => candidate.id === entry.agentActorId);
 
@@ -305,18 +322,8 @@ export function ExecutionsPage() {
                       actorName={actor?.displayName}
                       actorSlug={actor?.slug}
                     />,
-                    <button
-                      key="details"
-                      type="button"
-                      className="executions-details-toggle"
-                      onClick={() => toggleHistoryMessage(entry.id)}
-                      aria-expanded={expandedHistoryIds.has(entry.id)}
-                      aria-label={expandedHistoryIds.has(entry.id) ? "Hide details" : "Show details"}
-                    >
-                      <Text as="span" size="2" weight="semibold">
-                        {expandedHistoryIds.has(entry.id) ? "Hide details" : "Show details"}
-                      </Text>
-                    </button>,
+                    <DurationCell key="duration" start={entry.claimedAt} end={entry.transitionedAt} />,
+                    <RunLink key="run" label="Open run" onClick={() => navigate(`/runs/history/${entry.id}`)} />,
                     ],
                     mobile: (
                     <ExecutionMobileCard
@@ -348,6 +355,149 @@ export function ExecutionsPage() {
         </div>
       ) : null}
     </div>
+  );
+}
+
+export function ExecutionDetailPage() {
+  const navigate = useNavigate();
+  const { kind, id } = useParams<{ kind: string; id: string }>();
+  const { actors } = useActorsCtx();
+  const { queue, active, history, isLoading, hasLoadedOnce, error } = useExecutions();
+
+  useDocumentTitle();
+
+  const detail = useMemo<ExecutionDetailResult | null>(() => {
+    if (!kind || !id) {
+      return null;
+    }
+
+    if (kind === "queue") {
+      const entry = queue.find((candidate) => candidate.taskId === id);
+      return entry ? { kind: "queue", entry } : null;
+    }
+
+    if (kind === "active") {
+      const entry = active.find((candidate) => candidate.id === id);
+      return entry ? { kind: "active", entry } : null;
+    }
+
+    if (kind === "history") {
+      const entry = history.find((candidate) => candidate.id === id);
+      return entry ? { kind: "history", entry } : null;
+    }
+
+    return null;
+  }, [active, history, id, kind, queue]);
+
+  if (isLoading && !hasLoadedOnce) {
+    return (
+      <div className="executions-page">
+        <Card className="executions-empty-card">
+          <Text as="div" size="3" weight="medium">Loading run…</Text>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="executions-page">
+        <Card className="executions-empty-card">
+          <Text as="div" size="3" weight="medium">Could not load run</Text>
+          <Text as="div" tone="muted" wrap>{error}</Text>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div className="executions-page">
+        <Card className="executions-detail-card">
+          <div className="executions-detail-header">
+            <div>
+              <Text as="div" size="5" weight="bold">Run not found</Text>
+              <Text as="div" tone="muted" wrap>The run may have moved between queue, active, and history. Return to the runs list to find the latest state.</Text>
+            </div>
+            <Button variant="secondary" onClick={() => navigate('/runs')}>Back to runs</Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  const entry = detail.entry;
+  const actorId = "agentActorId" in entry ? entry.agentActorId : null;
+  const actor = actorId ? actors.find((candidate) => candidate.id === actorId) : undefined;
+  const title = entry.taskName ?? "Untitled task";
+  let status: string;
+  let tone: "accent" | "warning" | "success" | "danger";
+  let detailPanel: React.ReactNode;
+
+  if (detail.kind === "queue") {
+    status = "QUEUED";
+    tone = "accent";
+    detailPanel = (
+      <div className="executions-details-panel executions-details-panel--standalone">
+        <div className="executions-details-grid">
+          <div className="executions-details-section">
+            <Text as="div" size="1" weight="semibold" tone="muted" className="executions-details-heading">Queue</Text>
+            <div className="executions-details-rows">
+              <DetailRow label="Task status" value={entry.taskStatus ?? "Unknown"} />
+              <DetailRow label="Task ID" value={entry.taskId} mono />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  } else if (detail.kind === "active") {
+    status = "ACTIVE";
+    tone = "warning";
+    detailPanel = <ExecutionDetails execution={detail.entry} actor={actor} />;
+  } else {
+    status = detail.entry.status;
+    tone = detail.entry.status === "SUCCEEDED" ? "success" : "danger";
+    detailPanel = <ExecutionDetails execution={detail.entry} actor={actor} />;
+  }
+
+  return (
+    <div className="executions-page executions-page--detail">
+      <Card className="executions-detail-card">
+        <div className="executions-detail-header">
+          <div className="executions-detail-title-group">
+            <StatusPill tone={tone}><StatusMark status={status} /> {status}</StatusPill>
+            <Text as="div" size="5" weight="bold" wrap>{title}</Text>
+            <Text as="div" tone="muted" style="mono">{detail.kind}/{id}</Text>
+          </div>
+          <div className="executions-detail-actions">
+            <Button variant="secondary" onClick={() => navigate(`/tasks/task/${entry.taskId}`)}>Open task</Button>
+            <Button variant="secondary" onClick={() => navigate('/runs')}>Back to runs</Button>
+          </div>
+        </div>
+
+        {detailPanel}
+      </Card>
+    </div>
+  );
+}
+
+function OverviewMetric({
+  label,
+  value,
+  detail,
+  tone,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  tone: "accent" | "warning" | "success" | "danger" | "neutral";
+}) {
+  return (
+    <Card className={`executions-metric executions-metric--${tone}`}>
+      <Text as="div" size="1" tone="muted" className="executions-metric__label">{label}</Text>
+      <Text as="div" size="5" weight="bold" className="executions-metric__value">{value}</Text>
+      <Text as="div" size="2" tone="muted">{detail}</Text>
+    </Card>
   );
 }
 
@@ -444,6 +594,22 @@ function StatusPill({
   );
 }
 
+function StatusMark({ status }: { status: string }) {
+  if (status === "SUCCEEDED") {
+    return <span className="executions-status-mark executions-status-mark--success" aria-hidden="true">✓</span>;
+  }
+
+  if (status === "FAILED" || status === "CANCELLED") {
+    return <span className="executions-status-mark executions-status-mark--danger" aria-hidden="true">×</span>;
+  }
+
+  if (status === "ACTIVE") {
+    return <span className="executions-status-mark executions-status-mark--warning" aria-hidden="true">•</span>;
+  }
+
+  return <span className="executions-status-mark executions-status-mark--accent" aria-hidden="true">•</span>;
+}
+
 function StatusCellWithError({
   status,
   errorCode,
@@ -462,7 +628,7 @@ function StatusCellWithError({
 
   return (
     <div className="executions-status-with-error">
-      <StatusPill tone={tone}>{status}</StatusPill>
+      <StatusPill tone={tone}><StatusMark status={status} /> {status}</StatusPill>
       {hasError && onToggleDetails && (
         <button
           type="button"
@@ -475,6 +641,27 @@ function StatusCellWithError({
           !
         </button>
       )}
+    </div>
+  );
+}
+
+function RunLink({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="executions-details-toggle"
+      onClick={onClick}
+    >
+      <Text as="span" size="2" weight="semibold">{label}</Text>
+    </button>
+  );
+}
+
+function DurationCell({ start, end }: { start: string; end: string }) {
+  return (
+    <div className="executions-time-cell">
+      <Text as="div" size="2" weight="semibold">{formatDuration(new Date(end).getTime() - new Date(start).getTime())}</Text>
+      <Text as="div" size="1" tone="muted">{formatRelativeTime(end)}</Text>
     </div>
   );
 }

--- a/apps/ui/src/features/executions/ExecutionsRoutes.tsx
+++ b/apps/ui/src/features/executions/ExecutionsRoutes.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route } from 'react-router-dom';
-import { ExecutionsPage } from './ExecutionsPage';
+import { ExecutionDetailPage, ExecutionsPage } from './ExecutionsPage';
 import { ExecutionsLayout } from './ExecutionsLayout';
 
 export function ExecutionsRoutes() {
@@ -7,6 +7,7 @@ export function ExecutionsRoutes() {
     <Routes>
       <Route element={<ExecutionsLayout />}>
         <Route index element={<ExecutionsPage />} />
+        <Route path=":kind/:id" element={<ExecutionDetailPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- Refresh the runs overview with straight-edged metric cards and no gradient treatment.
- Add clearer queue, active, and history tables with status markers, task-focused rows, and history durations.
- Add dedicated run detail routes at `/runs/:kind/:id` for queue, active, and history entries using existing execution list APIs.

## Validation
- `npm run build:dev`
- `npm run dev:1` started successfully; terminated after the 60s validation timeout. The expected AppInitRunner prompt-block error appeared during startup.

## Technical Debt
- Detail pages resolve from the existing paginated list endpoints, so a run outside the loaded page can show the not-found fallback until a dedicated get-by-id API exists.