### PR TITLE
Refine backend controller DTO boundaries

### DIFF
--- a/apps/backend/src/auth-journeys/auth-journeys.controller.ts
+++ b/apps/backend/src/auth-journeys/auth-journeys.controller.ts
@@ -20,7 +20,11 @@ import {
   ConnectionFlowResponseDto,
   McpFlowResponseDto,
 } from './dto';
-import { AuthJourneyEntity } from './entities';
+import {
+  AuthJourneyResult,
+  ConnectionAuthorizationFlowResult,
+  McpAuthorizationFlowResult,
+} from './dto/service/auth-journeys.service.types';
 
 @ApiTags('Authorization Journeys')
 @ApiCookieAuth('JWT-Cookie')
@@ -51,7 +55,7 @@ export class AuthJourneysController {
   }
 
   private mapAuthJourneyToResponse(
-    journey: AuthJourneyEntity,
+    journey: AuthJourneyResult,
   ): AuthJourneyResponseDto {
     return {
       id: journey.id,
@@ -77,15 +81,17 @@ export class AuthJourneysController {
     };
   }
 
-  private mapMcpFlowToResponse(flow: any): McpFlowResponseDto {
+  private mapMcpFlowToResponse(
+    flow: McpAuthorizationFlowResult,
+  ): McpFlowResponseDto {
     return {
       id: flow.id,
       authorizationJourneyId: flow.authorizationJourneyId,
       serverId: flow.serverId,
       clientId: flow.clientId,
-      clientName: flow.client?.clientName || null,
+      clientName: flow.clientName,
       status: flow.status,
-      scope: flow.scope || null,
+      scope: flow.scope,
       authorizationCodeExpiresAt: flow.authorizationCodeExpiresAt
         ? this.formatDate(flow.authorizationCodeExpiresAt)
         : null,
@@ -95,12 +101,14 @@ export class AuthJourneysController {
     };
   }
 
-  private mapConnectionFlowToResponse(flow: any): ConnectionFlowResponseDto {
+  private mapConnectionFlowToResponse(
+    flow: ConnectionAuthorizationFlowResult,
+  ): ConnectionFlowResponseDto {
     return {
       id: flow.id,
       authorizationJourneyId: flow.authorizationJourneyId,
       mcpConnectionId: flow.mcpConnectionId,
-      connectionName: flow.mcpConnection?.friendlyName || null,
+      connectionName: flow.connectionName,
       status: flow.status,
       tokenExpiresAt: flow.tokenExpiresAt
         ? this.formatDate(flow.tokenExpiresAt)

--- a/apps/backend/src/auth-journeys/auth-journeys.service.ts
+++ b/apps/backend/src/auth-journeys/auth-journeys.service.ts
@@ -7,7 +7,12 @@ import {
   McpAuthorizationFlowEntity,
 } from './entities';
 import { AuthJourneyStatus } from './enums/auth-journey-status.enum';
-import { CreateAuthJourneyInput } from './dto/service/auth-journeys.service.types';
+import {
+  AuthJourneyResult,
+  ConnectionAuthorizationFlowResult,
+  CreateAuthJourneyInput,
+  McpAuthorizationFlowResult,
+} from './dto/service/auth-journeys.service.types';
 import { McpRegistryService } from '../mcp-registry/mcp-registry.service';
 import { McpAuthorizationFlowStatus } from './enums/mcp-authorization-flow-status.enum';
 import { RegisteredClientEntity } from '../authorization-server/entities/registered-client.entity';
@@ -91,7 +96,7 @@ export class AuthJourneysService {
   */
   async getJourneysForMcpServer(
     mcpServerId: string,
-  ): Promise<AuthJourneyEntity[]> {
+  ): Promise<AuthJourneyResult[]> {
     const authJourneys = await this.authJourneyRepository.find({
       where: {
         mcpAuthorizationFlow: {
@@ -108,7 +113,7 @@ export class AuthJourneysService {
         },
       },
     });
-    return authJourneys;
+    return authJourneys.map((journey) => this.mapAuthJourneyToResult(journey));
   }
 
   /*
@@ -203,6 +208,64 @@ export class AuthJourneysService {
     connectionFlow: ConnectionAuthorizationFlowEntity,
   ): Promise<ConnectionAuthorizationFlowEntity> {
     return this.connectionAuthorizationFlowRepository.save(connectionFlow);
+  }
+
+  private mapAuthJourneyToResult(journey: AuthJourneyEntity): AuthJourneyResult {
+    return {
+      id: journey.id,
+      status: journey.status,
+      actor: journey.actor
+        ? {
+            id: journey.actor.id,
+            type: journey.actor.type,
+            slug: journey.actor.slug,
+            displayName: journey.actor.displayName,
+            avatarUrl: journey.actor.avatarUrl,
+            introduction: journey.actor.introduction,
+          }
+        : null,
+      mcpAuthorizationFlow: this.mapMcpFlowToResult(
+        journey.mcpAuthorizationFlow,
+      ),
+      connectionAuthorizationFlows: journey.connectionAuthorizationFlows.map(
+        (flow) => this.mapConnectionFlowToResult(flow),
+      ),
+      createdAt: journey.createdAt,
+      updatedAt: journey.updatedAt,
+    };
+  }
+
+  private mapMcpFlowToResult(
+    flow: McpAuthorizationFlowEntity,
+  ): McpAuthorizationFlowResult {
+    return {
+      id: flow.id,
+      authorizationJourneyId: flow.authorizationJourneyId,
+      serverId: flow.serverId,
+      clientId: flow.clientId,
+      clientName: flow.client?.clientName ?? null,
+      status: flow.status,
+      scope: flow.scopes?.join(' ') ?? null,
+      authorizationCodeExpiresAt: flow.authorizationCodeExpiresAt ?? null,
+      authorizationCodeUsed: flow.authorizationCodeUsed,
+      createdAt: flow.createdAt,
+      updatedAt: flow.updatedAt,
+    };
+  }
+
+  private mapConnectionFlowToResult(
+    flow: ConnectionAuthorizationFlowEntity,
+  ): ConnectionAuthorizationFlowResult {
+    return {
+      id: flow.id,
+      authorizationJourneyId: flow.authorizationJourneyId,
+      mcpConnectionId: flow.mcpConnectionId,
+      connectionName: flow.mcpConnection?.friendlyName ?? null,
+      status: flow.status,
+      tokenExpiresAt: flow.tokenExpiresAt ?? null,
+      createdAt: flow.createdAt,
+      updatedAt: flow.updatedAt,
+    };
   }
 
   /*

--- a/apps/backend/src/auth-journeys/dto/service/auth-journeys.service.types.ts
+++ b/apps/backend/src/auth-journeys/dto/service/auth-journeys.service.types.ts
@@ -1,3 +1,8 @@
+import { ActorType } from '../../../identity-provider/enums';
+import { AuthJourneyStatus } from '../../enums/auth-journey-status.enum';
+import { ConnectionAuthorizationFlowStatus } from '../../enums/connection-authorization-flow-status.enum';
+import { McpAuthorizationFlowStatus } from '../../enums/mcp-authorization-flow-status.enum';
+
 /*
 Starts during client registration.
  - "I am this client, I want to connect to that server."
@@ -5,4 +10,48 @@ Starts during client registration.
 export type CreateAuthJourneyInput = {
   mcpClientId: string;
   mcpServerId: string;
+};
+
+export type AuthJourneyActorResult = {
+  id: string;
+  type: ActorType;
+  slug: string;
+  displayName: string;
+  avatarUrl: string | null;
+  introduction: string | null;
+};
+
+export type McpAuthorizationFlowResult = {
+  id: string;
+  authorizationJourneyId: string;
+  serverId: string;
+  clientId: string;
+  clientName: string | null;
+  status: McpAuthorizationFlowStatus;
+  scope: string | null;
+  authorizationCodeExpiresAt: Date | null;
+  authorizationCodeUsed: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type ConnectionAuthorizationFlowResult = {
+  id: string;
+  authorizationJourneyId: string;
+  mcpConnectionId: string;
+  connectionName: string | null;
+  status: ConnectionAuthorizationFlowStatus;
+  tokenExpiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type AuthJourneyResult = {
+  id: string;
+  status: AuthJourneyStatus;
+  actor: AuthJourneyActorResult | null;
+  mcpAuthorizationFlow: McpAuthorizationFlowResult;
+  connectionAuthorizationFlows: ConnectionAuthorizationFlowResult[];
+  createdAt: Date;
+  updatedAt: Date;
 };

--- a/apps/backend/src/authorization-server/client-registration.controller.ts
+++ b/apps/backend/src/authorization-server/client-registration.controller.ts
@@ -20,7 +20,7 @@ import {
 import { ClientRegistrationService } from './client-registration.service';
 import { RegisterClientDto } from './dto/register-client.dto';
 import { ClientRegistrationResponseDto } from './dto/client-registration-response.dto';
-import { RegisteredClientEntity } from './entities/registered-client.entity';
+import { ClientRegistrationResult } from './dto/service/client-registration.service.types';
 import { AccessTokenGuard } from '../auth/guards/guards/access-token.guard';
 import { ScopesGuard } from '../auth/guards/guards/scopes.guard';
 import { RequireScopes } from '../auth/guards/decorators/require-scopes.decorator';
@@ -34,7 +34,7 @@ export class ClientRegistrationController {
   ) {}
 
   private mapToClientRegistrationResponseDto(
-    client: RegisteredClientEntity,
+    client: ClientRegistrationResult,
   ): ClientRegistrationResponseDto {
     const response: ClientRegistrationResponseDto = {
       client_id: client.clientId,

--- a/apps/backend/src/authorization-server/client-registration.service.ts
+++ b/apps/backend/src/authorization-server/client-registration.service.ts
@@ -15,6 +15,7 @@ import { AuthJourneysService } from 'src/auth-journeys/auth-journeys.service';
 import { McpRegistryService } from 'src/mcp-registry/mcp-registry.service';
 import { getConfig } from 'src/config/env.config';
 import * as bcrypt from 'bcrypt';
+import { ClientRegistrationResult } from './dto/service/client-registration.service.types';
 
 @Injectable()
 export class ClientRegistrationService {
@@ -35,7 +36,7 @@ export class ClientRegistrationService {
   async registerClient(
     dto: RegisterClientDto,
     serverId: string,
-  ): Promise<RegisteredClientEntity> {
+  ): Promise<ClientRegistrationResult> {
     // Validate payload without touching the database
 
     // Validate required fields
@@ -84,16 +85,16 @@ export class ClientRegistrationService {
       });
 
     // Return the client with the plaintext secret (only time it's exposed)
-    return {
+    return this.mapClientToResult({
       ...savedClient,
       clientSecret,
-    };
+    });
   }
 
   /**
    * Retrieve a registered client by client_id
    */
-  async getClient(clientId: string): Promise<RegisteredClientEntity> {
+  async getClient(clientId: string): Promise<ClientRegistrationResult> {
     const client = await this.clientRepository.findOne({
       where: { clientId },
     });
@@ -102,16 +103,18 @@ export class ClientRegistrationService {
       throw new ClientNotFoundError(clientId);
     }
 
-    return client;
+    return this.mapClientToResult(client);
   }
 
   /**
    * List all registered clients (for admin purposes)
    */
-  async listClients(): Promise<RegisteredClientEntity[]> {
-    return this.clientRepository.find({
+  async listClients(): Promise<ClientRegistrationResult[]> {
+    const clients = await this.clientRepository.find({
       order: { createdAt: 'DESC' },
     });
+
+    return clients.map((client) => this.mapClientToResult(client));
   }
 
   // Validation methods
@@ -197,5 +200,19 @@ export class ClientRegistrationService {
     hash: string,
   ): Promise<boolean> {
     return bcrypt.compare(plaintext, hash);
+  }
+
+  private mapClientToResult(
+    client: RegisteredClientEntity,
+  ): ClientRegistrationResult {
+    return {
+      clientId: client.clientId,
+      clientName: client.clientName,
+      redirectUris: client.redirectUris,
+      grantTypes: client.grantTypes,
+      tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
+      contacts: client.contacts,
+      createdAt: client.createdAt,
+    };
   }
 }

--- a/apps/backend/src/authorization-server/dto/service/client-registration.service.types.ts
+++ b/apps/backend/src/authorization-server/dto/service/client-registration.service.types.ts
@@ -1,0 +1,11 @@
+import { GrantType, TokenEndpointAuthMethod } from '../../enums';
+
+export type ClientRegistrationResult = {
+  clientId: string;
+  clientName: string;
+  redirectUris: string[];
+  grantTypes: GrantType[];
+  tokenEndpointAuthMethod: TokenEndpointAuthMethod;
+  contacts: string[] | null;
+  createdAt: Date;
+};

--- a/apps/backend/src/executions/active/active-task-execution.controller.ts
+++ b/apps/backend/src/executions/active/active-task-execution.controller.ts
@@ -68,7 +68,7 @@ export class ActiveTaskExecutionController {
 
     return {
       items: result.items.map((item) =>
-        ActiveTaskExecutionResponseDto.fromEntity(item),
+        ActiveTaskExecutionResponseDto.fromResult(item),
       ),
       total: result.total,
       page: result.page,
@@ -100,7 +100,7 @@ export class ActiveTaskExecutionController {
         errorMessage: dto.errorMessage,
       });
 
-      return TaskExecutionHistoryResponseDto.fromEntity(historyEntry);
+      return TaskExecutionHistoryResponseDto.fromResult(historyEntry);
     } catch (error) {
       if (error instanceof ActiveTaskExecutionNotFoundError) {
         throw new NotFoundException(error.message);

--- a/apps/backend/src/executions/active/active-task-execution.service.ts
+++ b/apps/backend/src/executions/active/active-task-execution.service.ts
@@ -25,6 +25,12 @@ import {
 import { ExecutionActivityService } from '../execution-activity.service';
 import { ExecutionInterruptEvent } from '../events/execution-interrupt.event';
 import { ExecutionStatsEntity } from '../stats/execution-stats.entity';
+import {
+  ActiveTaskExecutionListResult,
+  ActiveTaskExecutionResult,
+  ExecutionStatsResult,
+  TaskExecutionHistoryResult,
+} from '../dto/service/execution-results.service.types';
 
 export type ClaimTaskExecutionInput = {
   taskId: string;
@@ -81,12 +87,7 @@ export class ActiveTaskExecutionService {
     page?: number;
     limit?: number;
     taskId?: string;
-  }): Promise<{
-    items: ActiveTaskExecutionEntity[];
-    total: number;
-    page: number;
-    limit: number;
-  }> {
+  }): Promise<ActiveTaskExecutionListResult> {
     const page = options?.page ?? 1;
     const limit = options?.limit ?? 50;
     const skip = (page - 1) * limit;
@@ -101,12 +102,17 @@ export class ActiveTaskExecutionService {
       take: limit,
     });
 
-    return { items, total, page, limit };
+    return {
+      items: items.map((item) => this.mapActiveExecutionToResult(item)),
+      total,
+      page,
+      limit,
+    };
   }
 
   async claimTask(
     input: ClaimTaskExecutionInput,
-  ): Promise<ActiveTaskExecutionEntity> {
+  ): Promise<ActiveTaskExecutionResult> {
     const execution = await this.dataSource.transaction(async (manager) => {
       const task = await manager.findOne(TaskEntity, {
         where: { id: input.taskId },
@@ -194,12 +200,12 @@ export class ActiveTaskExecutionService {
       message: 'Execution started',
     });
 
-    return execution;
+    return this.mapActiveExecutionToResult(execution);
   }
 
   async stopTask(
     input: StopTaskExecutionInput,
-  ): Promise<TaskExecutionHistoryEntity> {
+  ): Promise<TaskExecutionHistoryResult> {
     const historyEntry = await this.dataSource.transaction(async (manager) => {
       const activeExecution = await manager.findOne(ActiveTaskExecutionEntity, {
         where: { id: input.executionId },
@@ -262,7 +268,7 @@ export class ActiveTaskExecutionService {
       message: `Execution history recorded (${historyEntry.status.toLowerCase()})`,
     });
 
-    return historyEntry;
+    return this.mapHistoryEntryToResult(historyEntry);
   }
 
   async unclaimTask(input: UnclaimTaskExecutionInput): Promise<void> {
@@ -420,5 +426,61 @@ export class ActiveTaskExecutionService {
       kind: 'execution.interrupt.requested',
       message: 'Execution interrupt requested',
     });
+  }
+
+  private mapActiveExecutionToResult(
+    execution: ActiveTaskExecutionEntity,
+  ): ActiveTaskExecutionResult {
+    return {
+      id: execution.id,
+      taskId: execution.taskId,
+      taskName: execution.task?.name ?? null,
+      taskStatus: execution.task?.status ?? null,
+      claimedAt: execution.claimedAt,
+      lastHeartbeatAt: execution.lastHeartbeatAt,
+      runnerSessionId: execution.runnerSessionId,
+      toolCallCount: execution.toolCallCount,
+      taskStatusBeforeClaim: execution.taskStatusBeforeClaim,
+      taskTagsBeforeClaim: execution.taskTagsBeforeClaim.map((tag) => ({
+        id: tag.id,
+        name: tag.name,
+      })),
+      workerClientId: execution.workerClientId,
+      taskAssigneeActorIdBeforeClaim: execution.taskAssigneeActorIdBeforeClaim,
+      agentActorId: execution.agentActorId,
+      stats: execution.stats ? this.mapStatsToResult(execution.stats) : null,
+    };
+  }
+
+  private mapHistoryEntryToResult(
+    historyEntry: TaskExecutionHistoryEntity,
+  ): TaskExecutionHistoryResult {
+    return {
+      id: historyEntry.id,
+      taskId: historyEntry.taskId,
+      taskName: historyEntry.task?.name ?? null,
+      taskStatus: historyEntry.task?.status ?? null,
+      claimedAt: historyEntry.claimedAt,
+      transitionedAt: historyEntry.transitionedAt,
+      agentActorId: historyEntry.agentActorId,
+      workerClientId: historyEntry.workerClientId,
+      runnerSessionId: historyEntry.runnerSessionId,
+      toolCallCount: historyEntry.toolCallCount,
+      status: historyEntry.status,
+      errorCode: historyEntry.errorCode,
+      errorMessage: historyEntry.errorMessage,
+      stats: historyEntry.stats ? this.mapStatsToResult(historyEntry.stats) : null,
+    };
+  }
+
+  private mapStatsToResult(stats: ExecutionStatsEntity): ExecutionStatsResult {
+    return {
+      harness: stats.harness,
+      providerId: stats.providerId,
+      modelId: stats.modelId,
+      inputTokens: stats.inputTokens,
+      outputTokens: stats.outputTokens,
+      totalTokens: stats.totalTokens,
+    };
   }
 }

--- a/apps/backend/src/executions/active/dto/http/active-task-execution-response.dto.ts
+++ b/apps/backend/src/executions/active/dto/http/active-task-execution-response.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { TaskStatus } from '../../../../tasks/enums';
 import {
-  ActiveTaskExecutionEntity,
-  type ActiveTaskExecutionTagSnapshot,
-} from '../../active-task-execution.entity';
+  ActiveTaskExecutionResult,
+  ActiveTaskExecutionTagSnapshotResult,
+} from '../../../dto/service/execution-results.service.types';
 import { ExecutionStatsResponseDto } from '../../../dto/http/execution-stats-response.dto';
 
 class ActiveTaskExecutionTagSnapshotResponseDto {
@@ -20,7 +20,7 @@ class ActiveTaskExecutionTagSnapshotResponseDto {
   name!: string;
 
   static fromSnapshot(
-    snapshot: ActiveTaskExecutionTagSnapshot,
+    snapshot: ActiveTaskExecutionTagSnapshotResult,
   ): ActiveTaskExecutionTagSnapshotResponseDto {
     return {
       id: snapshot.id,
@@ -124,26 +124,26 @@ export class ActiveTaskExecutionResponseDto {
   })
   stats!: ExecutionStatsResponseDto | null;
 
-  static fromEntity(
-    entity: ActiveTaskExecutionEntity,
+  static fromResult(
+    result: ActiveTaskExecutionResult,
   ): ActiveTaskExecutionResponseDto {
     return {
-      id: entity.id,
-      taskId: entity.taskId,
-      taskName: entity.task?.name ?? null,
-      taskStatus: entity.task?.status ?? null,
-      claimedAt: entity.claimedAt.toISOString(),
-      lastHeartbeatAt: entity.lastHeartbeatAt?.toISOString() ?? null,
-      runnerSessionId: entity.runnerSessionId,
-      toolCallCount: entity.toolCallCount,
-      taskStatusBeforeClaim: entity.taskStatusBeforeClaim,
-      taskTagsBeforeClaim: entity.taskTagsBeforeClaim.map((tag) =>
+      id: result.id,
+      taskId: result.taskId,
+      taskName: result.taskName,
+      taskStatus: result.taskStatus,
+      claimedAt: result.claimedAt.toISOString(),
+      lastHeartbeatAt: result.lastHeartbeatAt?.toISOString() ?? null,
+      runnerSessionId: result.runnerSessionId,
+      toolCallCount: result.toolCallCount,
+      taskStatusBeforeClaim: result.taskStatusBeforeClaim,
+      taskTagsBeforeClaim: result.taskTagsBeforeClaim.map((tag) =>
         ActiveTaskExecutionTagSnapshotResponseDto.fromSnapshot(tag),
       ),
-      workerClientId: entity.workerClientId,
-      taskAssigneeActorIdBeforeClaim: entity.taskAssigneeActorIdBeforeClaim,
-      agentActorId: entity.agentActorId,
-      stats: entity.stats ? ExecutionStatsResponseDto.fromEntity(entity.stats) : null,
+      workerClientId: result.workerClientId,
+      taskAssigneeActorIdBeforeClaim: result.taskAssigneeActorIdBeforeClaim,
+      agentActorId: result.agentActorId,
+      stats: result.stats ? ExecutionStatsResponseDto.fromResult(result.stats) : null,
     };
   }
 }

--- a/apps/backend/src/executions/dto/http/execution-stats-response.dto.ts
+++ b/apps/backend/src/executions/dto/http/execution-stats-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { ExecutionStatsEntity } from '../../stats/execution-stats.entity';
+import { ExecutionStatsResult } from '../service/execution-results.service.types';
 
 export class ExecutionStatsResponseDto {
   @ApiProperty({
@@ -50,14 +50,14 @@ export class ExecutionStatsResponseDto {
   })
   totalTokens!: number | null;
 
-  static fromEntity(entity: ExecutionStatsEntity): ExecutionStatsResponseDto {
+  static fromResult(result: ExecutionStatsResult): ExecutionStatsResponseDto {
     return {
-      harness: entity.harness,
-      providerId: entity.providerId,
-      modelId: entity.modelId,
-      inputTokens: entity.inputTokens,
-      outputTokens: entity.outputTokens,
-      totalTokens: entity.totalTokens,
+      harness: result.harness,
+      providerId: result.providerId,
+      modelId: result.modelId,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      totalTokens: result.totalTokens,
     };
   }
 }

--- a/apps/backend/src/executions/dto/service/execution-results.service.types.ts
+++ b/apps/backend/src/executions/dto/service/execution-results.service.types.ts
@@ -1,0 +1,78 @@
+import { TaskStatus } from '../../../tasks/enums';
+import { TaskExecutionHistoryErrorCode } from '../../history/task-execution-history-error-code.enum';
+import { TaskExecutionHistoryStatus } from '../../history/task-execution-history-status.enum';
+
+export type ExecutionStatsResult = {
+  harness: string | null;
+  providerId: string | null;
+  modelId: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  totalTokens: number | null;
+};
+
+export type TaskExecutionQueueEntryResult = {
+  taskId: string;
+  taskName: string | null;
+  taskStatus: TaskStatus | null;
+};
+
+export type TaskExecutionQueueListResult = {
+  items: TaskExecutionQueueEntryResult[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type ActiveTaskExecutionTagSnapshotResult = {
+  id: string;
+  name: string;
+};
+
+export type ActiveTaskExecutionResult = {
+  id: string;
+  taskId: string;
+  taskName: string | null;
+  taskStatus: TaskStatus | null;
+  claimedAt: Date;
+  lastHeartbeatAt: Date | null;
+  runnerSessionId: string | null;
+  toolCallCount: number;
+  taskStatusBeforeClaim: TaskStatus;
+  taskTagsBeforeClaim: ActiveTaskExecutionTagSnapshotResult[];
+  workerClientId: string;
+  taskAssigneeActorIdBeforeClaim: string | null;
+  agentActorId: string;
+  stats: ExecutionStatsResult | null;
+};
+
+export type ActiveTaskExecutionListResult = {
+  items: ActiveTaskExecutionResult[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type TaskExecutionHistoryResult = {
+  id: string;
+  taskId: string;
+  taskName: string | null;
+  taskStatus: TaskStatus | null;
+  claimedAt: Date;
+  transitionedAt: Date;
+  agentActorId: string;
+  workerClientId: string;
+  runnerSessionId: string | null;
+  toolCallCount: number;
+  status: TaskExecutionHistoryStatus;
+  errorCode: TaskExecutionHistoryErrorCode | null;
+  errorMessage: string | null;
+  stats: ExecutionStatsResult | null;
+};
+
+export type TaskExecutionHistoryListResult = {
+  items: TaskExecutionHistoryResult[];
+  total: number;
+  page: number;
+  limit: number;
+};

--- a/apps/backend/src/executions/history/dto/http/task-execution-history-response.dto.ts
+++ b/apps/backend/src/executions/history/dto/http/task-execution-history-response.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { TaskStatus } from '../../../../tasks/enums';
-import { TaskExecutionHistoryEntity } from '../../task-execution-history.entity';
 import { TaskExecutionHistoryErrorCode } from '../../task-execution-history-error-code.enum';
 import { TaskExecutionHistoryStatus } from '../../task-execution-history-status.enum';
 import { ExecutionStatsResponseDto } from '../../../dto/http/execution-stats-response.dto';
+import { TaskExecutionHistoryResult } from '../../../dto/service/execution-results.service.types';
 
 export class TaskExecutionHistoryResponseDto {
   @ApiProperty({
@@ -99,24 +99,24 @@ export class TaskExecutionHistoryResponseDto {
   })
   stats!: ExecutionStatsResponseDto | null;
 
-  static fromEntity(
-    entity: TaskExecutionHistoryEntity,
+  static fromResult(
+    result: TaskExecutionHistoryResult,
   ): TaskExecutionHistoryResponseDto {
     return {
-      id: entity.id,
-      taskId: entity.taskId,
-      taskName: entity.task?.name ?? null,
-      taskStatus: entity.task?.status ?? null,
-      claimedAt: entity.claimedAt.toISOString(),
-      transitionedAt: entity.transitionedAt.toISOString(),
-      agentActorId: entity.agentActorId,
-      workerClientId: entity.workerClientId,
-      runnerSessionId: entity.runnerSessionId,
-      toolCallCount: entity.toolCallCount,
-      status: entity.status,
-      errorCode: entity.errorCode,
-      errorMessage: entity.errorMessage,
-      stats: entity.stats ? ExecutionStatsResponseDto.fromEntity(entity.stats) : null,
+      id: result.id,
+      taskId: result.taskId,
+      taskName: result.taskName,
+      taskStatus: result.taskStatus,
+      claimedAt: result.claimedAt.toISOString(),
+      transitionedAt: result.transitionedAt.toISOString(),
+      agentActorId: result.agentActorId,
+      workerClientId: result.workerClientId,
+      runnerSessionId: result.runnerSessionId,
+      toolCallCount: result.toolCallCount,
+      status: result.status,
+      errorCode: result.errorCode,
+      errorMessage: result.errorMessage,
+      stats: result.stats ? ExecutionStatsResponseDto.fromResult(result.stats) : null,
     };
   }
 }

--- a/apps/backend/src/executions/history/task-execution-history.controller.ts
+++ b/apps/backend/src/executions/history/task-execution-history.controller.ts
@@ -42,7 +42,7 @@ export class TaskExecutionHistoryController {
 
     return {
       items: result.items.map((item) =>
-        TaskExecutionHistoryResponseDto.fromEntity(item),
+        TaskExecutionHistoryResponseDto.fromResult(item),
       ),
       total: result.total,
       page: result.page,

--- a/apps/backend/src/executions/history/task-execution-history.service.ts
+++ b/apps/backend/src/executions/history/task-execution-history.service.ts
@@ -2,6 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TaskExecutionHistoryEntity } from './task-execution-history.entity';
+import {
+  ExecutionStatsResult,
+  TaskExecutionHistoryListResult,
+  TaskExecutionHistoryResult,
+} from '../dto/service/execution-results.service.types';
+import { ExecutionStatsEntity } from '../stats/execution-stats.entity';
 
 @Injectable()
 export class TaskExecutionHistoryService {
@@ -14,12 +20,7 @@ export class TaskExecutionHistoryService {
     page?: number;
     limit?: number;
     taskId?: string;
-  }): Promise<{
-    items: TaskExecutionHistoryEntity[];
-    total: number;
-    page: number;
-    limit: number;
-  }> {
+  }): Promise<TaskExecutionHistoryListResult> {
     const page = options?.page ?? 1;
     const limit = options?.limit ?? 50;
     const skip = (page - 1) * limit;
@@ -34,7 +35,12 @@ export class TaskExecutionHistoryService {
       take: limit,
     });
 
-    return { items, total, page, limit };
+    return {
+      items: items.map((item) => this.mapHistoryEntryToResult(item)),
+      total,
+      page,
+      limit,
+    };
   }
 
   async getLatestHistoryForTask(
@@ -68,5 +74,37 @@ export class TaskExecutionHistoryService {
     }
 
     return count;
+  }
+
+  private mapHistoryEntryToResult(
+    historyEntry: TaskExecutionHistoryEntity,
+  ): TaskExecutionHistoryResult {
+    return {
+      id: historyEntry.id,
+      taskId: historyEntry.taskId,
+      taskName: historyEntry.task?.name ?? null,
+      taskStatus: historyEntry.task?.status ?? null,
+      claimedAt: historyEntry.claimedAt,
+      transitionedAt: historyEntry.transitionedAt,
+      agentActorId: historyEntry.agentActorId,
+      workerClientId: historyEntry.workerClientId,
+      runnerSessionId: historyEntry.runnerSessionId,
+      toolCallCount: historyEntry.toolCallCount,
+      status: historyEntry.status,
+      errorCode: historyEntry.errorCode,
+      errorMessage: historyEntry.errorMessage,
+      stats: historyEntry.stats ? this.mapStatsToResult(historyEntry.stats) : null,
+    };
+  }
+
+  private mapStatsToResult(stats: ExecutionStatsEntity): ExecutionStatsResult {
+    return {
+      harness: stats.harness,
+      providerId: stats.providerId,
+      modelId: stats.modelId,
+      inputTokens: stats.inputTokens,
+      outputTokens: stats.outputTokens,
+      totalTokens: stats.totalTokens,
+    };
   }
 }

--- a/apps/backend/src/executions/queue/dto/http/task-execution-queue-entry-response.dto.ts
+++ b/apps/backend/src/executions/queue/dto/http/task-execution-queue-entry-response.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { TaskStatus } from '../../../../tasks/enums';
-import { TaskExecutionQueueEntity } from '../../task-execution-queue.entity';
 
 export class TaskExecutionQueueEntryResponseDto {
   @ApiProperty({
@@ -23,14 +22,4 @@ export class TaskExecutionQueueEntryResponseDto {
     nullable: true,
   })
   taskStatus!: TaskStatus | null;
-
-  static fromEntity(
-    entity: TaskExecutionQueueEntity,
-  ): TaskExecutionQueueEntryResponseDto {
-    return {
-      taskId: entity.taskId,
-      taskName: entity.task?.name ?? null,
-      taskStatus: entity.task?.status ?? null,
-    };
-  }
 }

--- a/apps/backend/src/executions/queue/task-execution-queue.controller.ts
+++ b/apps/backend/src/executions/queue/task-execution-queue.controller.ts
@@ -34,6 +34,7 @@ import { TaskExecutionQueueService } from './task-execution-queue.service';
 import { TaskExecutionQueueEntryResponseDto } from './dto/http/task-execution-queue-entry-response.dto';
 import { TaskExecutionQueueListResponseDto } from './dto/http/task-execution-queue-list-response.dto';
 import { ListQueueQueryDto } from './dto/http/list-queue-query.dto';
+import { TaskExecutionQueueEntryResult } from '../dto/service/execution-results.service.types';
 
 @ApiTags('Executions')
 @ApiCookieAuth('JWT-Cookie')
@@ -63,9 +64,7 @@ export class TaskExecutionQueueController {
     });
 
     return {
-      items: result.items.map((item) =>
-        TaskExecutionQueueEntryResponseDto.fromEntity(item),
-      ),
+      items: result.items.map((item) => this.mapQueueEntryToResponse(item)),
       total: result.total,
       page: result.page,
       limit: result.limit,
@@ -92,7 +91,7 @@ export class TaskExecutionQueueController {
         workerClientId: auth.claims.client_id,
       });
 
-      return ActiveTaskExecutionResponseDto.fromEntity(execution);
+      return ActiveTaskExecutionResponseDto.fromResult(execution);
     } catch (error) {
       if (error instanceof TaskNotFoundError) {
         throw new NotFoundException(error.message);
@@ -108,5 +107,15 @@ export class TaskExecutionQueueController {
 
       throw error;
     }
+  }
+
+  private mapQueueEntryToResponse(
+    entry: TaskExecutionQueueEntryResult,
+  ): TaskExecutionQueueEntryResponseDto {
+    return {
+      taskId: entry.taskId,
+      taskName: entry.taskName,
+      taskStatus: entry.taskStatus,
+    };
   }
 }

--- a/apps/backend/src/executions/queue/task-execution-queue.service.ts
+++ b/apps/backend/src/executions/queue/task-execution-queue.service.ts
@@ -2,6 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TaskExecutionQueueEntity } from './task-execution-queue.entity';
+import {
+  TaskExecutionQueueEntryResult,
+  TaskExecutionQueueListResult,
+} from '../dto/service/execution-results.service.types';
 
 @Injectable()
 export class TaskExecutionQueueService {
@@ -13,12 +17,7 @@ export class TaskExecutionQueueService {
   async listQueue(options?: {
     page?: number;
     limit?: number;
-  }): Promise<{
-    items: TaskExecutionQueueEntity[];
-    total: number;
-    page: number;
-    limit: number;
-  }> {
+  }): Promise<TaskExecutionQueueListResult> {
     const page = options?.page ?? 1;
     const limit = options?.limit ?? 50;
     const skip = (page - 1) * limit;
@@ -30,6 +29,21 @@ export class TaskExecutionQueueService {
       take: limit,
     });
 
-    return { items, total, page, limit };
+    return {
+      items: items.map((item) => this.mapQueueEntryToResult(item)),
+      total,
+      page,
+      limit,
+    };
+  }
+
+  private mapQueueEntryToResult(
+    entry: TaskExecutionQueueEntity,
+  ): TaskExecutionQueueEntryResult {
+    return {
+      taskId: entry.taskId,
+      taskName: entry.task?.name ?? null,
+      taskStatus: entry.task?.status ?? null,
+    };
   }
 }

--- a/apps/backend/src/workers/dto/http/worker-response.dto.ts
+++ b/apps/backend/src/workers/dto/http/worker-response.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AgentType } from 'src/agents/enums';
-import { WorkerEntity } from '../../worker.entity';
 
 export class WorkerResponseDto {
   @ApiProperty({ format: 'uuid' })
@@ -20,15 +19,4 @@ export class WorkerResponseDto {
 
   @ApiProperty({ format: 'date-time' })
   updatedAt!: string;
-
-  static fromEntity(entity: WorkerEntity): WorkerResponseDto {
-    return {
-      id: entity.id,
-      oauthClientId: entity.oauthClientId,
-      lastSeenAt: entity.lastSeenAt.toISOString(),
-      harnesses: entity.harnesses,
-      createdAt: entity.createdAt.toISOString(),
-      updatedAt: entity.updatedAt.toISOString(),
-    };
-  }
 }

--- a/apps/backend/src/workers/dto/service/workers.service.types.ts
+++ b/apps/backend/src/workers/dto/service/workers.service.types.ts
@@ -5,3 +5,12 @@ export type RecordWorkerSeenInput = {
   seenAt?: Date;
   harnesses?: AgentType[];
 };
+
+export type WorkerResult = {
+  id: string;
+  oauthClientId: string;
+  lastSeenAt: Date;
+  harnesses: AgentType[];
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/apps/backend/src/workers/workers.controller.ts
+++ b/apps/backend/src/workers/workers.controller.ts
@@ -6,6 +6,7 @@ import { AccessTokenGuard } from 'src/auth/guards/guards/access-token.guard';
 import { ScopesGuard } from 'src/auth/guards/guards/scopes.guard';
 import { RequireScopes } from 'src/auth/guards/decorators/require-scopes.decorator';
 import { WorkersScopes } from 'src/executions/workers.scopes';
+import { WorkerResult } from './dto/service/workers.service.types';
 
 @ApiTags('workers')
 @UseGuards(AccessTokenGuard, ScopesGuard)
@@ -23,6 +24,17 @@ export class WorkersController {
   })
   async listWorkers(): Promise<WorkerResponseDto[]> {
     const workers = await this.workersService.findAll();
-    return workers.map((worker) => WorkerResponseDto.fromEntity(worker));
+    return workers.map((worker) => this.mapWorkerToResponse(worker));
+  }
+
+  private mapWorkerToResponse(worker: WorkerResult): WorkerResponseDto {
+    return {
+      id: worker.id,
+      oauthClientId: worker.oauthClientId,
+      lastSeenAt: worker.lastSeenAt.toISOString(),
+      harnesses: worker.harnesses,
+      createdAt: worker.createdAt.toISOString(),
+      updatedAt: worker.updatedAt.toISOString(),
+    };
   }
 }

--- a/apps/backend/src/workers/workers.gateway.ts
+++ b/apps/backend/src/workers/workers.gateway.ts
@@ -74,7 +74,14 @@ export class WorkersGateway
 
   @OnEvent(WorkerSeenEvent.INTERNAL)
   handleWorkerSeen(event: WorkerSeenEvent) {
-    const dto = WorkerResponseDto.fromEntity(event.payload);
+    const dto: WorkerResponseDto = {
+      id: event.payload.id,
+      oauthClientId: event.payload.oauthClientId,
+      lastSeenAt: event.payload.lastSeenAt.toISOString(),
+      harnesses: event.payload.harnesses,
+      createdAt: event.payload.createdAt.toISOString(),
+      updatedAt: event.payload.updatedAt.toISOString(),
+    };
     const wireEvent: WorkerSeenWireEvent = {
       worker: dto,
       occurredAt: event.occurredAt.toISOString(),

--- a/apps/backend/src/workers/workers.service.ts
+++ b/apps/backend/src/workers/workers.service.ts
@@ -3,7 +3,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { WorkerEntity } from './worker.entity';
-import { RecordWorkerSeenInput } from './dto/service/workers.service.types';
+import {
+  RecordWorkerSeenInput,
+  WorkerResult,
+} from './dto/service/workers.service.types';
 import { WorkerSeenEvent } from './events/workers.events';
 
 @Injectable()
@@ -14,12 +17,14 @@ export class WorkersService {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
-  async findAll(): Promise<WorkerEntity[]> {
-    return this.workersRepository.find({
+  async findAll(): Promise<WorkerResult[]> {
+    const workers = await this.workersRepository.find({
       order: {
         lastSeenAt: 'DESC',
       },
     });
+
+    return workers.map((worker) => this.mapWorkerToResult(worker));
   }
 
   async recordWorkerSeen(input: RecordWorkerSeenInput): Promise<WorkerEntity> {
@@ -59,5 +64,16 @@ export class WorkersService {
     );
 
     return savedWorker;
+  }
+
+  private mapWorkerToResult(worker: WorkerEntity): WorkerResult {
+    return {
+      id: worker.id,
+      oauthClientId: worker.oauthClientId,
+      lastSeenAt: worker.lastSeenAt,
+      harnesses: worker.harnesses,
+      createdAt: worker.createdAt,
+      updatedAt: worker.updatedAt,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- Added transport-agnostic service result types for worker, execution, client registration, and auth journey controller responses.
- Moved entity-to-result mapping into services so controllers map service results to response DTOs without importing entities.
- Removed execution/worker HTTP DTO dependencies on persistence entities where those DTOs were used by controllers.

## Validation
- npm run build:dev
- npm run dev:1, observed backend startup on http://localhost:2003; expected AppInitRunner prompt context block error appeared during startup.

## Technical Debt
- Several older DTOs outside the touched controller paths still expose `fromEntity` helpers. I left them unchanged to keep this PR focused on controller boundary violations found during the review.