### PR TITLE
Refine runs view

### DIFF
--- a/apps/ui/src/features/executions/ExecutionsPage.css
+++ b/apps/ui/src/features/executions/ExecutionsPage.css
@@ -4,6 +4,13 @@
   gap: var(--space-4);
 }
 
+.executions-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4);
+  align-items: center;
+}
+
 .executions-worker-status {
   display: inline-flex;
   align-items: center;
@@ -35,591 +42,178 @@
   border-radius: var(--r-1);
 }
 
-.executions-hero {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--space-4);
-  align-items: flex-start;
-}
-
-.executions-hero__copy {
-  display: grid;
-  gap: var(--space-2);
-}
-
-.executions-hero__actions {
-  display: flex;
-  gap: var(--space-3);
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.executions-pill {
-  display: inline-flex;
-  align-items: center;
-  min-height: 36px;
-  padding: 0 var(--space-3);
-  border-radius: 0;
-  border: 1px solid var(--border);
-  background: var(--card-bg);
-  color: var(--text);
-  font-size: var(--fs-1);
-  font-weight: var(--fw-semibold);
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.executions-pill--success {
-  color: var(--success);
-  border-color: color-mix(in srgb, var(--success) 25%, var(--border));
-  background: color-mix(in srgb, var(--success) 8%, var(--card-bg));
-}
-
-.executions-pill--danger {
-  color: var(--danger);
-  border-color: color-mix(in srgb, var(--danger) 25%, var(--border));
-  background: color-mix(in srgb, var(--danger) 8%, var(--card-bg));
-}
-
 .executions-empty-card {
   border-radius: 0;
 }
 
-.executions-overview {
+.executions-feed {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--space-3);
-}
-
-.executions-metric {
-  display: grid;
-  gap: var(--space-1);
-  border-radius: 0;
-  border-left: 4px solid var(--border);
-}
-
-.executions-metric--accent {
-  border-left-color: var(--accent);
-}
-
-.executions-metric--warning {
-  border-left-color: var(--warning);
-}
-
-.executions-metric--success {
-  border-left-color: var(--success);
-}
-
-.executions-metric--danger {
-  border-left-color: var(--danger);
-}
-
-.executions-metric__label {
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.executions-metric__value {
-  line-height: 1;
-}
-
-.executions-sections {
-  display: grid;
-  gap: var(--space-4);
-}
-
-.executions-section-card {
-  border-radius: 0;
-  overflow: hidden;
-}
-
-.executions-section-card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: var(--space-4);
-  padding: var(--space-4);
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--card-bg);
-}
-
-.executions-count-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 40px;
-  height: 32px;
-  padding: 0 var(--space-2);
-  border-radius: 0;
-  background: var(--surface);
   border: 1px solid var(--border);
-  color: var(--text);
-  font-size: var(--fs-2);
-  font-weight: var(--fw-semibold);
-}
-
-.executions-section-card__empty {
-  padding: var(--space-5) var(--space-4);
-}
-
-.executions-table-wrap {
-  overflow-x: auto;
-}
-
-.executions-table {
-  width: 100%;
-  border-collapse: collapse;
   background: var(--card-bg);
 }
 
-.executions-table thead {
-  background: color-mix(in srgb, var(--surface) 65%, var(--card-bg));
-}
-
-.executions-table th {
+.executions-feed-row {
+  display: grid;
+  grid-template-columns: 34px minmax(220px, 1fr) minmax(180px, 260px) minmax(130px, 180px) auto;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
   padding: var(--space-3) var(--space-4);
-  text-align: left;
-  font-size: var(--fs-1);
-  font-weight: var(--fw-semibold);
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  white-space: nowrap;
-}
-
-.executions-table td {
-  padding: var(--space-3) var(--space-4);
+  border: 0;
   border-top: 1px solid var(--border-subtle);
-  vertical-align: top;
+  background: var(--card-bg);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
 }
 
-.executions-table tbody tr:hover {
+.executions-feed-row:first-child {
+  border-top: 0;
+}
+
+.executions-feed-row:hover {
   background: color-mix(in srgb, var(--surface) 45%, var(--card-bg));
 }
 
-.executions-table-detail-row:hover {
+.executions-feed-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.executions-feed-row__main,
+.executions-feed-row__meta,
+.executions-feed-row__stats {
+  display: grid;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.executions-feed-row__meta,
+.executions-feed-row__stats {
+  justify-items: start;
+}
+
+.executions-feed-row__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.executions-run-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  font-size: var(--fs-2);
+  font-weight: var(--fw-bold);
+  line-height: 1;
+}
+
+.executions-run-icon--queued {
+  border: 2px solid var(--text-muted);
   background: transparent;
 }
 
-.executions-table-detail-row td {
-  padding-top: 0;
+.executions-run-icon--active {
+  border: 2px solid color-mix(in srgb, var(--warning) 35%, var(--border));
+  border-top-color: var(--warning);
+  animation: executions-spin 0.9s linear infinite;
 }
 
-.executions-status-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 26px;
-  padding: 0 var(--space-2);
-  border-radius: 0;
-  font-size: var(--fs-1);
-  font-weight: var(--fw-semibold);
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  border: 1px solid transparent;
-  gap: var(--space-1);
+.executions-run-icon--success {
+  background: var(--success);
+  color: var(--text-inverse);
 }
 
-.executions-status-mark {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 14px;
-  height: 14px;
-  line-height: 1;
-  font-size: var(--fs-1);
-  font-weight: var(--fw-bold);
-}
-
-.executions-status-pill--accent {
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 10%, var(--card-bg));
-  border-color: color-mix(in srgb, var(--accent) 20%, var(--border));
-}
-
-.executions-status-pill--warning {
-  color: var(--warning);
-  background: color-mix(in srgb, var(--warning) 10%, var(--card-bg));
-  border-color: color-mix(in srgb, var(--warning) 20%, var(--border));
-}
-
-.executions-status-pill--success {
-  color: var(--success);
-  background: color-mix(in srgb, var(--success) 10%, var(--card-bg));
-  border-color: color-mix(in srgb, var(--success) 20%, var(--border));
-}
-
-.executions-status-pill--danger {
-  color: var(--danger);
-  background: color-mix(in srgb, var(--danger) 10%, var(--card-bg));
-  border-color: color-mix(in srgb, var(--danger) 20%, var(--border));
-}
-
-.executions-status-pill--neutral {
-  color: var(--text-muted);
-  background: var(--surface);
-  border-color: var(--border);
-}
-
-.executions-task-cell,
-.executions-time-cell {
-  display: grid;
-  gap: var(--space-1);
-}
-
-.executions-actor-cell {
-  display: grid;
-  gap: var(--space-1);
-}
-
-.executions-actor-slug {
-  color: var(--text-muted);
-}
-
-.executions-task-cell--clickable {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-  font: inherit;
-  color: inherit;
-}
-
-.executions-task-cell--clickable:hover {
-  color: var(--accent);
-  text-decoration: underline;
-}
-
-.executions-task-cell--clickable:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-  border-radius: var(--r-2);
-}
-
-.executions-code-copy {
-  color: var(--text-muted);
-}
-
-.executions-muted-copy {
-  color: var(--text-muted);
-  font-size: var(--fs-2);
+.executions-run-icon--danger {
+  background: var(--danger);
+  color: var(--text-inverse);
 }
 
 .executions-error-copy {
   color: var(--danger);
-  font-size: var(--fs-2);
-}
-
-.executions-error-cell {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.executions-error-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border: 1px solid color-mix(in srgb, var(--danger) 25%, var(--border));
-  border-radius: 0;
-  background: color-mix(in srgb, var(--danger) 10%, var(--card-bg));
-  color: var(--danger);
-  font-size: var(--fs-1);
-  font-weight: var(--fw-bold);
-  cursor: pointer;
-}
-
-.executions-error-toggle:hover {
-  background: color-mix(in srgb, var(--danger) 16%, var(--card-bg));
-}
-
-.executions-error-toggle:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--danger) 45%, transparent);
-  outline-offset: 2px;
-}
-
-.executions-error-detail {
-  display: grid;
-  gap: var(--space-2);
-  padding: var(--space-3);
-  border-radius: 0;
-  background: color-mix(in srgb, var(--danger) 5%, var(--surface));
-  border: 1px solid color-mix(in srgb, var(--danger) 12%, var(--border-subtle));
-}
-
-.executions-error-detail__label {
-  color: var(--danger);
-}
-
-.executions-mobile-list {
-  display: none;
-}
-
-.executions-mobile-card {
-  display: grid;
-  gap: var(--space-3);
-  padding: var(--space-4);
-  border-top: 1px solid var(--border-subtle);
-  border-left: 4px solid transparent;
-}
-
-.executions-mobile-card--clickable {
-  background: none;
-  border: none;
-  border-top: 1px solid var(--border-subtle);
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-  font: inherit;
-  color: inherit;
-  transition: background-color 0.15s ease;
-}
-
-.executions-mobile-card--clickable:hover {
-  background: color-mix(in srgb, var(--surface) 45%, var(--card-bg));
-}
-
-.executions-mobile-card--clickable:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-  background: color-mix(in srgb, var(--surface) 35%, var(--card-bg));
-}
-
-.executions-mobile-card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: var(--space-3);
-}
-
-.executions-mobile-card__header--clickable {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-  font: inherit;
-  color: inherit;
-  transition: color 0.15s ease;
-}
-
-.executions-mobile-card__header--clickable:hover {
-  color: var(--accent);
-}
-
-.executions-mobile-card__header--clickable:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-  border-radius: var(--r-2);
-}
-
-.executions-mobile-card__body {
-  display: grid;
-  gap: var(--space-2);
-}
-
-.executions-mobile-card__row {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: var(--space-3);
-}
-
-.executions-mobile-card__actions {
-  display: flex;
-  gap: var(--space-2);
-  padding-top: var(--space-2);
-  border-top: 1px solid var(--border-subtle);
-}
-
-.executions-task-cell-with-status {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-}
-
-.executions-task-cell-with-status.executions-task-cell--clickable {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-  font: inherit;
-  color: inherit;
-}
-
-.executions-task-cell-with-status.executions-task-cell--clickable:hover {
-  color: var(--accent);
-  text-decoration: underline;
-}
-
-.executions-task-cell-with-status.executions-task-cell--clickable:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-  border-radius: var(--r-2);
-}
-
-.executions-status-with-error {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.executions-error-indicator {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border: 1px solid color-mix(in srgb, var(--danger) 25%, var(--border));
-  border-radius: 0;
-  background: color-mix(in srgb, var(--danger) 10%, var(--card-bg));
-  color: var(--danger);
-  font-size: var(--fs-1);
-  font-weight: var(--fw-bold);
-  cursor: pointer;
-  padding: 0;
-  font-family: inherit;
-}
-
-.executions-error-indicator:hover {
-  background: color-mix(in srgb, var(--danger) 16%, var(--card-bg));
-}
-
-.executions-error-indicator:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--danger) 45%, transparent);
-  outline-offset: 2px;
-}
-
-.executions-details-toggle {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  font: inherit;
-  color: var(--accent);
-}
-
-.executions-details-toggle:hover {
-  text-decoration: underline;
-}
-
-.executions-details-toggle:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-  border-radius: var(--r-2);
-}
-
-.executions-details-panel {
-  padding: var(--space-4);
-  background: color-mix(in srgb, var(--surface) 25%, var(--card-bg));
-  border-radius: 0;
-  border: 1px solid var(--border-subtle);
-}
-
-.executions-details-panel--standalone {
-  margin-top: var(--space-4);
-}
-
-.executions-details-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: var(--space-4);
-}
-
-.executions-details-section {
-  display: grid;
-  gap: var(--space-2);
-}
-
-.executions-details-section--full {
-  grid-column: 1 / -1;
-}
-
-.executions-details-heading {
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  padding-bottom: var(--space-1);
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.executions-details-rows {
-  display: grid;
-  gap: var(--space-2);
-}
-
-.executions-detail-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: var(--space-3);
-}
-
-.executions-mobile-card__title-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  flex: 1;
-}
-
-.executions-mobile-details-toggle {
-  background: none;
-  border: none;
-  padding: var(--space-2) 0;
-  cursor: pointer;
-  font: inherit;
-  text-align: left;
-  width: 100%;
-  border-top: 1px solid var(--border-subtle);
-  color: var(--accent);
-}
-
-.executions-mobile-details-toggle:hover {
-  text-decoration: underline;
-}
-
-.executions-mobile-details-toggle:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-  border-radius: var(--r-2);
 }
 
 .executions-page--detail {
   max-width: 1120px;
 }
 
-.executions-detail-card {
-  border-radius: 0;
+.executions-detail-topbar {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
 }
 
-.executions-detail-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-4);
-}
-
-.executions-detail-title-group,
-.executions-detail-actions {
-  display: flex;
-  flex-direction: column;
+.executions-run-header {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
   gap: var(--space-3);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--border);
 }
 
-.executions-detail-actions {
-  align-items: flex-end;
+.executions-run-header__copy {
+  display: grid;
+  gap: var(--space-1);
+  min-width: 0;
 }
 
-@media (max-width: 980px) {
-  .executions-overview {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+.executions-run-status-label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.executions-detail-section {
+  display: grid;
+  gap: var(--space-3);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.executions-detail-section--danger {
+  border-color: color-mix(in srgb, var(--danger) 30%, var(--border-subtle));
+}
+
+.executions-detail-section__title {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.executions-detail-list {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.executions-detail-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+@keyframes executions-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 820px) {
+  .executions-feed-row {
+    grid-template-columns: 30px minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .executions-feed-row__meta,
+  .executions-feed-row__stats,
+  .executions-feed-row__actions {
+    grid-column: 2;
+  }
+
+  .executions-feed-row__actions {
+    justify-content: flex-start;
   }
 }
 
@@ -629,28 +223,29 @@
   }
 
   .executions-hero,
-  .executions-section-card__header {
+  .executions-detail-topbar {
+    align-items: flex-start;
     flex-direction: column;
   }
 
-  .executions-overview {
-    grid-template-columns: 1fr;
-  }
-
-  .executions-detail-header {
-    flex-direction: column;
-  }
-
-  .executions-detail-actions {
+  .executions-detail-topbar {
     width: 100%;
-    align-items: stretch;
   }
 
-  .executions-table-wrap {
-    display: none;
+  .executions-detail-topbar > * {
+    width: 100%;
   }
 
-  .executions-mobile-list {
-    display: block;
+  .executions-run-header {
+    grid-template-columns: 30px minmax(0, 1fr);
+  }
+
+  .executions-run-status-label {
+    grid-column: 2;
+  }
+
+  .executions-detail-row {
+    grid-template-columns: 1fr;
+    gap: var(--space-1);
   }
 }

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -1,17 +1,17 @@
-import { Fragment, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
 import { Button, Card, Text } from "../../ui/primitives";
 import { useActorsCtx } from "../actors";
-import { useExecutions } from "./useExecutions";
-import { ExecutionsService } from "./api";
-import { useToast } from "../../shared/context/ToastContext";
 import { useWorkers } from "../workers/useWorkers";
+import { ExecutionsService } from "./api";
 import type {
-  TaskExecutionQueueEntryResponseDto,
   ActiveTaskExecutionResponseDto,
   TaskExecutionHistoryResponseDto,
+  TaskExecutionQueueEntryResponseDto,
 } from "./types";
+import { useToast } from "../../shared/context/ToastContext";
+import { useExecutions } from "./useExecutions";
 import "./ExecutionsPage.css";
 
 type ExecutionDetailResult =
@@ -19,65 +19,34 @@ type ExecutionDetailResult =
   | { kind: "active"; entry: ActiveTaskExecutionResponseDto }
   | { kind: "history"; entry: TaskExecutionHistoryResponseDto };
 
+type RunFeedEntry =
+  | { kind: "queue"; entry: TaskExecutionQueueEntryResponseDto }
+  | { kind: "active"; entry: ActiveTaskExecutionResponseDto }
+  | { kind: "history"; entry: TaskExecutionHistoryResponseDto };
+
+type ActorSummary = { id: string; displayName?: string; slug?: string };
+
 export function ExecutionsPage() {
   const navigate = useNavigate();
   const { actors } = useActorsCtx();
   const { showToast, showError } = useToast();
-  const {
-    queue,
-    active,
-    history,
-    isLoading,
-    hasLoadedOnce,
-    error,
-    loadExecutions,
-  } = useExecutions();
+  const { queue, active, history, isLoading, hasLoadedOnce, error, loadExecutions } = useExecutions();
   const { workers } = useWorkers();
+  const [interruptingExecutions, setInterruptingExecutions] = useState<Set<string>>(() => new Set());
 
   useDocumentTitle();
 
-  // Calculate connected workers (seen in last 2 minutes)
   const connectedWorkersCount = useMemo(() => {
-    const now = new Date();
+    const now = Date.now();
     const twoMinutesMs = 2 * 60 * 1000;
-    return workers.filter((worker) => {
-      const lastSeen = new Date(worker.lastSeenAt);
-      const diffMs = now.getTime() - lastSeen.getTime();
-      return diffMs <= twoMinutesMs;
-    }).length;
+    return workers.filter((worker) => now - new Date(worker.lastSeenAt).getTime() <= twoMinutesMs).length;
   }, [workers]);
 
-  const [expandedHistoryIds, setExpandedHistoryIds] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const [interruptingExecutions, setInterruptingExecutions] = useState<Set<string>>(
-    () => new Set(),
-  );
-
-  const failedHistory = useMemo(
-    () => history.filter((entry) => entry.status !== "SUCCEEDED"),
-    [history],
-  );
-  const successRate = useMemo(() => {
-    if (history.length === 0) {
-      return "-";
-    }
-
-    const succeeded = history.filter((entry) => entry.status === "SUCCEEDED").length;
-    return `${Math.round((succeeded / history.length) * 100)}%`;
-  }, [history]);
-
-  const toggleHistoryMessage = (historyId: string) => {
-    setExpandedHistoryIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(historyId)) {
-        next.delete(historyId);
-      } else {
-        next.add(historyId);
-      }
-      return next;
-    });
-  };
+  const feedEntries = useMemo<RunFeedEntry[]>(() => [
+    ...queue.map((entry) => ({ kind: "queue" as const, entry })),
+    ...active.map((entry) => ({ kind: "active" as const, entry })),
+    ...history.map((entry) => ({ kind: "history" as const, entry })),
+  ], [active, history, queue]);
 
   const handleInterruptExecution = async (executionId: string, taskName: string | null) => {
     if (!confirm(`Are you sure you want to interrupt the execution for "${taskName ?? "Untitled task"}"?`)) {
@@ -89,7 +58,6 @@ export function ExecutionsPage() {
     try {
       await ExecutionsService.ActiveTaskExecutionController_interruptExecution({ executionId });
       showToast(`Interrupt signal sent for "${taskName ?? "Untitled task"}"`);
-      // Refresh executions to show updated state
       await loadExecutions();
     } catch (err) {
       showError(err);
@@ -105,52 +73,34 @@ export function ExecutionsPage() {
   return (
     <div className="executions-page">
       <div className="executions-hero">
-        <div className="executions-hero__copy">
-          <div className="executions-worker-status">
-            <span
-              className="executions-worker-status__indicator"
-              style={{ color: connectedWorkersCount > 0 ? 'var(--success)' : 'var(--danger)' }}
-              aria-label={connectedWorkersCount > 0 ? 'Workers connected' : 'No workers connected'}
+        <div className="executions-worker-status">
+          <span
+            className="executions-worker-status__indicator"
+            style={{ color: connectedWorkersCount > 0 ? "var(--success)" : "var(--danger)" }}
+            aria-label={connectedWorkersCount > 0 ? "Workers connected" : "No workers connected"}
+          >
+            ●
+          </span>
+          <Text as="span" size="2" tone="muted">
+            {connectedWorkersCount > 0
+              ? `${connectedWorkersCount} worker${connectedWorkersCount !== 1 ? "s" : ""} connected`
+              : "no worker connected"}
+            {" · "}
+            <button
+              type="button"
+              className="executions-worker-status__link"
+              onClick={() => navigate("/settings/workers")}
             >
-              ●
-            </span>
-            <Text as="span" size="2" tone="muted">
-              {connectedWorkersCount > 0
-                ? `${connectedWorkersCount} worker${connectedWorkersCount !== 1 ? 's' : ''} connected`
-                : 'no worker connected'}
-              {' · '}
-              <button
-                type="button"
-                className="executions-worker-status__link"
-                onClick={() => navigate('/settings/workers')}
-              >
-                configure
-              </button>
-            </Text>
-          </div>
+              configure
+            </button>
+          </Text>
         </div>
-        {error ? (
-          <div className="executions-hero__actions">
-            <span className="executions-pill executions-pill--danger">
-              Fetch failed
-            </span>
-          </div>
-        ) : null}
+        {error ? <span className="executions-error-copy">Fetch failed</span> : null}
       </div>
-
-      {hasLoadedOnce && !error ? (
-        <div className="executions-overview" aria-label="Runs overview">
-          <OverviewMetric label="Queued" value={String(queue.length)} detail="waiting for a worker" tone="accent" />
-          <OverviewMetric label="Active" value={String(active.length)} detail="currently executing" tone="warning" />
-          <OverviewMetric label="Failed" value={String(failedHistory.length)} detail="recent failed or cancelled runs" tone={failedHistory.length > 0 ? "danger" : "neutral"} />
-          <OverviewMetric label="Success rate" value={successRate} detail="across loaded history" tone="success" />
-        </div>
-      ) : null}
-
 
       {isLoading && !hasLoadedOnce ? (
         <Card className="executions-empty-card">
-          <Text as="div" size="3" weight="medium">Loading executions…</Text>
+          <Text as="div" size="3" weight="medium">Loading executions...</Text>
         </Card>
       ) : null}
 
@@ -162,197 +112,34 @@ export function ExecutionsPage() {
       ) : null}
 
       {hasLoadedOnce && !error ? (
-        <div className="executions-sections">
-          <ExecutionSection
-            title="Queue"
-            subtitle="Runs waiting to be claimed"
-            count={queue.length}
-            emptyMessage="Nothing is waiting in the queue."
-            table={
-              <ExecutionTable
-                columns={["State", "Task", "Task status", "Task ID", "Run"]}
-                rows={queue.map((entry) => ({
-                  key: entry.taskId,
-                  cells: [
-                    <StatusPill key="state" tone="accent">Queued</StatusPill>,
-                    <TaskCell key="task" taskId={entry.taskId} taskName={entry.taskName} onClick={() => navigate(`/tasks/task/${entry.taskId}`)} />,
-                    <StatusPill key="status" tone={taskStatusTone(entry.taskStatus)}>
-                      {entry.taskStatus ?? "Unknown"}
-                    </StatusPill>,
-                    <CodeCell key="id" value={entry.taskId} />,
-                    <RunLink key="run" label="Open run" onClick={() => navigate(`/runs/queue/${entry.taskId}`)} />,
-                  ],
-                  mobile: (
-                    <ExecutionMobileCard
-                      key={`queue-mobile-${entry.taskId}`}
-                      tone="accent"
-                      title={entry.taskName ?? "Untitled task"}
-                      badge="Queued"
-                      lines={[
-                        { label: "Task status", value: entry.taskStatus ?? "Unknown" },
-                        { label: "Task ID", value: shortId(entry.taskId), mono: true },
-                      ]}
-                      onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
-                    />
-                  ),
-                }))}
-              />
-            }
-          />
+        feedEntries.length > 0 ? (
+          <div className="executions-feed" aria-label="Execution runs">
+            {feedEntries.map((feedEntry) => {
+              const key = getRunKey(feedEntry);
+              const runPath = getRunPath(feedEntry);
+              const actor = getActorForRun(feedEntry, actors);
+              const isInterrupting = feedEntry.kind === "active" && interruptingExecutions.has(feedEntry.entry.id);
 
-          <ExecutionSection
-            title="Active"
-            subtitle="Live agent work with heartbeat and worker details"
-            count={active.length}
-            emptyMessage="No active executions right now."
-            table={
-              <ExecutionTable
-                columns={["Status", "Task", "Agent", "Heartbeat", "Run", "Actions"]}
-                rows={active.map((entry) => {
-                  const actor = actors.find((candidate) => candidate.id === entry.agentActorId);
-                  const isInterrupting = interruptingExecutions.has(entry.id);
-
-                  return {
-                    key: entry.id,
-                    expandedContent: expandedHistoryIds.has(entry.id) ? (
-                      <ExecutionDetails
-                        execution={entry}
-                        actor={actor}
-                      />
-                    ) : null,
-                    cells: [
-                    <StatusPill key="state" tone="warning"><StatusMark status="ACTIVE" /> Active</StatusPill>,
-                    <TaskCellWithStatus
-                      key="task"
-                      taskId={entry.taskId}
-                      taskName={entry.taskName}
-                      taskStatus={entry.taskStatus}
-                      onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
-                    />,
-                    <ActorCell
-                      key="agent"
-                      actorId={entry.agentActorId}
-                      actorName={actor?.displayName}
-                      actorSlug={actor?.slug}
-                    />,
-                    <TimeCell key="heartbeat" value={entry.lastHeartbeatAt} />,
-                    <RunLink key="run" label="Open run" onClick={() => navigate(`/runs/active/${entry.id}`)} />,
-                    <Button
-                      key="interrupt"
-                      variant="danger"
-                      size="sm"
-                      disabled={isInterrupting}
-                      onClick={() => void handleInterruptExecution(entry.id, entry.taskName)}
-                    >
-                      {isInterrupting ? "Interrupting…" : "Interrupt"}
-                    </Button>,
-                    ],
-                    mobile: (
-                    <ExecutionMobileCard
-                      key={`active-mobile-${entry.id}`}
-                      tone="warning"
-                      title={entry.taskName ?? "Untitled task"}
-                      badge="Active"
-                      taskStatus={entry.taskStatus}
-                      lines={[
-                        { label: "Latest heartbeat", value: formatDateTime(entry.lastHeartbeatAt) },
-                        { label: "Agent", value: actor?.slug ? `@${actor.slug}` : shortId(entry.agentActorId), mono: true },
-                      ]}
-                      actionButton={
-                        <Button
-                          variant="danger"
-                          size="sm"
-                          disabled={isInterrupting}
-                          onClick={() => void handleInterruptExecution(entry.id, entry.taskName)}
-                        >
-                          {isInterrupting ? "Interrupting…" : "Interrupt"}
-                        </Button>
-                      }
-                      onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
-                      onToggleDetails={() => toggleHistoryMessage(entry.id)}
-                      detailsExpanded={expandedHistoryIds.has(entry.id)}
-                      executionDetails={entry}
-                      actor={actor}
-                    />
-                    ),
-                  };
-                })}
-              />
-            }
-          />
-
-          <ExecutionSection
-            title="History"
-            subtitle="Completed, failed, and cancelled runs"
-            count={history.length}
-            emptyMessage="No historical executions yet."
-            table={
-              <ExecutionTable
-                columns={["Status", "Task", "Agent", "Duration", "Run"]}
-                rows={history.map((entry) => {
-                  const actor = actors.find((candidate) => candidate.id === entry.agentActorId);
-
-                  return {
-                    key: entry.id,
-                    expandedContent: expandedHistoryIds.has(entry.id) ? (
-                      <ExecutionDetails
-                        execution={entry}
-                        actor={actor}
-                      />
-                    ) : null,
-                    cells: [
-                    <StatusCellWithError
-                      key="status"
-                      status={entry.status}
-                      errorCode={entry.errorCode}
-                      errorMessage={entry.errorMessage}
-                      onToggleDetails={() => toggleHistoryMessage(entry.id)}
-                      detailsExpanded={expandedHistoryIds.has(entry.id)}
-                    />,
-                    <TaskCellWithStatus
-                      key="task"
-                      taskId={entry.taskId}
-                      taskName={entry.taskName}
-                      taskStatus={entry.taskStatus}
-                      onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
-                    />,
-                    <ActorCell
-                      key="agent"
-                      actorId={entry.agentActorId}
-                      actorName={actor?.displayName}
-                      actorSlug={actor?.slug}
-                    />,
-                    <DurationCell key="duration" start={entry.claimedAt} end={entry.transitionedAt} />,
-                    <RunLink key="run" label="Open run" onClick={() => navigate(`/runs/history/${entry.id}`)} />,
-                    ],
-                    mobile: (
-                    <ExecutionMobileCard
-                      key={`history-mobile-${entry.id}`}
-                      tone={entry.status === "SUCCEEDED" ? "success" : "danger"}
-                      title={entry.taskName ?? "Untitled task"}
-                      badge={entry.status}
-                      taskStatus={entry.taskStatus}
-                      lines={[
-                        { label: "Transitioned", value: formatDateTime(entry.transitionedAt) },
-                        { label: "Agent", value: actor?.slug ? `@${actor.slug}` : shortId(entry.agentActorId), mono: true },
-                        { label: "Error", value: entry.errorCode ?? "None" },
-                        ...(entry.errorMessage
-                          ? [{ label: "Message", value: entry.errorMessage }]
-                          : []),
-                      ]}
-                      onClick={() => navigate(`/tasks/task/${entry.taskId}`)}
-                      onToggleDetails={() => toggleHistoryMessage(entry.id)}
-                      detailsExpanded={expandedHistoryIds.has(entry.id)}
-                      executionDetails={entry}
-                      actor={actor}
-                    />
-                    ),
-                  };
-                })}
-              />
-            }
-          />
-        </div>
+              return (
+                <RunFeedRow
+                  key={key}
+                  feedEntry={feedEntry}
+                  actor={actor}
+                  isInterrupting={isInterrupting}
+                  onClick={() => navigate(runPath)}
+                  onInterrupt={feedEntry.kind === "active"
+                    ? () => void handleInterruptExecution(feedEntry.entry.id, feedEntry.entry.taskName)
+                    : undefined}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <Card className="executions-empty-card">
+            <Text as="div" size="3" weight="medium">No executions yet</Text>
+            <Text as="div" tone="muted">Queued, running, and completed executions will appear here.</Text>
+          </Card>
+        )
       ) : null}
     </div>
   );
@@ -393,7 +180,7 @@ export function ExecutionDetailPage() {
     return (
       <div className="executions-page">
         <Card className="executions-empty-card">
-          <Text as="div" size="3" weight="medium">Loading run…</Text>
+          <Text as="div" size="3" weight="medium">Loading run...</Text>
         </Card>
       </div>
     );
@@ -412,497 +199,184 @@ export function ExecutionDetailPage() {
 
   if (!detail) {
     return (
-      <div className="executions-page">
-        <Card className="executions-detail-card">
-          <div className="executions-detail-header">
-            <div>
-              <Text as="div" size="5" weight="bold">Run not found</Text>
-              <Text as="div" tone="muted" wrap>The run may have moved between queue, active, and history. Return to the runs list to find the latest state.</Text>
-            </div>
-            <Button variant="secondary" onClick={() => navigate('/runs')}>Back to runs</Button>
-          </div>
-        </Card>
-      </div>
-    );
-  }
-
-  const entry = detail.entry;
-  const actorId = "agentActorId" in entry ? entry.agentActorId : null;
-  const actor = actorId ? actors.find((candidate) => candidate.id === actorId) : undefined;
-  const title = entry.taskName ?? "Untitled task";
-  let status: string;
-  let tone: "accent" | "warning" | "success" | "danger";
-  let detailPanel: React.ReactNode;
-
-  if (detail.kind === "queue") {
-    status = "QUEUED";
-    tone = "accent";
-    detailPanel = (
-      <div className="executions-details-panel executions-details-panel--standalone">
-        <div className="executions-details-grid">
-          <div className="executions-details-section">
-            <Text as="div" size="1" weight="semibold" tone="muted" className="executions-details-heading">Queue</Text>
-            <div className="executions-details-rows">
-              <DetailRow label="Task status" value={entry.taskStatus ?? "Unknown"} />
-              <DetailRow label="Task ID" value={entry.taskId} mono />
-            </div>
-          </div>
+      <div className="executions-page executions-page--detail">
+        <div className="executions-detail-topbar">
+          <Button variant="secondary" onClick={() => navigate("/runs")}>Back to runs</Button>
         </div>
+        <Text as="div" size="5" weight="bold">Run not found</Text>
+        <Text as="div" tone="muted" wrap>The run may have moved between queued, active, and historical states.</Text>
       </div>
     );
-  } else if (detail.kind === "active") {
-    status = "ACTIVE";
-    tone = "warning";
-    detailPanel = <ExecutionDetails execution={detail.entry} actor={actor} />;
-  } else {
-    status = detail.entry.status;
-    tone = detail.entry.status === "SUCCEEDED" ? "success" : "danger";
-    detailPanel = <ExecutionDetails execution={detail.entry} actor={actor} />;
   }
+
+  const actor = getActorForRun(detail, actors);
+  const title = detail.entry.taskName ?? "Untitled task";
+  const statusLabel = getRunStatusLabel(detail);
 
   return (
     <div className="executions-page executions-page--detail">
-      <Card className="executions-detail-card">
-        <div className="executions-detail-header">
-          <div className="executions-detail-title-group">
-            <StatusPill tone={tone}><StatusMark status={status} /> {status}</StatusPill>
-            <Text as="div" size="5" weight="bold" wrap>{title}</Text>
-            <Text as="div" tone="muted" style="mono">{detail.kind}/{id}</Text>
+      <div className="executions-detail-topbar">
+        <Button variant="secondary" onClick={() => navigate("/runs")}>Back to runs</Button>
+        <Button variant="secondary" onClick={() => navigate(`/tasks/task/${detail.entry.taskId}`)}>Open task</Button>
+      </div>
+
+      <header className="executions-run-header">
+        <RunStatusIcon feedEntry={detail} />
+        <div className="executions-run-header__copy">
+          <Text as="div" size="5" weight="bold" wrap>{title}</Text>
+          <Text as="div" size="2" tone="muted">
+            {actor ? `picked by @${actor.slug ?? actor.displayName ?? actor.id}` : "waiting to be picked"}
+          </Text>
+        </div>
+        <Text as="div" size="2" tone="muted" className="executions-run-status-label">{statusLabel}</Text>
+      </header>
+
+      {detail.kind === "queue" ? (
+        <section className="executions-detail-section">
+          <Text as="div" size="1" weight="semibold" tone="muted" className="executions-detail-section__title">Queue</Text>
+          <div className="executions-detail-list">
+            <DetailRow label="Task status" value={detail.entry.taskStatus ?? "Unknown"} />
+            <DetailRow label="Task ID" value={detail.entry.taskId} mono />
           </div>
-          <div className="executions-detail-actions">
-            <Button variant="secondary" onClick={() => navigate(`/tasks/task/${entry.taskId}`)}>Open task</Button>
-            <Button variant="secondary" onClick={() => navigate('/runs')}>Back to runs</Button>
-          </div>
-        </div>
-
-        {detailPanel}
-      </Card>
-    </div>
-  );
-}
-
-function OverviewMetric({
-  label,
-  value,
-  detail,
-  tone,
-}: {
-  label: string;
-  value: string;
-  detail: string;
-  tone: "accent" | "warning" | "success" | "danger" | "neutral";
-}) {
-  return (
-    <Card className={`executions-metric executions-metric--${tone}`}>
-      <Text as="div" size="1" tone="muted" className="executions-metric__label">{label}</Text>
-      <Text as="div" size="5" weight="bold" className="executions-metric__value">{value}</Text>
-      <Text as="div" size="2" tone="muted">{detail}</Text>
-    </Card>
-  );
-}
-
-function ExecutionSection({
-  title,
-  subtitle,
-  count,
-  emptyMessage,
-  table,
-}: {
-  title: string;
-  subtitle: string;
-  count: number;
-  emptyMessage: string;
-  table: React.ReactNode;
-}) {
-  return (
-    <Card padding="0" className="executions-section-card">
-      <div className="executions-section-card__header">
-        <div>
-          <Text as="div" size="4" weight="bold">{title}</Text>
-          <Text as="div" size="2" tone="muted">{subtitle}</Text>
-        </div>
-        <span className="executions-count-pill">{count}</span>
-      </div>
-      {count === 0 ? (
-        <div className="executions-section-card__empty">
-          <Text as="div" tone="muted">{emptyMessage}</Text>
-        </div>
-      ) : table}
-    </Card>
-  );
-}
-
-function ExecutionTable({
-  columns,
-  rows,
-}: {
-  columns: string[];
-  rows: Array<{
-    key: string;
-    cells: React.ReactNode[];
-    mobile: React.ReactNode;
-    expandedContent?: React.ReactNode;
-  }>;
-}) {
-  return (
-    <>
-      <div className="executions-table-wrap">
-        <table className="executions-table">
-          <thead>
-            <tr>
-              {columns.map((column) => (
-                <th key={column}>{column}</th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <Fragment key={row.key}>
-                <tr>
-                  {row.cells.map((cell, index) => (
-                    <td key={`${row.key}-${index}`}>{cell}</td>
-                  ))}
-                </tr>
-                {row.expandedContent ? (
-                  <tr className="executions-table-detail-row">
-                    <td colSpan={columns.length}>{row.expandedContent}</td>
-                  </tr>
-                ) : null}
-              </Fragment>
-            ))}
-          </tbody>
-        </table>
-      </div>
-      <div className="executions-mobile-list">
-        {rows.map((row) => row.mobile)}
-      </div>
-    </>
-  );
-}
-
-function StatusPill({
-  children,
-  tone,
-}: {
-  children: React.ReactNode;
-  tone: "accent" | "warning" | "success" | "danger" | "neutral";
-}) {
-  return (
-    <span className={`executions-status-pill executions-status-pill--${tone}`}>
-      {children}
-    </span>
-  );
-}
-
-function StatusMark({ status }: { status: string }) {
-  if (status === "SUCCEEDED") {
-    return <span className="executions-status-mark executions-status-mark--success" aria-hidden="true">✓</span>;
-  }
-
-  if (status === "FAILED" || status === "CANCELLED") {
-    return <span className="executions-status-mark executions-status-mark--danger" aria-hidden="true">×</span>;
-  }
-
-  if (status === "ACTIVE") {
-    return <span className="executions-status-mark executions-status-mark--warning" aria-hidden="true">•</span>;
-  }
-
-  return <span className="executions-status-mark executions-status-mark--accent" aria-hidden="true">•</span>;
-}
-
-function StatusCellWithError({
-  status,
-  errorCode,
-  errorMessage,
-  onToggleDetails,
-  detailsExpanded,
-}: {
-  status: TaskExecutionHistoryResponseDto["status"];
-  errorCode: TaskExecutionHistoryResponseDto["errorCode"];
-  errorMessage: string | null;
-  onToggleDetails?: () => void;
-  detailsExpanded?: boolean;
-}) {
-  const hasError = Boolean(errorCode || errorMessage);
-  const tone = status === "SUCCEEDED" ? "success" : "danger";
-
-  return (
-    <div className="executions-status-with-error">
-      <StatusPill tone={tone}><StatusMark status={status} /> {status}</StatusPill>
-      {hasError && onToggleDetails && (
-        <button
-          type="button"
-          className="executions-error-indicator"
-          onClick={onToggleDetails}
-          aria-expanded={detailsExpanded}
-          aria-label={detailsExpanded ? "Hide error details" : "Show error details"}
-          title={detailsExpanded ? "Hide error details" : "Show error details"}
-        >
-          !
-        </button>
+        </section>
+      ) : (
+        <RunExecutionDetails execution={detail.entry} actor={actor} />
       )}
     </div>
   );
 }
 
-function RunLink({ label, onClick }: { label: string; onClick: () => void }) {
+function RunFeedRow({
+  feedEntry,
+  actor,
+  isInterrupting,
+  onClick,
+  onInterrupt,
+}: {
+  feedEntry: RunFeedEntry;
+  actor?: ActorSummary;
+  isInterrupting: boolean;
+  onClick: () => void;
+  onInterrupt?: () => void;
+}) {
+  const taskName = feedEntry.entry.taskName ?? "Untitled task";
+  const statusDetail = getRunStatusDetail(feedEntry);
+  const timeDetail = getRunTimeDetail(feedEntry);
+  const agentDetail = actor ? `picked by @${actor.slug ?? actor.displayName ?? actor.id}` : "waiting to be picked";
+
   return (
-    <button
-      type="button"
-      className="executions-details-toggle"
+    <div
+      role="button"
+      tabIndex={0}
+      className="executions-feed-row"
       onClick={onClick}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onClick();
+        }
+      }}
+      aria-label={`Open run for ${taskName}`}
     >
-      <Text as="span" size="2" weight="semibold">{label}</Text>
-    </button>
-  );
-}
-
-function DurationCell({ start, end }: { start: string; end: string }) {
-  return (
-    <div className="executions-time-cell">
-      <Text as="div" size="2" weight="semibold">{formatDuration(new Date(end).getTime() - new Date(start).getTime())}</Text>
-      <Text as="div" size="1" tone="muted">{formatRelativeTime(end)}</Text>
-    </div>
-  );
-}
-
-function TaskCell({
-  taskId,
-  taskName,
-  onClick,
-}: {
-  taskId: string;
-  taskName: string | null;
-  onClick?: () => void;
-}) {
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        className="executions-task-cell executions-task-cell--clickable"
-        onClick={onClick}
-        aria-label={`Navigate to task: ${taskName ?? "Untitled task"}`}
-      >
-        <Text as="div" size="2" weight="semibold">{taskName ?? "Untitled task"}</Text>
-        <Text as="div" size="1" tone="muted" style="mono">{shortId(taskId)}</Text>
-      </button>
-    );
-  }
-
-  return (
-    <div className="executions-task-cell">
-      <Text as="div" size="2" weight="semibold">{taskName ?? "Untitled task"}</Text>
-      <Text as="div" size="1" tone="muted" style="mono">{shortId(taskId)}</Text>
-    </div>
-  );
-}
-
-function TaskCellWithStatus({
-  taskId,
-  taskName,
-  taskStatus,
-  onClick,
-}: {
-  taskId: string;
-  taskName: string | null;
-  taskStatus: string | null;
-  onClick?: () => void;
-}) {
-  const content = (
-    <>
-      <Text as="div" size="2" weight="semibold">{taskName ?? "Untitled task"}</Text>
-      {taskStatus && (
-        <StatusPill tone={taskStatusTone(taskStatus)}>
-          {taskStatus}
-        </StatusPill>
-      )}
-    </>
-  );
-
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        className="executions-task-cell-with-status executions-task-cell--clickable"
-        onClick={onClick}
-        aria-label={`Navigate to task: ${taskName ?? "Untitled task"}`}
-      >
-        {content}
-      </button>
-    );
-  }
-
-  return (
-    <div className="executions-task-cell-with-status">
-      {content}
-    </div>
-  );
-}
-
-function CodeCell({ value }: { value: string }) {
-  return (
-    <Text as="span" size="1" style="mono" className="executions-code-copy">
-      {shortId(value)}
-    </Text>
-  );
-}
-
-function ActorCell({
-  actorId,
-  actorName,
-  actorSlug,
-}: {
-  actorId: string;
-  actorName?: string;
-  actorSlug?: string;
-}) {
-  return (
-    <div className="executions-actor-cell">
-      <Text as="div" size="2" weight="semibold">{actorName ?? shortId(actorId)}</Text>
-      <Text as="div" size="1" tone="muted" style="mono" className="executions-actor-slug">
-        {actorSlug ? `@${actorSlug}` : shortId(actorId)}
-      </Text>
-    </div>
-  );
-}
-
-function ErrorCell({
-  errorCode,
-  errorMessage,
-  expanded,
-  onToggle,
-}: {
-  errorCode: TaskExecutionHistoryResponseDto["errorCode"];
-  errorMessage: string | null;
-  expanded: boolean;
-  onToggle: () => void;
-}) {
-  const hasMessage = Boolean(errorMessage);
-
-  return (
-    <div className="executions-error-cell">
-      <span className={errorCode ? "executions-error-copy" : "executions-muted-copy"}>
-        {errorCode ?? "None"}
-      </span>
-      {hasMessage ? (
-        <button
-          type="button"
-          className="executions-error-toggle"
-          onClick={onToggle}
-          aria-expanded={expanded}
-          aria-label={expanded ? "Hide error message" : "Show error message"}
-          title={expanded ? "Hide error message" : "Show error message"}
-        >
-          !
-        </button>
+      <RunStatusIcon feedEntry={feedEntry} />
+      <div className="executions-feed-row__main">
+        <Text as="div" size="3" weight="semibold" wrap>{taskName}</Text>
+        <Text as="div" size="2" tone="muted" wrap>{agentDetail}</Text>
+      </div>
+      <div className="executions-feed-row__meta">
+        <Text as="div" size="2" weight="medium">{statusDetail}</Text>
+        <Text as="div" size="1" tone="muted">{timeDetail}</Text>
+      </div>
+      <div className="executions-feed-row__stats">
+        <Text as="div" size="2" weight="medium">{getRunToolCount(feedEntry)}</Text>
+        <Text as="div" size="1" tone="muted">{getRunTokenCount(feedEntry)}</Text>
+      </div>
+      {onInterrupt ? (
+        <div className="executions-feed-row__actions">
+          <Button
+            variant="danger"
+            size="sm"
+            disabled={isInterrupting}
+            onClick={(event) => {
+              event.stopPropagation();
+              onInterrupt();
+            }}
+          >
+            {isInterrupting ? "Interrupting..." : "Interrupt"}
+          </Button>
+        </div>
       ) : null}
     </div>
   );
 }
 
-function ExecutionErrorMessage({
-  status,
-  message,
-}: {
-  status: TaskExecutionHistoryResponseDto["status"];
-  message: string;
-}) {
-  return (
-    <div className="executions-error-detail">
-      <Text
-        as="div"
-        size="1"
-        weight="medium"
-        tone={status === "CANCELLED" ? "muted" : "default"}
-        className={status === "CANCELLED" ? undefined : "executions-error-detail__label"}
-      >
-        {status === "CANCELLED" ? "Cancellation message" : "Failure message"}
-      </Text>
-      <Text as="div" size="2" wrap>{message}</Text>
-    </div>
-  );
+function RunStatusIcon({ feedEntry }: { feedEntry: RunFeedEntry | ExecutionDetailResult }) {
+  if (feedEntry.kind === "queue") {
+    return <span className="executions-run-icon executions-run-icon--queued" aria-label="Queued" />;
+  }
+
+  if (feedEntry.kind === "active") {
+    return <span className="executions-run-icon executions-run-icon--active" aria-label="Active" />;
+  }
+
+  if (feedEntry.entry.status === "SUCCEEDED") {
+    return <span className="executions-run-icon executions-run-icon--success" aria-label="Succeeded">✓</span>;
+  }
+
+  return <span className="executions-run-icon executions-run-icon--danger" aria-label={feedEntry.entry.status}>×</span>;
 }
 
-function ExecutionDetails({
-  execution,
-  actor,
-}: {
-  execution: ActiveTaskExecutionResponseDto | TaskExecutionHistoryResponseDto;
-  actor?: { id: string; displayName?: string; slug?: string };
-}) {
+function RunExecutionDetails({ execution, actor }: { execution: ActiveTaskExecutionResponseDto | TaskExecutionHistoryResponseDto; actor?: ActorSummary }) {
   const isHistory = "transitionedAt" in execution;
   const claimedAt = new Date(execution.claimedAt);
   const endTime = isHistory ? new Date(execution.transitionedAt) : new Date();
-  const durationMs = endTime.getTime() - claimedAt.getTime();
-  const durationText = formatDuration(durationMs);
+  const durationText = formatDuration(endTime.getTime() - claimedAt.getTime());
+  const stats = execution.stats;
 
   return (
-    <div className="executions-details-panel">
-      <div className="executions-details-grid">
-        <div className="executions-details-section">
-          <Text as="div" size="1" weight="semibold" tone="muted" className="executions-details-heading">
-            Timing
-          </Text>
-          <div className="executions-details-rows">
-            <DetailRow label="Claimed at" value={formatDateTime(execution.claimedAt)} />
-            {isHistory && (
-              <>
-                <DetailRow label="Finished at" value={formatDateTime(execution.transitionedAt)} />
-                <DetailRow label="Duration" value={durationText} />
-              </>
-            )}
-            {!isHistory && "lastHeartbeatAt" in execution && (
-              <DetailRow label="Latest heartbeat" value={formatDateTime(execution.lastHeartbeatAt)} />
-            )}
-          </div>
+    <>
+      <section className="executions-detail-section">
+        <Text as="div" size="1" weight="semibold" tone="muted" className="executions-detail-section__title">Timing</Text>
+        <div className="executions-detail-list">
+          <DetailRow label="Claimed at" value={formatDateTime(execution.claimedAt)} />
+          {isHistory ? <DetailRow label="Finished at" value={formatDateTime(execution.transitionedAt)} /> : null}
+          {!isHistory && "lastHeartbeatAt" in execution ? <DetailRow label="Latest heartbeat" value={formatDateTime(execution.lastHeartbeatAt)} /> : null}
+          <DetailRow label="Duration" value={durationText} />
         </div>
+      </section>
 
-        {execution.stats && (
-          <div className="executions-details-section">
-            <Text as="div" size="1" weight="semibold" tone="muted" className="executions-details-heading">
-              Execution Stats
-            </Text>
-            <div className="executions-details-rows">
-              {execution.stats.harness && (
-                <DetailRow label="Harness" value={execution.stats.harness} />
-              )}
-              {execution.stats.providerId && (
-                <DetailRow label="Provider" value={execution.stats.providerId} />
-              )}
-              {execution.stats.modelId && (
-                <DetailRow label="Model" value={execution.stats.modelId} />
-              )}
-              {execution.stats.totalTokens !== null && (
-                <DetailRow
-                  label="Tokens"
-                  value={`${execution.stats.totalTokens.toLocaleString()} (${execution.stats.inputTokens?.toLocaleString() ?? 0} in / ${execution.stats.outputTokens?.toLocaleString() ?? 0} out)`}
-                />
-              )}
-            </div>
-          </div>
-        )}
-
-        <div className="executions-details-section">
-          <Text as="div" size="1" weight="semibold" tone="muted" className="executions-details-heading">
-            System Info
-          </Text>
-          <div className="executions-details-rows">
-            <DetailRow label="Worker ID" value={shortId(execution.workerClientId)} mono />
-            <DetailRow label="Session ID" value={formatSession(execution.runnerSessionId)} mono />
-            <DetailRow label="Tool calls" value={String(execution.toolCallCount)} />
-          </div>
+      <section className="executions-detail-section">
+        <Text as="div" size="1" weight="semibold" tone="muted" className="executions-detail-section__title">Work</Text>
+        <div className="executions-detail-list">
+          <DetailRow label="Agent" value={actor ? `@${actor.slug ?? actor.displayName ?? actor.id}` : execution.agentActorId} mono={!actor} />
+          <DetailRow label="Tool calls" value={execution.toolCallCount.toLocaleString()} />
+          <DetailRow label="Tokens used" value={formatTokenStats(stats)} />
+          <DetailRow label="Harness" value={stats?.harness ?? "Unknown"} />
+          <DetailRow label="Provider" value={stats?.providerId ?? "Unknown"} />
+          <DetailRow label="Model" value={stats?.modelId ?? "Unknown"} />
         </div>
+      </section>
 
-        {isHistory && execution.errorMessage && (
-          <div className="executions-details-section executions-details-section--full">
-            <ExecutionErrorMessage
-              status={execution.status}
-              message={execution.errorMessage}
-            />
+      <section className="executions-detail-section">
+        <Text as="div" size="1" weight="semibold" tone="muted" className="executions-detail-section__title">IDs</Text>
+        <div className="executions-detail-list">
+          <DetailRow label="Run ID" value={execution.id} mono />
+          <DetailRow label="Task ID" value={execution.taskId} mono />
+          <DetailRow label="Worker ID" value={execution.workerClientId} mono />
+          <DetailRow label="Session ID" value={execution.runnerSessionId ?? "pending"} mono />
+        </div>
+      </section>
+
+      {isHistory && (execution.errorCode || execution.errorMessage) ? (
+        <section className="executions-detail-section executions-detail-section--danger">
+          <Text as="div" size="1" weight="semibold" tone="muted" className="executions-detail-section__title">Failure</Text>
+          <div className="executions-detail-list">
+            <DetailRow label="Error code" value={execution.errorCode ?? "None"} />
+            {execution.errorMessage ? <DetailRow label="Message" value={execution.errorMessage} /> : null}
           </div>
-        )}
-      </div>
-    </div>
+        </section>
+      ) : null}
+    </>
   );
 }
 
@@ -910,9 +384,97 @@ function DetailRow({ label, value, mono }: { label: string; value: string; mono?
   return (
     <div className="executions-detail-row">
       <Text as="span" size="1" tone="muted">{label}</Text>
-      <Text as="span" size="2" style={mono ? "mono" : "sans"}>{value}</Text>
+      <Text as="span" size="2" style={mono ? "mono" : "sans"} wrap>{value}</Text>
     </div>
   );
+}
+
+function getActorForRun(feedEntry: RunFeedEntry | ExecutionDetailResult, actors: ActorSummary[]) {
+  if (feedEntry.kind === "queue") {
+    return undefined;
+  }
+
+  return actors.find((candidate) => candidate.id === feedEntry.entry.agentActorId);
+}
+
+function getRunKey(feedEntry: RunFeedEntry) {
+  return feedEntry.kind === "queue" ? `queue-${feedEntry.entry.taskId}` : `${feedEntry.kind}-${feedEntry.entry.id}`;
+}
+
+function getRunPath(feedEntry: RunFeedEntry) {
+  if (feedEntry.kind === "queue") {
+    return `/runs/queue/${feedEntry.entry.taskId}`;
+  }
+
+  return `/runs/${feedEntry.kind}/${feedEntry.entry.id}`;
+}
+
+function getRunStatusLabel(feedEntry: RunFeedEntry | ExecutionDetailResult) {
+  if (feedEntry.kind === "queue") {
+    return "Queued";
+  }
+
+  if (feedEntry.kind === "active") {
+    return "Running";
+  }
+
+  return sentenceCase(feedEntry.entry.status);
+}
+
+function getRunStatusDetail(feedEntry: RunFeedEntry) {
+  if (feedEntry.kind === "queue") {
+    return `Queued · ${feedEntry.entry.taskStatus ?? "Unknown task status"}`;
+  }
+
+  if (feedEntry.kind === "active") {
+    return `Running · ${feedEntry.entry.taskStatus ?? "Unknown task status"}`;
+  }
+
+  const error = feedEntry.entry.errorCode ? ` · ${feedEntry.entry.errorCode}` : "";
+  return `${sentenceCase(feedEntry.entry.status)}${error}`;
+}
+
+function getRunTimeDetail(feedEntry: RunFeedEntry) {
+  if (feedEntry.kind === "queue") {
+    return shortId(feedEntry.entry.taskId);
+  }
+
+  if (feedEntry.kind === "active") {
+    return `heartbeat ${formatRelativeTime(feedEntry.entry.lastHeartbeatAt)}`;
+  }
+
+  return `${formatDuration(new Date(feedEntry.entry.transitionedAt).getTime() - new Date(feedEntry.entry.claimedAt).getTime())} · ${formatRelativeTime(feedEntry.entry.transitionedAt)}`;
+}
+
+function getRunToolCount(feedEntry: RunFeedEntry) {
+  if (feedEntry.kind === "queue") {
+    return "No tools yet";
+  }
+
+  return `${feedEntry.entry.toolCallCount.toLocaleString()} tool calls`;
+}
+
+function getRunTokenCount(feedEntry: RunFeedEntry) {
+  if (feedEntry.kind === "queue") {
+    return "No tokens yet";
+  }
+
+  const totalTokens = feedEntry.entry.stats?.totalTokens;
+  return totalTokens === null || totalTokens === undefined ? "tokens unknown" : `${totalTokens.toLocaleString()} tokens`;
+}
+
+function formatTokenStats(stats: ActiveTaskExecutionResponseDto["stats"] | TaskExecutionHistoryResponseDto["stats"]) {
+  if (!stats || stats.totalTokens === null) {
+    return "Unknown";
+  }
+
+  const input = stats.inputTokens === null ? "unknown" : stats.inputTokens.toLocaleString();
+  const output = stats.outputTokens === null ? "unknown" : stats.outputTokens.toLocaleString();
+  return `${stats.totalTokens.toLocaleString()} total (${input} input / ${output} output)`;
+}
+
+function sentenceCase(value: string) {
+  return value.toLowerCase().replace(/^./, (letter) => letter.toUpperCase());
 }
 
 function formatDuration(ms: number): string {
@@ -933,198 +495,6 @@ function formatDuration(ms: number): string {
   return `${seconds}s`;
 }
 
-function TimeCell({ value }: { value: string | null }) {
-  return (
-    <div className="executions-time-cell">
-      <Text as="div" size="2">{formatDateTime(value)}</Text>
-      {value ? (
-        <Text as="div" size="1" tone="muted">
-          {formatRelativeTime(value)}
-        </Text>
-      ) : null}
-    </div>
-  );
-}
-
-function SessionCell({ value }: { value: string | null }) {
-  return (
-    <Text as="span" size="1" style="mono" className="executions-code-copy">
-      {formatSession(value)}
-    </Text>
-  );
-}
-
-function ToolCountCell({ value }: { value: number }) {
-  return (
-    <Text as="span" size="2" weight="semibold">
-      {value}
-    </Text>
-  );
-}
-
-function ExecutionMobileCard({
-  title,
-  badge,
-  tone,
-  taskStatus,
-  lines,
-  onClick,
-  actionButton,
-  onToggleDetails,
-  detailsExpanded,
-  executionDetails,
-  actor,
-}: {
-  title: string;
-  badge: string;
-  tone: "accent" | "warning" | "success" | "danger";
-  taskStatus?: string | null;
-  lines: Array<{ label: string; value: string; mono?: boolean }>;
-  onClick?: () => void;
-  actionButton?: React.ReactNode;
-  onToggleDetails?: () => void;
-  detailsExpanded?: boolean;
-  executionDetails?: ActiveTaskExecutionResponseDto | TaskExecutionHistoryResponseDto;
-  actor?: { id: string; displayName?: string; slug?: string };
-}) {
-  // When we have both onClick and other interactive elements (actionButton or details toggle),
-  // render as div to avoid nested interactive elements. Only the header becomes clickable for navigation.
-  const hasOtherInteractiveElements = actionButton || onToggleDetails;
-
-  if (onClick && hasOtherInteractiveElements) {
-    return (
-      <div className="executions-mobile-card">
-        <button
-          type="button"
-          className="executions-mobile-card__header executions-mobile-card__header--clickable"
-          onClick={onClick}
-          aria-label={`Navigate to task: ${title}`}
-        >
-          <div className="executions-mobile-card__title-group">
-            <Text as="div" size="3" weight="semibold" wrap>{title}</Text>
-            {taskStatus && (
-              <StatusPill tone={taskStatusTone(taskStatus)}>
-                {taskStatus}
-              </StatusPill>
-            )}
-          </div>
-          <StatusPill tone={tone}>{badge}</StatusPill>
-        </button>
-        <div className="executions-mobile-card__body">
-          {lines.map((line) => (
-            <div key={`${badge}-${line.label}`} className="executions-mobile-card__row">
-              <Text as="span" size="1" tone="muted">{line.label}</Text>
-              <Text
-                as="span"
-                size="2"
-                style={line.mono ? "mono" : "sans"}
-                className={line.label === "Error" && line.value !== "None" ? "executions-error-copy" : ""}
-              >
-                {line.value}
-              </Text>
-            </div>
-          ))}
-        </div>
-        {onToggleDetails && executionDetails && (
-          <>
-            <button
-              type="button"
-              className="executions-mobile-details-toggle"
-              onClick={onToggleDetails}
-              aria-expanded={detailsExpanded}
-            >
-              <Text as="span" size="2" weight="semibold">
-                {detailsExpanded ? "Hide details" : "Show details"}
-              </Text>
-            </button>
-            {detailsExpanded && (
-              <ExecutionDetails execution={executionDetails} actor={actor} />
-            )}
-          </>
-        )}
-        {actionButton && (
-          <div className="executions-mobile-card__actions">
-            {actionButton}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  const className = onClick
-    ? "executions-mobile-card executions-mobile-card--clickable"
-    : "executions-mobile-card";
-
-  const CardContent = (
-    <>
-      <div className="executions-mobile-card__header">
-        <div className="executions-mobile-card__title-group">
-          <Text as="div" size="3" weight="semibold" wrap>{title}</Text>
-          {taskStatus && (
-            <StatusPill tone={taskStatusTone(taskStatus)}>
-              {taskStatus}
-            </StatusPill>
-          )}
-        </div>
-        <StatusPill tone={tone}>{badge}</StatusPill>
-      </div>
-      <div className="executions-mobile-card__body">
-        {lines.map((line) => (
-          <div key={`${badge}-${line.label}`} className="executions-mobile-card__row">
-            <Text as="span" size="1" tone="muted">{line.label}</Text>
-            <Text
-              as="span"
-              size="2"
-              style={line.mono ? "mono" : "sans"}
-              className={line.label === "Error" && line.value !== "None" ? "executions-error-copy" : ""}
-            >
-              {line.value}
-            </Text>
-          </div>
-        ))}
-      </div>
-    </>
-  );
-
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        className={className}
-        onClick={onClick}
-        aria-label={`Navigate to task: ${title}`}
-      >
-        {CardContent}
-      </button>
-    );
-  }
-
-  return (
-    <div className={className}>
-      {CardContent}
-    </div>
-  );
-}
-
-function taskStatusTone(
-  status: string | null,
-): "accent" | "warning" | "success" | "danger" | "neutral" {
-  switch (status) {
-    case "NOT_STARTED":
-      return "accent";
-    case "IN_PROGRESS":
-      return "warning";
-    case "FOR_REVIEW":
-      return "warning";
-    case "DONE":
-      return "success";
-    case null:
-      return "neutral";
-    default:
-      return "neutral";
-  }
-}
-
 function formatDateTime(value: string | null | undefined) {
   if (!value) {
     return "Never";
@@ -1133,7 +503,11 @@ function formatDateTime(value: string | null | undefined) {
   return new Date(value).toLocaleString();
 }
 
-function formatRelativeTime(value: string) {
+function formatRelativeTime(value: string | null) {
+  if (!value) {
+    return "never";
+  }
+
   const deltaMs = Date.now() - new Date(value).getTime();
   const deltaSeconds = Math.max(0, Math.floor(deltaMs / 1000));
 
@@ -1156,13 +530,5 @@ function formatRelativeTime(value: string) {
 }
 
 function shortId(value: string) {
-  return value.length > 12 ? `${value.slice(0, 8)}…${value.slice(-4)}` : value;
-}
-
-function formatSession(value: string | null): string {
-  if (!value) {
-    return 'pending';
-  }
-
-  return shortId(value);
+  return value.length > 12 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value;
 }


### PR DESCRIPTION
## Summary
- Replace the runs page tables and overview cards with one ordered row-style feed: queued, active, then history.
- Use GitHub Actions-style status icons, including a queued circle and spinning active indicator, with the whole row linking to the run detail page.
- Simplify the run detail page and show full worker/session IDs, tool calls, token usage, timing, and failure metadata without nested card/table framing.

## Validation
- `npm run build:dev`
- `npm run dev:1` started successfully; terminated after the 60s validation timeout after Nest reported the app running. The known AppInitRunner seed/prompt errors appeared during startup.

## Technical Debt
- Run detail pages still resolve from the existing execution list APIs, so a run outside the loaded list can show the not-found fallback until a dedicated get-by-id API exists.