### PR TITLE
Report worker version

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -11969,6 +11969,12 @@
             "example": "gpt-5.4",
             "nullable": true
           },
+          "workerVersion": {
+            "type": "string",
+            "description": "Taico worker package version used for this run",
+            "example": "0.2.16",
+            "nullable": true
+          },
           "inputTokens": {
             "type": "number",
             "description": "Input token usage when available",
@@ -11992,6 +11998,7 @@
           "harness",
           "providerId",
           "modelId",
+          "workerVersion",
           "inputTokens",
           "outputTokens",
           "totalTokens"
@@ -12337,6 +12344,13 @@
             "example": "gpt-5.4",
             "maxLength": 255
           },
+          "workerVersion": {
+            "type": "string",
+            "nullable": true,
+            "description": "Taico worker package version used for this execution",
+            "example": "0.2.16",
+            "maxLength": 100
+          },
           "inputTokens": {
             "type": "number",
             "nullable": true,
@@ -12409,6 +12423,11 @@
           "oauthClientId": {
             "type": "string"
           },
+          "workerVersion": {
+            "type": "string",
+            "nullable": true,
+            "example": "0.2.16"
+          },
           "lastSeenAt": {
             "type": "string",
             "format": "date-time"
@@ -12439,6 +12458,7 @@
         "required": [
           "id",
           "oauthClientId",
+          "workerVersion",
           "lastSeenAt",
           "harnesses",
           "createdAt",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -44,6 +44,7 @@ import { AddWorkersTable1742300000000 } from './migrations/1742300000000-AddWork
 import { RenameHasSeenWalkthroughToOnboardingDisplayMode1742400000000 } from './migrations/1742400000000-RenameHasSeenWalkthroughToOnboardingDisplayMode';
 import { AllowInterruptedExecutionErrorCode1742500000000 } from './migrations/1742500000000-AllowInterruptedExecutionErrorCode';
 import { AddExecutionStatsTable1742600000000 } from './migrations/1742600000000-AddExecutionStatsTable';
+import { AddWorkerVersionFields1742700000000 } from './migrations/1742700000000-AddWorkerVersionFields';
 import { SecretsModule } from './secrets/secrets.module';
 import { ChatProvidersModule } from './chat-providers/chat-providers.module';
 import { ExecutionsModule } from './executions/executions.module';
@@ -86,6 +87,7 @@ import { WalkthroughModule } from './walkthrough/walkthrough.module';
         RenameHasSeenWalkthroughToOnboardingDisplayMode1742400000000,
         AllowInterruptedExecutionErrorCode1742500000000,
         AddExecutionStatsTable1742600000000,
+        AddWorkerVersionFields1742700000000,
       ],
     }),
     EventEmitterModule.forRoot(),

--- a/apps/backend/src/executions/active/active-task-execution.controller.ts
+++ b/apps/backend/src/executions/active/active-task-execution.controller.ts
@@ -212,6 +212,7 @@ export class ActiveTaskExecutionController {
         harness: dto.harness,
         providerId: dto.providerId,
         modelId: dto.modelId,
+        workerVersion: dto.workerVersion,
         inputTokens: dto.inputTokens,
         outputTokens: dto.outputTokens,
         totalTokens: dto.totalTokens,

--- a/apps/backend/src/executions/active/active-task-execution.service.ts
+++ b/apps/backend/src/executions/active/active-task-execution.service.ts
@@ -68,6 +68,7 @@ export type UpdateExecutionStatsInput = {
   harness?: string | null;
   providerId?: string | null;
   modelId?: string | null;
+  workerVersion?: string | null;
   inputTokens?: number | null;
   outputTokens?: number | null;
   totalTokens?: number | null;
@@ -181,6 +182,7 @@ export class ActiveTaskExecutionService {
         harness: null,
         providerId: null,
         modelId: null,
+        workerVersion: null,
         inputTokens: null,
         outputTokens: null,
         totalTokens: null,
@@ -351,6 +353,9 @@ export class ActiveTaskExecutionService {
     if (input.modelId !== undefined) {
       valuesToSet.modelId = input.modelId;
     }
+    if (input.workerVersion !== undefined) {
+      valuesToSet.workerVersion = input.workerVersion;
+    }
     if (input.inputTokens !== undefined) {
       valuesToSet.inputTokens = input.inputTokens;
     }
@@ -478,6 +483,7 @@ export class ActiveTaskExecutionService {
       harness: stats.harness,
       providerId: stats.providerId,
       modelId: stats.modelId,
+      workerVersion: stats.workerVersion,
       inputTokens: stats.inputTokens,
       outputTokens: stats.outputTokens,
       totalTokens: stats.totalTokens,

--- a/apps/backend/src/executions/active/dto/http/update-execution-stats.dto.ts
+++ b/apps/backend/src/executions/active/dto/http/update-execution-stats.dto.ts
@@ -48,6 +48,19 @@ export class UpdateExecutionStatsDto {
   modelId?: string | null;
 
   @ApiProperty({
+    type: String,
+    required: false,
+    nullable: true,
+    description: 'Taico worker package version used for this execution',
+    example: '0.2.16',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  workerVersion?: string | null;
+
+  @ApiProperty({
     type: Number,
     required: false,
     nullable: true,

--- a/apps/backend/src/executions/dto/http/execution-stats-response.dto.ts
+++ b/apps/backend/src/executions/dto/http/execution-stats-response.dto.ts
@@ -27,6 +27,14 @@ export class ExecutionStatsResponseDto {
   modelId!: string | null;
 
   @ApiProperty({
+    type: String,
+    description: 'Taico worker package version used for this run',
+    example: '0.2.16',
+    nullable: true,
+  })
+  workerVersion!: string | null;
+
+  @ApiProperty({
     type: Number,
     description: 'Input token usage when available',
     example: 1200,
@@ -55,6 +63,7 @@ export class ExecutionStatsResponseDto {
       harness: result.harness,
       providerId: result.providerId,
       modelId: result.modelId,
+      workerVersion: result.workerVersion,
       inputTokens: result.inputTokens,
       outputTokens: result.outputTokens,
       totalTokens: result.totalTokens,

--- a/apps/backend/src/executions/dto/service/execution-results.service.types.ts
+++ b/apps/backend/src/executions/dto/service/execution-results.service.types.ts
@@ -6,6 +6,7 @@ export type ExecutionStatsResult = {
   harness: string | null;
   providerId: string | null;
   modelId: string | null;
+  workerVersion: string | null;
   inputTokens: number | null;
   outputTokens: number | null;
   totalTokens: number | null;

--- a/apps/backend/src/executions/executions-worker.gateway.ts
+++ b/apps/backend/src/executions/executions-worker.gateway.ts
@@ -16,6 +16,7 @@ import {
   ExecutionWireEvents,
   type PostExecutionHeartbeatPayload,
   type PostExecutionActivityPayload,
+  type PostWorkerHeartbeatPayload,
   type TaskExecutionQueuedWireEvent,
   type ExecutionInterruptRequestWireEvent,
 } from '@taico/events';
@@ -175,9 +176,12 @@ export class ExecutionsWorkerGateway
   }
 
   @SubscribeMessage(ExecutionWireEvents.WORKER_HEARTBEAT_POST)
-  async postWorkerHeartbeat(@ConnectedSocket() client: Socket) {
+  async postWorkerHeartbeat(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() body?: PostWorkerHeartbeatPayload,
+  ) {
     try {
-      await this.recordAuthenticatedWorkerSeen(client);
+      await this.recordAuthenticatedWorkerSeen(client, body?.workerVersion);
       return { ok: true };
     } catch (error) {
       this.logger.error({
@@ -222,18 +226,27 @@ export class ExecutionsWorkerGateway
     this.socketExpiryTimers.delete(socketId);
   }
 
-  private async recordWorkerSeen(client: Socket): Promise<boolean> {
+  private async recordWorkerSeen(
+    client: Socket,
+    workerVersion?: string | null,
+  ): Promise<boolean> {
     const oauthClientId = this.getOauthClientId(client);
     if (!oauthClientId) {
       return false;
     }
 
-    await this.workersService.recordWorkerSeen({ oauthClientId });
+    await this.workersService.recordWorkerSeen({
+      oauthClientId,
+      workerVersion: workerVersion ?? this.getHandshakeWorkerVersion(client),
+    });
     return true;
   }
 
-  private async recordAuthenticatedWorkerSeen(client: Socket): Promise<void> {
-    if (!(await this.recordWorkerSeen(client))) {
+  private async recordAuthenticatedWorkerSeen(
+    client: Socket,
+    workerVersion?: string | null,
+  ): Promise<void> {
+    if (!(await this.recordWorkerSeen(client, workerVersion))) {
       return;
     }
 
@@ -252,6 +265,11 @@ export class ExecutionsWorkerGateway
     }
 
     return oauthClientId;
+  }
+
+  private getHandshakeWorkerVersion(client: Socket): string | null {
+    const workerVersion = client.handshake.auth?.workerVersion;
+    return typeof workerVersion === 'string' ? workerVersion : null;
   }
 
   private requestWorkerHarnessesReport(client: Socket): void {

--- a/apps/backend/src/executions/history/task-execution-history.service.ts
+++ b/apps/backend/src/executions/history/task-execution-history.service.ts
@@ -102,6 +102,7 @@ export class TaskExecutionHistoryService {
       harness: stats.harness,
       providerId: stats.providerId,
       modelId: stats.modelId,
+      workerVersion: stats.workerVersion,
       inputTokens: stats.inputTokens,
       outputTokens: stats.outputTokens,
       totalTokens: stats.totalTokens,

--- a/apps/backend/src/executions/stats/execution-stats.entity.ts
+++ b/apps/backend/src/executions/stats/execution-stats.entity.ts
@@ -21,6 +21,9 @@ export class ExecutionStatsEntity {
   @Column({ type: 'text', name: 'model_id', nullable: true })
   modelId!: string | null;
 
+  @Column({ type: 'text', name: 'worker_version', nullable: true })
+  workerVersion!: string | null;
+
   @Column({ type: 'integer', name: 'input_tokens', nullable: true })
   inputTokens!: number | null;
 

--- a/apps/backend/src/migrations/1742700000000-AddWorkerVersionFields.ts
+++ b/apps/backend/src/migrations/1742700000000-AddWorkerVersionFields.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWorkerVersionFields1742700000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE workers
+      ADD COLUMN worker_version text
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE execution_stats
+      ADD COLUMN worker_version text
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE execution_stats
+      DROP COLUMN worker_version
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE workers
+      DROP COLUMN worker_version
+    `);
+  }
+}

--- a/apps/backend/src/workers/dto/http/worker-response.dto.ts
+++ b/apps/backend/src/workers/dto/http/worker-response.dto.ts
@@ -8,6 +8,9 @@ export class WorkerResponseDto {
   @ApiProperty()
   oauthClientId!: string;
 
+  @ApiProperty({ type: String, nullable: true, example: '0.2.16' })
+  workerVersion!: string | null;
+
   @ApiProperty({ format: 'date-time' })
   lastSeenAt!: string;
 

--- a/apps/backend/src/workers/dto/service/workers.service.types.ts
+++ b/apps/backend/src/workers/dto/service/workers.service.types.ts
@@ -3,12 +3,14 @@ import { AgentType } from 'src/agents/enums';
 export type RecordWorkerSeenInput = {
   oauthClientId: string;
   seenAt?: Date;
+  workerVersion?: string | null;
   harnesses?: AgentType[];
 };
 
 export type WorkerResult = {
   id: string;
   oauthClientId: string;
+  workerVersion: string | null;
   lastSeenAt: Date;
   harnesses: AgentType[];
   createdAt: Date;

--- a/apps/backend/src/workers/worker.entity.ts
+++ b/apps/backend/src/workers/worker.entity.ts
@@ -26,6 +26,9 @@ export class WorkerEntity {
   @Column({ type: 'datetime', name: 'last_seen_at' })
   lastSeenAt!: Date;
 
+  @Column({ type: 'text', name: 'worker_version', nullable: true })
+  workerVersion!: string | null;
+
   @Column({ type: 'simple-json', default: '[]' })
   harnesses!: AgentType[];
 

--- a/apps/backend/src/workers/workers.controller.ts
+++ b/apps/backend/src/workers/workers.controller.ts
@@ -31,6 +31,7 @@ export class WorkersController {
     return {
       id: worker.id,
       oauthClientId: worker.oauthClientId,
+      workerVersion: worker.workerVersion,
       lastSeenAt: worker.lastSeenAt.toISOString(),
       harnesses: worker.harnesses,
       createdAt: worker.createdAt.toISOString(),

--- a/apps/backend/src/workers/workers.gateway.ts
+++ b/apps/backend/src/workers/workers.gateway.ts
@@ -77,6 +77,7 @@ export class WorkersGateway
     const dto: WorkerResponseDto = {
       id: event.payload.id,
       oauthClientId: event.payload.oauthClientId,
+      workerVersion: event.payload.workerVersion,
       lastSeenAt: event.payload.lastSeenAt.toISOString(),
       harnesses: event.payload.harnesses,
       createdAt: event.payload.createdAt.toISOString(),

--- a/apps/backend/src/workers/workers.service.ts
+++ b/apps/backend/src/workers/workers.service.ts
@@ -41,11 +41,16 @@ export class WorkersService {
         this.workersRepository.create({
           oauthClientId: input.oauthClientId,
           lastSeenAt: nextSeenAt,
+          workerVersion: normalizeWorkerVersion(input.workerVersion),
           harnesses: input.harnesses ?? [],
         }),
       );
     } else {
       worker.lastSeenAt = nextSeenAt;
+
+      if (input.workerVersion !== undefined) {
+        worker.workerVersion = normalizeWorkerVersion(input.workerVersion);
+      }
 
       if (input.harnesses) {
         worker.harnesses = input.harnesses;
@@ -70,10 +75,16 @@ export class WorkersService {
     return {
       id: worker.id,
       oauthClientId: worker.oauthClientId,
+      workerVersion: worker.workerVersion,
       lastSeenAt: worker.lastSeenAt,
       harnesses: worker.harnesses,
       createdAt: worker.createdAt,
       updatedAt: worker.updatedAt,
     };
   }
+}
+
+function normalizeWorkerVersion(workerVersion: string | null | undefined): string | null {
+  const normalized = workerVersion?.trim();
+  return normalized ? normalized.slice(0, 100) : null;
 }

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -354,6 +354,7 @@ function RunExecutionDetails({ execution, actor }: { execution: ActiveTaskExecut
           <DetailRow label="Harness" value={stats?.harness ?? "Unknown"} />
           <DetailRow label="Provider" value={stats?.providerId ?? "Unknown"} />
           <DetailRow label="Model" value={stats?.modelId ?? "Unknown"} />
+          <DetailRow label="Worker version" value={stats?.workerVersion ?? "Unknown"} />
         </div>
       </section>
 

--- a/apps/ui/src/features/home/SettingsWorkersPage.tsx
+++ b/apps/ui/src/features/home/SettingsWorkersPage.tsx
@@ -121,6 +121,9 @@ export function SettingsWorkersPage() {
                         ID: {worker.id}
                       </Text>
                       <Text size="1" tone="muted">
+                        Version: {worker.workerVersion ?? 'Unknown'}
+                      </Text>
+                      <Text size="1" tone="muted">
                         Last seen: {lastSeenStr}
                       </Text>
                     </Stack>

--- a/apps/ui/src/features/workers/useWorkers.ts
+++ b/apps/ui/src/features/workers/useWorkers.ts
@@ -16,6 +16,7 @@ type WorkersSubscribeAck = {
 export interface Worker {
   id: string;
   oauthClientId: string;
+  workerVersion: string | null;
   lastSeenAt: string;
   harnesses: string[];
   createdAt: string;

--- a/apps/worker/src/execution-activity-gateway-client.ts
+++ b/apps/worker/src/execution-activity-gateway-client.ts
@@ -3,10 +3,12 @@ import {
   ExecutionWireEvents,
   type PostExecutionActivityPayload,
   type PostExecutionHeartbeatPayload,
+  type PostWorkerHeartbeatPayload,
   type TaskExecutionQueuedWireEvent,
   type ExecutionInterruptRequestWireEvent,
 } from '@taico/events';
 import { WorkerAuth } from './auth/worker-auth.js';
+import { WORKER_VERSION } from './version.js';
 
 const DEFAULT_TOKEN_REFRESH_SKEW_MS = 60_000;
 const ACK_TIMEOUT_MS = 5_000;
@@ -97,12 +99,16 @@ export class ExecutionActivityGatewayClient {
   async publishWorkerHeartbeat(): Promise<boolean> {
     return this.emitWithAck(
       ExecutionWireEvents.WORKER_HEARTBEAT_POST,
+      { workerVersion: WORKER_VERSION },
     );
   }
 
   private async emitWithAck(
     eventName: string,
-    payload?: PostExecutionActivityPayload | PostExecutionHeartbeatPayload,
+    payload?:
+      | PostExecutionActivityPayload
+      | PostExecutionHeartbeatPayload
+      | PostWorkerHeartbeatPayload,
   ): Promise<boolean> {
     if (!this.socket || !this.socket.connected) {
       if (this.options.debug) {
@@ -169,7 +175,7 @@ export class ExecutionActivityGatewayClient {
 
     this.socket = io(url, {
       transports,
-      auth: { token: credentials.accessToken },
+      auth: { token: credentials.accessToken, workerVersion: WORKER_VERSION },
       reconnection,
       reconnectionAttempts,
       reconnectionDelay,

--- a/apps/worker/src/task-runner.ts
+++ b/apps/worker/src/task-runner.ts
@@ -16,6 +16,7 @@ import { GitHubCopilotAgentRunner } from './runners/GitHubCopilotAgentRunner.js'
 import { buildPrompt } from './prompt.js';
 import { InputRequestLike, RunMode } from './types.js';
 import { ExecutionActivityGatewayClient } from './execution-activity-gateway-client.js';
+import { WORKER_VERSION } from './version.js';
 import {
   InterruptedExecutionError,
   TaskExecutionPreconditionError,
@@ -156,6 +157,7 @@ export async function executeTask({
           harness: runner.kind,
           providerId: resolvedModel?.providerId ?? null,
           modelId: resolvedModel?.modelId ?? null,
+          workerVersion: WORKER_VERSION,
         },
       })
       .catch((error) => {

--- a/apps/worker/src/version.ts
+++ b/apps/worker/src/version.ts
@@ -1,0 +1,6 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json') as { version?: string };
+
+export const WORKER_VERSION = packageJson.version ?? 'unknown';

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -11969,6 +11969,12 @@
             "example": "gpt-5.4",
             "nullable": true
           },
+          "workerVersion": {
+            "type": "string",
+            "description": "Taico worker package version used for this run",
+            "example": "0.2.16",
+            "nullable": true
+          },
           "inputTokens": {
             "type": "number",
             "description": "Input token usage when available",
@@ -11992,6 +11998,7 @@
           "harness",
           "providerId",
           "modelId",
+          "workerVersion",
           "inputTokens",
           "outputTokens",
           "totalTokens"
@@ -12337,6 +12344,13 @@
             "example": "gpt-5.4",
             "maxLength": 255
           },
+          "workerVersion": {
+            "type": "string",
+            "nullable": true,
+            "description": "Taico worker package version used for this execution",
+            "example": "0.2.16",
+            "maxLength": 100
+          },
           "inputTokens": {
             "type": "number",
             "nullable": true,
@@ -12409,6 +12423,11 @@
           "oauthClientId": {
             "type": "string"
           },
+          "workerVersion": {
+            "type": "string",
+            "nullable": true,
+            "example": "0.2.16"
+          },
           "lastSeenAt": {
             "type": "string",
             "format": "date-time"
@@ -12439,6 +12458,7 @@
         "required": [
           "id",
           "oauthClientId",
+          "workerVersion",
           "lastSeenAt",
           "harnesses",
           "createdAt",

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -5331,6 +5331,11 @@ export interface components {
              */
             modelId: string | null;
             /**
+             * @description Taico worker package version used for this run
+             * @example 0.2.16
+             */
+            workerVersion: string | null;
+            /**
              * @description Input token usage when available
              * @example 1200
              */
@@ -5548,6 +5553,11 @@ export interface components {
              */
             modelId?: string | null;
             /**
+             * @description Taico worker package version used for this execution
+             * @example 0.2.16
+             */
+            workerVersion?: string | null;
+            /**
              * @description Input token usage when available
              * @example 1200
              */
@@ -5591,6 +5601,8 @@ export interface components {
             /** Format: uuid */
             id: string;
             oauthClientId: string;
+            /** @example 0.2.16 */
+            workerVersion: string | null;
             /** Format: date-time */
             lastSeenAt: string;
             harnesses: ("claude" | "codex" | "opencode" | "adk" | "githubcopilot" | "other")[];

--- a/packages/client/src/v1/client/models/ExecutionStatsResponseDto.ts
+++ b/packages/client/src/v1/client/models/ExecutionStatsResponseDto.ts
@@ -16,6 +16,10 @@ export type ExecutionStatsResponseDto = {
      */
     modelId: string | null;
     /**
+     * Taico worker package version used for this run
+     */
+    workerVersion: string | null;
+    /**
      * Input token usage when available
      */
     inputTokens: number | null;

--- a/packages/client/src/v1/client/models/UpdateExecutionStatsDto.ts
+++ b/packages/client/src/v1/client/models/UpdateExecutionStatsDto.ts
@@ -16,6 +16,10 @@ export type UpdateExecutionStatsDto = {
      */
     modelId?: string | null;
     /**
+     * Taico worker package version used for this execution
+     */
+    workerVersion?: string | null;
+    /**
      * Input token usage when available
      */
     inputTokens?: number | null;

--- a/packages/client/src/v1/client/models/WorkerResponseDto.ts
+++ b/packages/client/src/v1/client/models/WorkerResponseDto.ts
@@ -5,6 +5,7 @@
 export type WorkerResponseDto = {
     id: string;
     oauthClientId: string;
+    workerVersion: string | null;
     lastSeenAt: string;
     harnesses: Array<'claude' | 'codex' | 'opencode' | 'adk' | 'githubcopilot' | 'other'>;
     createdAt: string;

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -964,6 +964,7 @@ export interface ExecutionStatsResponseDto {
   harness: string | null;
   providerId: string | null;
   modelId: string | null;
+  workerVersion: string | null;
   inputTokens: number | null;
   outputTokens: number | null;
   totalTokens: number | null;
@@ -1025,6 +1026,7 @@ export interface UpdateExecutionStatsDto {
   harness?: string | null;
   providerId?: string | null;
   modelId?: string | null;
+  workerVersion?: string | null;
   inputTokens?: number | null;
   outputTokens?: number | null;
   totalTokens?: number | null;
@@ -1041,6 +1043,7 @@ export interface TaskExecutionHistoryListResponseDto {
 export interface WorkerResponseDto {
   id: string;
   oauthClientId: string;
+  workerVersion: string | null;
   lastSeenAt: string;
   harnesses: ('claude' | 'codex' | 'opencode' | 'adk' | 'githubcopilot' | 'other')[];
   createdAt: string;

--- a/packages/events/src/types/execution-events.ts
+++ b/packages/events/src/types/execution-events.ts
@@ -108,6 +108,10 @@ export interface PostExecutionHeartbeatPayload {
   executionId: string;
 }
 
+export interface PostWorkerHeartbeatPayload {
+  workerVersion?: string | null;
+}
+
 /**
  * Execution activity event
  * Emitted for real-time activity updates from workers/runners

--- a/packages/events/src/types/worker-events.ts
+++ b/packages/events/src/types/worker-events.ts
@@ -27,6 +27,7 @@ export type WorkerWireEventName =
 export interface WorkerWirePayload {
   id: string;
   oauthClientId: string;
+  workerVersion: string | null;
   lastSeenAt: string;
   harnesses: string[];
   createdAt: string;


### PR DESCRIPTION
## Summary
- Persist worker package version on worker liveness records and execution stats snapshots.
- Send the worker version during worker socket connect/heartbeat and execution stats updates.
- Display worker version in `/settings/workers` and execution run details.

## Validation
- `NX_SKIP_NX_CACHE=true npm run build:dev`
- `npm run dev:1` reached backend startup; command was stopped after timeout once startup completed. Expected AppInitRunner prompt block error was present.

## Technical Debt
- No new technical debt identified.