### PR TITLE
Add task execution unclaim flow

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -6153,6 +6153,37 @@
         ]
       }
     },
+    "/api/v1/executions/active/{executionId}/unclaim": {
+      "post": {
+        "description": "Atomically removes the execution from the active execution table and returns its task to the execution queue. Only the worker that claimed the execution may unclaim it.",
+        "operationId": "ActiveTaskExecutionController_unclaimTaskExecution",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to unclaim",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Unclaim an active task execution and return it to the queue",
+        "tags": [
+          "Executions"
+        ]
+      }
+    },
     "/api/v1/executions/active/{executionId}/session": {
       "patch": {
         "description": "Stores the runtime session identifier emitted by the agent harness so it can be propagated to execution history.",

--- a/apps/backend/src/executions/active/active-task-execution.controller.ts
+++ b/apps/backend/src/executions/active/active-task-execution.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  ForbiddenException,
   Get,
   HttpCode,
   NotFoundException,
@@ -27,6 +28,7 @@ import { TasksScopes } from '../../tasks/tasks.scopes';
 import { WorkersScopes } from '../workers.scopes';
 import {
   ActiveTaskExecutionNotFoundError,
+  ActiveTaskExecutionWorkerMismatchError,
   ExecutionStatsNotFoundError,
 } from '../errors/executions.errors';
 import { ActiveTaskExecutionService } from './active-task-execution.service';
@@ -102,6 +104,37 @@ export class ActiveTaskExecutionController {
     } catch (error) {
       if (error instanceof ActiveTaskExecutionNotFoundError) {
         throw new NotFoundException(error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  @Post(':executionId/unclaim')
+  @HttpCode(204)
+  @RequireScopes(WorkersScopes.CONNECT.id)
+  @ApiOperation({
+    summary: 'Unclaim an active task execution and return it to the queue',
+    description:
+      'Atomically removes the execution from the active execution table and returns its task to the execution queue. Only the worker that claimed the execution may unclaim it.',
+  })
+  @ApiParam({ name: 'executionId', description: 'Execution ID to unclaim' })
+  async unclaimTaskExecution(
+    @Param('executionId') executionId: string,
+    @CurrentAuth() auth: AuthContext,
+  ): Promise<void> {
+    try {
+      await this.activeTaskExecutionService.unclaimTask({
+        executionId,
+        workerClientId: auth.claims.client_id,
+      });
+    } catch (error) {
+      if (error instanceof ActiveTaskExecutionNotFoundError) {
+        throw new NotFoundException(error.message);
+      }
+
+      if (error instanceof ActiveTaskExecutionWorkerMismatchError) {
+        throw new ForbiddenException(error.message);
       }
 
       throw error;

--- a/apps/backend/src/executions/active/active-task-execution.service.ts
+++ b/apps/backend/src/executions/active/active-task-execution.service.ts
@@ -17,6 +17,7 @@ import {
 } from '../../tasks/errors/tasks.errors';
 import {
   ActiveTaskExecutionNotFoundError,
+  ActiveTaskExecutionWorkerMismatchError,
   ExecutionStatsNotFoundError,
   TaskAlreadyClaimedError,
   TaskExecutionQueueEntryNotFoundError,
@@ -36,6 +37,11 @@ export type StopTaskExecutionInput = {
   status: TaskExecutionHistoryStatus;
   errorCode?: TaskExecutionHistoryErrorCode | null;
   errorMessage?: string | null;
+};
+
+export type UnclaimTaskExecutionInput = {
+  executionId: string;
+  workerClientId: string;
 };
 
 export type UpdateRunnerSessionIdInput = {
@@ -257,6 +263,44 @@ export class ActiveTaskExecutionService {
     });
 
     return historyEntry;
+  }
+
+  async unclaimTask(input: UnclaimTaskExecutionInput): Promise<void> {
+    const execution = await this.dataSource.transaction(async (manager) => {
+      const activeExecution = await manager.findOne(ActiveTaskExecutionEntity, {
+        where: { id: input.executionId },
+      });
+
+      if (!activeExecution) {
+        throw new ActiveTaskExecutionNotFoundError(input.executionId);
+      }
+
+      if (activeExecution.workerClientId !== input.workerClientId) {
+        throw new ActiveTaskExecutionWorkerMismatchError(input.executionId);
+      }
+
+      await manager.delete(ExecutionStatsEntity, {
+        executionId: activeExecution.id,
+      });
+      await manager.delete(ActiveTaskExecutionEntity, {
+        id: activeExecution.id,
+      });
+      await manager.upsert(
+        TaskExecutionQueueEntity,
+        { taskId: activeExecution.taskId },
+        ['taskId'],
+      );
+
+      return activeExecution;
+    });
+
+    this.executionActivityService.publishSystemActivity({
+      executionId: execution.id,
+      taskId: execution.taskId,
+      agentActorId: execution.agentActorId,
+      kind: 'execution.unclaimed',
+      message: 'Execution unclaimed and returned to queue',
+    });
   }
 
   async updateRunnerSessionId(input: UpdateRunnerSessionIdInput): Promise<void> {

--- a/apps/backend/src/executions/errors/executions.errors.ts
+++ b/apps/backend/src/executions/errors/executions.errors.ts
@@ -23,6 +23,12 @@ export class ActiveTaskExecutionNotFoundError extends ExecutionsError {
   }
 }
 
+export class ActiveTaskExecutionWorkerMismatchError extends ExecutionsError {
+  constructor(executionId: string) {
+    super('Active execution is claimed by a different worker.', { executionId });
+  }
+}
+
 export class ExecutionStatsNotFoundError extends ExecutionsError {
   constructor(executionId: string) {
     super('Execution stats were not found.', { executionId });

--- a/apps/worker/src/task-claim-deferral.ts
+++ b/apps/worker/src/task-claim-deferral.ts
@@ -1,0 +1,42 @@
+const DEFAULT_UNCLAIM_GRACE_PERIOD_MS = 3 * 60 * 1000;
+const UNCLAIM_GRACE_PERIOD_MS = readDurationMs(
+  process.env.WORKER_UNCLAIM_GRACE_PERIOD_MS,
+  DEFAULT_UNCLAIM_GRACE_PERIOD_MS,
+);
+const deferredTaskClaims = new Map<string, number>();
+
+export function deferTaskClaimAfterUnclaim(taskId: string): void {
+  const until = Date.now() + UNCLAIM_GRACE_PERIOD_MS;
+  deferredTaskClaims.set(taskId, until);
+
+  console.log(
+    `[worker] Deferring claims for task ${taskId} for ${Math.round(UNCLAIM_GRACE_PERIOD_MS / 1000)}s after unclaim.`,
+  );
+}
+
+export function isTaskClaimDeferred(taskId: string): boolean {
+  const deferredUntil = deferredTaskClaims.get(taskId);
+  if (!deferredUntil) {
+    return false;
+  }
+
+  if (deferredUntil <= Date.now()) {
+    deferredTaskClaims.delete(taskId);
+    return false;
+  }
+
+  return true;
+}
+
+function readDurationMs(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  return parsed;
+}

--- a/apps/worker/src/task-claim-worker.ts
+++ b/apps/worker/src/task-claim-worker.ts
@@ -2,6 +2,7 @@ import { setTimeout as sleep } from 'timers/promises';
 import { ApiClient } from '@taico/client/v2';
 import { pickTask } from './task-picker.js';
 import { ExecutionActivityGatewayClient } from './execution-activity-gateway-client.js';
+import { isTaskClaimDeferred } from './task-claim-deferral.js';
 
 const QUEUE_POLL_INTERVAL_MS = 60_000;
 
@@ -41,6 +42,11 @@ export async function attemptClaimTask(
 ): Promise<void> {
   console.log(`[worker] Received queue notification for task ${taskId}, attempting to claim...`);
 
+  if (isTaskClaimDeferred(taskId)) {
+    console.log(`[worker] Skipping task ${taskId}; recently unclaimed by this worker.`);
+    return;
+  }
+
   try {
     await pickTask({
       client,
@@ -61,10 +67,12 @@ async function processNextQueuedTask(
   baseUrl: string,
   activityGatewayClient: ExecutionActivityGatewayClient,
 ): Promise<void> {
-  const queueResponse = await client.executions.TaskExecutionQueueController_listQueue({ limit: 1 });
+  const queueResponse = await client.executions.TaskExecutionQueueController_listQueue({ limit: 25 });
   console.log(`[worker] Queue poll succeeded. ${queueResponse.total} task(s) ready.`);
 
-  const nextTask = queueResponse.items[0];
+  const nextTask = queueResponse.items.find(
+    (item) => !isTaskClaimDeferred(item.taskId),
+  );
   if (!nextTask) {
     return;
   }

--- a/apps/worker/src/task-picker.ts
+++ b/apps/worker/src/task-picker.ts
@@ -1,7 +1,11 @@
 import { ApiClient } from '@taico/client/v2';
 import { executeTask } from './task-runner.js';
 import { ExecutionActivityGatewayClient } from './execution-activity-gateway-client.js';
-import { TaskExecutionError } from './task-execution-errors.js';
+import {
+  TaskExecutionError,
+  UnsupportedAgentTypeError,
+} from './task-execution-errors.js';
+import { deferTaskClaimAfterUnclaim } from './task-claim-deferral.js';
 
 type PickTaskParams = {
   client: ApiClient;
@@ -34,6 +38,7 @@ export async function pickTask({
   let stopErrorMessage: string | undefined;
   let shouldRethrow = false;
   let taskError: unknown;
+  let shouldUnclaim = false;
 
   try {
     await executeTask({
@@ -45,7 +50,10 @@ export async function pickTask({
       activityGatewayClient,
     });
   } catch (error) {
-    if (error instanceof TaskExecutionError) {
+    if (error instanceof UnsupportedAgentTypeError) {
+      shouldUnclaim = true;
+      stopErrorMessage = error.displayMessage;
+    } else if (error instanceof TaskExecutionError) {
       if (error.kind === 'interrupted') {
         stopStatus = 'CANCELLED';
         stopErrorCode = 'INTERRUPTED';
@@ -69,19 +77,30 @@ export async function pickTask({
     }
     taskError = error;
   } finally {
-    const historyEntry =
-      await client.executions.ActiveTaskExecutionController_stopTaskExecution({
+    if (shouldUnclaim) {
+      await client.executions.ActiveTaskExecutionController_unclaimTaskExecution({
         executionId: execution.id,
-        body: {
-          status: stopStatus,
-          errorCode: stopErrorCode,
-          errorMessage: stopErrorMessage,
-        },
       });
+      deferTaskClaimAfterUnclaim(execution.taskId);
 
-    console.log(
-      `[worker] Stopped execution ${execution.id} with status ${historyEntry.status}.`,
-    );
+      console.log(
+        `[worker] Unclaimed execution ${execution.id} for task ${execution.taskId}: ${stopErrorMessage}`,
+      );
+    } else {
+      const historyEntry =
+        await client.executions.ActiveTaskExecutionController_stopTaskExecution({
+          executionId: execution.id,
+          body: {
+            status: stopStatus,
+            errorCode: stopErrorCode,
+            errorMessage: stopErrorMessage,
+          },
+        });
+
+      console.log(
+        `[worker] Stopped execution ${execution.id} with status ${historyEntry.status}.`,
+      );
+    }
   }
 
   if (shouldRethrow) {

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -6153,6 +6153,37 @@
         ]
       }
     },
+    "/api/v1/executions/active/{executionId}/unclaim": {
+      "post": {
+        "description": "Atomically removes the execution from the active execution table and returns its task to the execution queue. Only the worker that claimed the execution may unclaim it.",
+        "operationId": "ActiveTaskExecutionController_unclaimTaskExecution",
+        "parameters": [
+          {
+            "name": "executionId",
+            "required": true,
+            "in": "path",
+            "description": "Execution ID to unclaim",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Unclaim an active task execution and return it to the queue",
+        "tags": [
+          "Executions"
+        ]
+      }
+    },
     "/api/v1/executions/active/{executionId}/session": {
       "patch": {
         "description": "Stores the runtime session identifier emitted by the agent harness so it can be propagated to execution history.",

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -1760,6 +1760,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/executions/active/{executionId}/unclaim": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unclaim an active task execution and return it to the queue
+         * @description Atomically removes the execution from the active execution table and returns its task to the execution queue. Only the worker that claimed the execution may unclaim it.
+         */
+        post: operations["ActiveTaskExecutionController_unclaimTaskExecution"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/executions/active/{executionId}/session": {
         parameters: {
             query?: never;
@@ -10222,6 +10242,26 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["TaskExecutionHistoryResponseDto"];
                 };
+            };
+        };
+    };
+    ActiveTaskExecutionController_unclaimTaskExecution: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Execution ID to unclaim */
+                executionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/client/src/v1/client/services/ExecutionsService.ts
+++ b/packages/client/src/v1/client/services/ExecutionsService.ts
@@ -105,6 +105,25 @@ export class ExecutionsService {
         });
     }
     /**
+     * Unclaim an active task execution and return it to the queue
+     * Atomically removes the execution from the active execution table and returns its task to the execution queue. Only the worker that claimed the execution may unclaim it.
+     * @param executionId Execution ID to unclaim
+     * @returns void
+     * @throws ApiError
+     */
+    public static activeTaskExecutionControllerUnclaimTaskExecution(
+        executionId: string,
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<void> {
+        return __request(config, {
+            method: 'POST',
+            url: '/api/v1/executions/active/{executionId}/unclaim',
+            path: {
+                'executionId': executionId,
+            },
+        });
+    }
+    /**
      * Attach the runner session id to an active execution
      * Stores the runtime session identifier emitted by the agent harness so it can be propagated to execution history.
      * @param executionId Execution ID to update

--- a/packages/client/src/v2/executions-resource.ts
+++ b/packages/client/src/v2/executions-resource.ts
@@ -26,6 +26,11 @@ export class ExecutionsResource extends BaseClient {
     return this.request('POST', `/api/v1/executions/active/${params.executionId}/stop`, { body: params.body, signal: params?.signal });
   }
 
+  /** Unclaim an active task execution and return it to the queue */
+  async ActiveTaskExecutionController_unclaimTaskExecution(params: { executionId: string; signal?: AbortSignal }): Promise<void> {
+    return this.request('POST', `/api/v1/executions/active/${params.executionId}/unclaim`, { responseType: 'void', signal: params?.signal });
+  }
+
   /** Attach the runner session id to an active execution */
   async ActiveTaskExecutionController_updateRunnerSessionId(params: { executionId: string; body: UpdateRunnerSessionIdDto; signal?: AbortSignal }): Promise<void> {
     return this.request('PATCH', `/api/v1/executions/active/${params.executionId}/session`, { body: params.body, responseType: 'void', signal: params?.signal });


### PR DESCRIPTION
## Summary
- Add a worker-only unclaim endpoint that validates the claiming worker before returning an active execution to the queue.
- Regenerate API clients/OpenAPI contracts for the new endpoint.
- Update the worker to unclaim unsupported agent types and locally defer reclaiming the task for a configurable grace period.

## Validation
- npm run build:dev
- npm run dev:1 (startup validated; command stopped after timeout)

## Technical Debt
- No new focused unit tests were added for the active execution transaction path; coverage currently relies on build/startup validation.