### PR TITLE
Fix button height regression in Task Detail view

### DIFF
--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -1044,7 +1044,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
         {Object.entries(TASKS_STATUS).map(([status, info]) => (
           <Button
             key={status}
-            size='sm'
+            size='lg'
             variant={status === task.status ? 'primary' : 'secondary'}
             onClick={() => handleChangeStatus(status as TaskStatus)}
             disabled={isLoading}


### PR DESCRIPTION
## Summary
Fixed button height regression in Task Detail view where status buttons (Queued/Building/Review/Shipped) were shorter than action buttons (Assign, Assign to Me, Delete).

## Changes
- Changed status buttons from `size='sm'` to `size='lg'` to match the height of other action buttons

## Root Cause
Status buttons were using `size='sm'` (padding: `var(--space-1) var(--space-3)`) while action buttons use `size='lg'` (padding: `var(--space-3) var(--space-5)`), causing a visual inconsistency.

## Test Plan
- [x] Ran `npm run build:dev` - build successful
- [x] Ran `npm run dev:2` - app starts successfully
- [x] Verified all status buttons now match the height of action buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)