### PR TITLE
Add version display to settings page

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -154,6 +154,33 @@
         ]
       }
     },
+    "/api/v1/meta/version": {
+      "get": {
+        "operationId": "MetaController_getVersion",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Version information for backend and UI",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Get version information",
+        "tags": [
+          "Meta"
+        ]
+      }
+    },
     "/api/v1/meta/projects": {
       "post": {
         "operationId": "ProjectsController_createProject",
@@ -7186,6 +7213,25 @@
           "name",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "VersionResponseDto": {
+        "type": "object",
+        "properties": {
+          "backend": {
+            "type": "string",
+            "description": "Backend version",
+            "example": "0.2.16"
+          },
+          "ui": {
+            "type": "string",
+            "description": "UI version",
+            "example": "0.2.16"
+          }
+        },
+        "required": [
+          "backend",
+          "ui"
         ]
       },
       "CreateProjectDto": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "nest build",
     "build:prod": "npm run build && NODE_ENV=development node dist/main.js --generate-openapi",
-    "assemble-public": "rm -rf dist/public && mkdir -p dist && cp -R ../ui/dist dist/public && cp -R ../ui-v1/dist dist/public/beta",
+    "assemble-public": "rm -rf dist/public && mkdir -p dist && cp -R ../ui/dist dist/public && cp ../ui/package.json dist/public/ && cp -R ../ui-v1/dist dist/public/beta",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch -- --server",

--- a/apps/backend/src/meta/dto/service/meta.service.types.ts
+++ b/apps/backend/src/meta/dto/service/meta.service.types.ts
@@ -17,3 +17,8 @@ export type TagResult = {
   createdAt: Date;
   updatedAt: Date;
 };
+
+export type VersionResult = {
+  backend: string;
+  ui: string;
+};

--- a/apps/backend/src/meta/dto/version-response.dto.ts
+++ b/apps/backend/src/meta/dto/version-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VersionResponseDto {
+  @ApiProperty({
+    description: 'Backend version',
+    example: '0.2.16',
+  })
+  backend!: string;
+
+  @ApiProperty({
+    description: 'UI version',
+    example: '0.2.16',
+  })
+  ui!: string;
+}

--- a/apps/backend/src/meta/meta.controller.ts
+++ b/apps/backend/src/meta/meta.controller.ts
@@ -22,7 +22,8 @@ import {
 import { MetaService, TAG_COLOR_PALETTE } from './meta.service';
 import { CreateTagDto } from './dto/create-tag.dto';
 import { MetaTagResponseDto } from './dto/tag-response.dto';
-import { TagResult } from './dto/service/meta.service.types';
+import { VersionResponseDto } from './dto/version-response.dto';
+import { TagResult, VersionResult } from './dto/service/meta.service.types';
 import { AccessTokenGuard } from '../auth/guards/guards/access-token.guard';
 import { ScopesGuard } from '../auth/guards/guards/scopes.guard';
 import { RequireScopes } from '../auth/guards/decorators/require-scopes.decorator';
@@ -82,6 +83,17 @@ export class MetaController {
     await this.metaService.deleteTag(tagId);
   }
 
+  @Get('version')
+  @ApiOperation({ summary: 'Get version information' })
+  @ApiOkResponse({
+    type: VersionResponseDto,
+    description: 'Version information for backend and UI',
+  })
+  getVersion(): VersionResponseDto {
+    const result = this.metaService.getVersion();
+    return this.mapVersionResultToResponse(result);
+  }
+
   private mapTagResultToResponse(result: TagResult): MetaTagResponseDto {
     return {
       id: result.id,
@@ -89,6 +101,13 @@ export class MetaController {
       color: result.color,
       createdAt: result.createdAt.toISOString(),
       updatedAt: result.updatedAt.toISOString(),
+    };
+  }
+
+  private mapVersionResultToResponse(result: VersionResult): VersionResponseDto {
+    return {
+      backend: result.backend,
+      ui: result.ui,
     };
   }
 }

--- a/apps/backend/src/meta/meta.service.ts
+++ b/apps/backend/src/meta/meta.service.ts
@@ -483,18 +483,19 @@ export class MetaService {
 
       // Read UI version from UI package.json
       // Path depends on whether we're in dev or prod:
-      // - Dev: ../ui/package.json
-      // - Prod: We'll copy it during build to dist/public/package.json
+      // - Prod (running from dist/meta): __dirname is dist/meta, so ../public/package.json resolves to dist/public/package.json
+      // - Dev (running from src/meta): __dirname is src/meta, so ../../ui/package.json resolves to apps/ui/package.json
       let uiVersion = backendVersion; // Fallback to backend version
 
       try {
-        const uiPackageJsonPath = join(__dirname, '../../public/package.json');
+        // First try production path (dist/public/package.json)
+        const uiPackageJsonPath = join(__dirname, '../public/package.json');
         const uiPackageJson = JSON.parse(
           readFileSync(uiPackageJsonPath, 'utf-8'),
         );
         uiVersion = uiPackageJson.version;
       } catch {
-        // If UI package.json is not found, try development path
+        // If not found, try development path
         try {
           const uiDevPackageJsonPath = join(__dirname, '../../../ui/package.json');
           const uiPackageJson = JSON.parse(

--- a/apps/backend/src/meta/meta.service.ts
+++ b/apps/backend/src/meta/meta.service.ts
@@ -2,10 +2,12 @@ import { Injectable, Logger, forwardRef, Inject } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { TagEntity } from './tag.entity';
 import { TagUsageEntity } from './tag-usage.entity';
 import { ProjectEntity } from './project.entity';
-import { CreateTagInput, TagResult } from './dto/service/meta.service.types';
+import { CreateTagInput, TagResult, VersionResult } from './dto/service/meta.service.types';
 
 /**
  * Predefined color palette for tags
@@ -461,6 +463,60 @@ export class MetaService {
 
     for (const tagId of tagIds) {
       await this.incrementTagUsage(tagId);
+    }
+  }
+
+  /**
+   * Get version information for backend and UI
+   */
+  getVersion(): VersionResult {
+    this.logger.log({ message: 'Getting version information' });
+
+    try {
+      // Read backend version from package.json
+      // In production (dist), this will be at dist/package.json (copied during build)
+      // In development, this will be at src/../package.json
+      const backendPackageJson = JSON.parse(
+        readFileSync(join(__dirname, '../../package.json'), 'utf-8'),
+      );
+      const backendVersion = backendPackageJson.version;
+
+      // Read UI version from UI package.json
+      // Path depends on whether we're in dev or prod:
+      // - Dev: ../ui/package.json
+      // - Prod: We'll copy it during build to dist/public/package.json
+      let uiVersion = backendVersion; // Fallback to backend version
+
+      try {
+        const uiPackageJsonPath = join(__dirname, '../../public/package.json');
+        const uiPackageJson = JSON.parse(
+          readFileSync(uiPackageJsonPath, 'utf-8'),
+        );
+        uiVersion = uiPackageJson.version;
+      } catch {
+        // If UI package.json is not found, try development path
+        try {
+          const uiDevPackageJsonPath = join(__dirname, '../../../ui/package.json');
+          const uiPackageJson = JSON.parse(
+            readFileSync(uiDevPackageJsonPath, 'utf-8'),
+          );
+          uiVersion = uiPackageJson.version;
+        } catch {
+          // If still not found, use backend version as fallback
+          this.logger.warn('Could not read UI package.json, using backend version as fallback');
+        }
+      }
+
+      return {
+        backend: backendVersion,
+        ui: uiVersion,
+      };
+    } catch (error) {
+      this.logger.error('Error reading version information', error);
+      return {
+        backend: 'unknown',
+        ui: 'unknown',
+      };
     }
   }
 

--- a/apps/ui/src/features/home/SettingsPage.tsx
+++ b/apps/ui/src/features/home/SettingsPage.tsx
@@ -1,23 +1,35 @@
 import { Stack, Text, Card, Row, Button } from '../../ui/primitives';
 import { useHomeCtx } from './HomeProvider';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useIsDesktop } from '../../app/hooks/useIsDesktop';
 import { useDocumentTitle } from '../../shared/hooks/useDocumentTitle';
 import { useNavigate } from 'react-router-dom';
 import { useCommandPalette } from '../../ui/components';
+import { MetaService } from '@taico/client';
 
 export function SettingsPage() {
   const { setSectionTitle } = useHomeCtx();
   const isDesktop = useIsDesktop();
   const navigate = useNavigate();
   const { registerCommands } = useCommandPalette();
+  const [version, setVersion] = useState<{ backend: string; ui: string } | null>(null);
 
   // Set document title (browser tab)
   useDocumentTitle();
 
   useEffect(() => {
     setSectionTitle('Settings');
+    loadVersion();
   }, []);
+
+  const loadVersion = async () => {
+    try {
+      const versionData = await MetaService.metaControllerGetVersion();
+      setVersion(versionData);
+    } catch (error) {
+      console.error('Failed to load version:', error);
+    }
+  };
 
   // Register page-specific commands
   useEffect(() => {
@@ -233,6 +245,22 @@ export function SettingsPage() {
           </Row>
         </Stack>
       </Card>
+
+      {version && (
+        <Card padding="5">
+          <Stack spacing="2">
+            <Text size="4" weight="semibold">Version</Text>
+            <Row justify="space-between" align="center">
+              <Text size="2" tone="muted">Backend</Text>
+              <Text size="2">{version.backend}</Text>
+            </Row>
+            <Row justify="space-between" align="center">
+              <Text size="2" tone="muted">UI</Text>
+              <Text size="2">{version.ui}</Text>
+            </Row>
+          </Stack>
+        </Card>
+      )}
     </Stack>
   );
 }

--- a/apps/ui/src/features/home/SettingsPage.tsx
+++ b/apps/ui/src/features/home/SettingsPage.tsx
@@ -247,19 +247,16 @@ export function SettingsPage() {
       </Card>
 
       {version && (
-        <Card padding="5">
-          <Stack spacing="2">
-            <Text size="4" weight="semibold">Version</Text>
-            <Row justify="space-between" align="center">
-              <Text size="2" tone="muted">Backend</Text>
-              <Text size="2">{version.backend}</Text>
-            </Row>
-            <Row justify="space-between" align="center">
-              <Text size="2" tone="muted">UI</Text>
-              <Text size="2">{version.ui}</Text>
-            </Row>
-          </Stack>
-        </Card>
+        <div style={{
+          textAlign: 'center',
+          paddingTop: 'var(--space-6)',
+          marginTop: 'var(--space-4)',
+          borderTop: '1px solid var(--border)',
+        }}>
+          <Text size="1" tone="muted">
+            Taico v{version.backend} • UI v{version.ui}
+          </Text>
+        </div>
       )}
     </Stack>
   );

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -154,6 +154,33 @@
         ]
       }
     },
+    "/api/v1/meta/version": {
+      "get": {
+        "operationId": "MetaController_getVersion",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Version information for backend and UI",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Get version information",
+        "tags": [
+          "Meta"
+        ]
+      }
+    },
     "/api/v1/meta/projects": {
       "post": {
         "operationId": "ProjectsController_createProject",
@@ -7186,6 +7213,25 @@
           "name",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "VersionResponseDto": {
+        "type": "object",
+        "properties": {
+          "backend": {
+            "type": "string",
+            "description": "Backend version",
+            "example": "0.2.16"
+          },
+          "ui": {
+            "type": "string",
+            "description": "UI version",
+            "example": "0.2.16"
+          }
+        },
+        "required": [
+          "backend",
+          "ui"
         ]
       },
       "CreateProjectDto": {

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -73,6 +73,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/meta/version": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get version information */
+        get: operations["MetaController_getVersion"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/meta/projects": {
         parameters: {
             query?: never;
@@ -2132,6 +2149,18 @@ export interface components {
              * @example 2024-01-15T10:30:00.000Z
              */
             updatedAt: string;
+        };
+        VersionResponseDto: {
+            /**
+             * @description Backend version
+             * @example 0.2.16
+             */
+            backend: string;
+            /**
+             * @description UI version
+             * @example 0.2.16
+             */
+            ui: string;
         };
         CreateProjectDto: {
             /**
@@ -6104,6 +6133,26 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    MetaController_getVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Version information for backend and UI */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VersionResponseDto"];
+                };
             };
         };
     };

--- a/packages/client/src/v1/client/index.ts
+++ b/packages/client/src/v1/client/index.ts
@@ -150,6 +150,7 @@ export type { UpdateThreadStateDto } from './models/UpdateThreadStateDto.js';
 export type { UpsertAgentToolPermissionDto } from './models/UpsertAgentToolPermissionDto.js';
 export { UserResponseDto } from './models/UserResponseDto.js';
 export { UserWalkthroughStatusResponseDto } from './models/UserWalkthroughStatusResponseDto.js';
+export type { VersionResponseDto } from './models/VersionResponseDto.js';
 export type { WorkerResponseDto } from './models/WorkerResponseDto.js';
 
 export { ActorsService } from './services/ActorsService.js';

--- a/packages/client/src/v1/client/models/VersionResponseDto.ts
+++ b/packages/client/src/v1/client/models/VersionResponseDto.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type VersionResponseDto = {
+    /**
+     * Backend version
+     */
+    backend: string;
+    /**
+     * UI version
+     */
+    ui: string;
+};
+

--- a/packages/client/src/v1/client/services/MetaService.ts
+++ b/packages/client/src/v1/client/services/MetaService.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 import type { CreateTagDto } from '../models/CreateTagDto.js';
 import type { MetaTagResponseDto } from '../models/MetaTagResponseDto.js';
+import type { VersionResponseDto } from '../models/VersionResponseDto.js';
 import type { CancelablePromise } from '../core/CancelablePromise.js';
 import { OpenAPI } from '../core/OpenAPI.js';
 import type { OpenAPIConfig } from '../core/OpenAPI.js';
@@ -70,6 +71,17 @@ export class MetaService {
             errors: {
                 404: `Tag not found`,
             },
+        });
+    }
+    /**
+     * Get version information
+     * @returns VersionResponseDto Version information for backend and UI
+     * @throws ApiError
+     */
+    public static metaControllerGetVersion(config: OpenAPIConfig = OpenAPI): CancelablePromise<VersionResponseDto> {
+        return __request(config, {
+            method: 'GET',
+            url: '/api/v1/meta/version',
         });
     }
 }

--- a/packages/client/src/v2/meta-resource.ts
+++ b/packages/client/src/v2/meta-resource.ts
@@ -1,5 +1,5 @@
 import { BaseClient, ClientConfig } from './base-client.js';
-import type { CreateTagDto, MetaTagResponseDto } from './types.js';
+import type { CreateTagDto, MetaTagResponseDto, VersionResponseDto } from './types.js';
 
 export class MetaResource extends BaseClient {
   constructor(config: ClientConfig) {
@@ -24,6 +24,11 @@ export class MetaResource extends BaseClient {
   /** Delete a tag from the system */
   async MetaController_deleteTag(params: { tagId: string; signal?: AbortSignal }): Promise<void> {
     return this.request('DELETE', `/api/v1/meta/tags/${params.tagId}`, { responseType: 'void', signal: params?.signal });
+  }
+
+  /** Get version information */
+  async MetaController_getVersion(params?: { signal?: AbortSignal }): Promise<VersionResponseDto> {
+    return this.request('GET', '/api/v1/meta/version', { signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -13,6 +13,11 @@ export interface MetaTagResponseDto {
   updatedAt: string;
 }
 
+export interface VersionResponseDto {
+  backend: string;
+  ui: string;
+}
+
 export interface CreateProjectDto {
   slug: string;
   description?: string;


### PR DESCRIPTION
## Summary

- Added version information display at the bottom of the settings page
- Shows both backend and UI versions (e.g., "Backend: 0.2.16, UI: 0.2.16")
- New endpoint: `GET /api/v1/meta/version` (requires authentication)

## Implementation Details

### Backend
- Created `GET /api/v1/meta/version` endpoint in MetaController
- Added `VersionResponseDto` and `VersionResult` types
- Implemented `getVersion()` in MetaService that reads from package.json files
- Includes fallback logic for dev (source files) vs prod (dist) environments
- Updated `assemble-public` script to copy UI package.json to dist folder

### Frontend
- Updated SettingsPage to fetch and display version info
- Added version card at the bottom of settings page
- Uses auto-generated client method `MetaService.metaControllerGetVersion()`

## Test plan

- [x] Run `npm run build:dev` - all packages build successfully
- [x] Run `npm run dev` - app starts without errors
- [ ] Navigate to `/settings` and verify version card displays at bottom
- [ ] Verify both backend and UI versions are shown correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)