### PR TITLE
[codex] Redesign settings pages

### DIFF
--- a/apps/ui/src/app/providers/ThemeProvider.tsx
+++ b/apps/ui/src/app/providers/ThemeProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
 
-type Theme =
+export type Theme =
   | 'light'
   | 'dark'
   | 'clarity'
@@ -13,6 +13,7 @@ type Theme =
   | 'mono'
   | 'terminal-amber'
   | 'oceanic'
+  | 'party'
   | 'tribute';
 
 interface ThemeContextValue {

--- a/apps/ui/src/features/home/HomeRoutes.tsx
+++ b/apps/ui/src/features/home/HomeRoutes.tsx
@@ -6,6 +6,7 @@ import { SettingsPage } from "./SettingsPage";
 import { SettingsAccountPage } from "./SettingsAccountPage";
 import { SettingsAppearancePage } from "./SettingsAppearancePage";
 import { SettingsProjectsPage } from "./SettingsProjectsPage";
+import { SettingsProjectCreatePage } from "./SettingsProjectCreatePage";
 import { SettingsChatPage } from "./SettingsChatPage";
 import { SettingsDataPage } from './SettingsDataPage';
 import { SettingsWorkersPage } from './SettingsWorkersPage';
@@ -22,6 +23,7 @@ export function HomeRoutes() {
           <Route path="/settings/account" element={<SettingsAccountPage />} />
           <Route path="/settings/appearance" element={<SettingsAppearancePage />} />
           <Route path="/settings/projects" element={<SettingsProjectsPage />} />
+          <Route path="/settings/projects/new" element={<SettingsProjectCreatePage />} />
           <Route path="/settings/chat" element={<SettingsChatPage />} />
           <Route path="/settings/workers" element={<SettingsWorkersPage />} />
           <Route path="/settings/ai-providers" element={<SettingsAIProvidersPage />} />

--- a/apps/ui/src/features/home/SettingsAIProvidersPage.tsx
+++ b/apps/ui/src/features/home/SettingsAIProvidersPage.tsx
@@ -2,6 +2,7 @@ import { Stack, Text, Card, Button, Row } from '../../ui/primitives';
 import { useHomeCtx } from './HomeProvider';
 import { useEffect } from 'react';
 import { useDocumentTitle } from '../../shared/hooks/useDocumentTitle';
+import './SettingsPage.css';
 import './SettingsAIProvidersPage.css';
 
 export function SettingsAIProvidersPage() {
@@ -15,10 +16,12 @@ export function SettingsAIProvidersPage() {
   }, []);
 
   return (
-    <Stack spacing="6">
-      <Text tone="muted">View usage and quota information for AI providers</Text>
+    <Stack spacing="6" className="settings-subpage">
+      <Text tone="muted" className="settings-subpage__intro">
+        View usage and quota information for AI providers.
+      </Text>
 
-      <Card padding="5">
+      <Card padding="5" className="settings-panel-card">
         <Stack spacing="4">
           <Row justify="space-between" align="center">
             <Stack spacing="1">
@@ -44,7 +47,7 @@ export function SettingsAIProvidersPage() {
       </Card>
 
 
-      <Card padding="5">
+      <Card padding="5" className="settings-panel-card">
         <Stack spacing="4">
           <Row justify="space-between" align="center">
             <Stack spacing="1">

--- a/apps/ui/src/features/home/SettingsAccountPage.tsx
+++ b/apps/ui/src/features/home/SettingsAccountPage.tsx
@@ -6,6 +6,7 @@ import { WebAuthenticationService } from '../../auth/api';
 import { ErrorText } from '../../ui/primitives/ErrorText';
 import { useNavigate } from 'react-router-dom';
 import '../../auth/LoginPage.css';
+import './SettingsPage.css';
 
 export function SettingsAccountPage() {
   const { setSectionTitle } = useHomeCtx();
@@ -50,8 +51,12 @@ export function SettingsAccountPage() {
   };
 
   return (
-    <Stack spacing="6">
-      <Card padding="5">
+    <Stack spacing="6" className="settings-subpage">
+      <Text tone="muted" className="settings-subpage__intro">
+        Update the password used to sign in to this Taico instance.
+      </Text>
+
+      <Card padding="5" className="settings-panel-card">
         <Stack spacing="4">
           <Stack spacing="2">
             <Text size="4" weight="semibold">Change Password</Text>

--- a/apps/ui/src/features/home/SettingsAppearancePage.tsx
+++ b/apps/ui/src/features/home/SettingsAppearancePage.tsx
@@ -1,24 +1,10 @@
-import { Stack, Text, Card, Row, Button } from '../../ui/primitives';
+import { Stack, Text } from '../../ui/primitives';
 import { useTheme } from '../../app/providers/ThemeProvider';
 import { useHomeCtx } from './HomeProvider';
 import { useEffect } from 'react';
+import { SettingsThemeVisual } from './SettingsThemeVisual';
+import { SETTINGS_THEME_OPTIONS } from './settingsThemes';
 import './SettingsPage.css';
-
-const THEMES = [
-  { value: 'light', label: 'Light', description: 'Clean light theme' },
-  { value: 'dark', label: 'Dark', description: 'Easy on the eyes' },
-  { value: 'clarity', label: 'Clarity', description: 'Soft neutral, all-day light theme' },
-  { value: 'github', label: 'GitHub', description: 'GitHub-inspired green accent' },
-  { value: 'forest', label: 'Forest', description: 'Nature-inspired dark green' },
-  { value: 'terminal', label: 'Terminal', description: 'Classic terminal green on black' },
-  { value: 'ai-vibes', label: 'AI Vibes', description: 'Deep purples with neon accents' },
-  { value: 'halo', label: 'Halo', description: 'Light background with deeper surfaces' },
-  { value: 'mono', label: 'Mono', description: 'Black and white minimalism' },
-  { value: 'terminal-amber', label: 'Terminal Amber', description: 'Terminal tones without the green' },
-  { value: 'oceanic', label: 'Oceanic', description: 'Cool blues and teals' },
-  { value: 'party', label: 'Party', description: 'Playful warm palette' },
-  { value: 'tribute', label: 'Tribute', description: 'Inspired by the old UI\'s dark sidebar' },
-] as const;
 
 export function SettingsAppearancePage() {
   const { theme, setTheme } = useTheme();
@@ -29,43 +15,41 @@ export function SettingsAppearancePage() {
   }, []);
 
   return (
-    <Stack spacing="6">
-      <Card padding="5">
-        <Stack spacing="4">
-          <Stack spacing="2">
-            <Text size="4" weight="semibold">Appearance</Text>
-            <Text tone="muted">Choose your preferred color theme</Text>
-          </Stack>
+    <Stack spacing="6" className="settings-subpage settings-subpage--wide">
+      <Text tone="muted" className="settings-subpage__intro">
+        Choose the visual style used across Taico.
+      </Text>
 
-          <Stack spacing="3">
-            {THEMES.map((themeOption) => {
-              const isActive = theme === themeOption.value;
+      <div className="settings-theme-grid" aria-label="Theme choices">
+        {SETTINGS_THEME_OPTIONS.map((themeOption) => {
+          const isActive = theme === themeOption.value;
 
-              return (
-                <Card
-                  key={themeOption.value}
-                  padding="4"
-                  className={isActive ? 'settings-theme-card--active' : ''}
-                >
-                  <Row justify="space-between" align="center">
-                    <Stack spacing="1">
-                      <Text weight="semibold">{themeOption.label}</Text>
-                      <Text size="1" tone="muted">{themeOption.description}</Text>
-                    </Stack>
-                    <Button
-                      variant={isActive ? 'primary' : 'secondary'}
-                      size="sm"
-                      onClick={() => setTheme(themeOption.value as any)}
-                    >
-                      {isActive ? 'Active' : 'Select'}
-                    </Button>
-                  </Row>
-                </Card>
-              );
-            })}
-          </Stack>
-        </Stack>
-      </Card>
+          return (
+            <button
+              key={themeOption.value}
+              type="button"
+              className={`settings-theme-card ${isActive ? 'settings-theme-card--active' : ''}`}
+              onClick={() => setTheme(themeOption.value)}
+              aria-pressed={isActive}
+            >
+              <SettingsThemeVisual preview={themeOption.preview} size="large" />
+              <span className="settings-theme-card__body">
+                <span className="settings-theme-card__header">
+                  <span className="settings-theme-card__title">{themeOption.label}</span>
+                  <span className="settings-theme-card__badge">{isActive ? 'Active' : themeOption.preview.font}</span>
+                </span>
+                <span className="settings-theme-card__description">{themeOption.description}</span>
+                <span className="settings-theme-card__palette" aria-hidden="true">
+                  <span style={{ backgroundColor: themeOption.preview.background }} />
+                  <span style={{ backgroundColor: themeOption.preview.surface }} />
+                  <span style={{ backgroundColor: themeOption.preview.card }} />
+                  <span style={{ backgroundColor: themeOption.preview.accent }} />
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
     </Stack>
   );
 }

--- a/apps/ui/src/features/home/SettingsChatPage.tsx
+++ b/apps/ui/src/features/home/SettingsChatPage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { ChatProvidersService } from '@taico/client';
 import { ErrorText } from '../../ui/primitives/ErrorText';
 import '../../auth/LoginPage.css';
+import './SettingsPage.css';
 import './SettingsChatPage.css';
 
 interface ChatProvider {
@@ -132,15 +133,17 @@ export function SettingsChatPage() {
 
   if (isLoading) {
     return (
-      <Stack spacing="6">
+      <Stack spacing="6" className="settings-subpage">
         <Text>Loading...</Text>
       </Stack>
     );
   }
 
   return (
-    <Stack spacing="6">
-      <Text tone="muted">Configure chat providers for thread conversations</Text>
+    <Stack spacing="6" className="settings-subpage">
+      <Text tone="muted" className="settings-subpage__intro">
+        Configure chat providers for thread conversations.
+      </Text>
 
       {error && (
         <ErrorText size="2" weight="medium">
@@ -149,12 +152,12 @@ export function SettingsChatPage() {
       )}
 
       {providers.length === 0 ? (
-        <Card padding="5">
+        <Card padding="5" className="settings-panel-card">
           <Text tone="muted">No chat providers available. OpenAI provider should be created automatically.</Text>
         </Card>
       ) : (
         providers.map((provider) => (
-          <Card key={provider.id} padding="5">
+          <Card key={provider.id} padding="5" className="settings-panel-card">
             <Stack spacing="4">
               <Row justify="space-between" align="center">
                 <Stack spacing="1" className="settings-chat__header-copy">

--- a/apps/ui/src/features/home/SettingsDataPage.tsx
+++ b/apps/ui/src/features/home/SettingsDataPage.tsx
@@ -3,6 +3,7 @@ import { Button, Card, Row, Stack, Text } from '../../ui/primitives';
 import { ErrorText } from '../../ui/primitives/ErrorText';
 import { BFF_BASE_URL } from '../../config/api';
 import { useHomeCtx } from './HomeProvider';
+import './SettingsPage.css';
 import './SettingsDataPage.css';
 
 type ImportResponse = {
@@ -99,8 +100,8 @@ export function SettingsDataPage() {
   };
 
   return (
-    <Stack spacing="6">
-      <Text tone="muted">
+    <Stack spacing="6" className="settings-subpage">
+      <Text tone="muted" className="settings-subpage__intro">
         Import and export workspace data. Blocks are available now; task support can be added in this section later.
       </Text>
 
@@ -116,7 +117,7 @@ export function SettingsDataPage() {
         </Text>
       ) : null}
 
-      <Card padding="5">
+      <Card padding="5" className="settings-panel-card">
         <Stack spacing="4">
           <Stack spacing="1">
             <Text size="4" weight="semibold">Export Blocks</Text>
@@ -135,7 +136,7 @@ export function SettingsDataPage() {
         </Stack>
       </Card>
 
-      <Card padding="5">
+      <Card padding="5" className="settings-panel-card">
         <Stack spacing="4">
           <Stack spacing="1">
             <Text size="4" weight="semibold">Import Blocks</Text>

--- a/apps/ui/src/features/home/SettingsPage.css
+++ b/apps/ui/src/features/home/SettingsPage.css
@@ -1,4 +1,648 @@
-.settings-theme-card--active {
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  min-height: 0;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+.settings-page *,
+.settings-page *::before,
+.settings-page *::after {
+  box-sizing: border-box;
+}
+
+.settings-page .text,
+.settings-page .stack {
+  min-width: 0;
+}
+
+.settings-page .text {
+  overflow-wrap: anywhere;
+}
+
+.settings-page__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+  gap: var(--space-5);
+  align-items: start;
+}
+
+.settings-page__main,
+.settings-page__side {
+  min-width: 0;
+}
+
+.settings-page__main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.settings-page__side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  position: sticky;
+  top: var(--space-4);
+}
+
+.settings-page__nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-4);
+  background: var(--card-bg);
+  box-shadow: var(--shadow-1);
+  overflow-x: auto;
+}
+
+.settings-page__nav-item {
+  appearance: none;
+  border: 0;
+  border-radius: var(--r-3);
+  background: transparent;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 40px;
+  padding: 0 var(--space-3);
+  font: inherit;
+  font-size: var(--fs-2);
+  font-weight: var(--fw-medium);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.settings-page__nav-item:first-child {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+}
+
+.settings-page__nav-item:hover {
+  background: var(--surface);
+  color: var(--text);
+}
+
+.settings-page__section-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-3);
+}
+
+.settings-page__section-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(140px, 200px) minmax(150px, 190px);
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  min-width: 0;
+  border-color: var(--border-subtle);
+  border-radius: var(--r-3);
+  box-shadow: var(--shadow-1);
+}
+
+.settings-page__section-card--with-carousel {
+  grid-template-columns: minmax(0, 0.8fr) minmax(280px, 1.2fr);
+}
+
+.settings-page__section-card--with-carousel .settings-page__section-action {
+  grid-column: 2;
+}
+
+.settings-page__section-header {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.settings-page__section-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--r-3);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  background: var(--surface);
+}
+
+.settings-page__section-icon--accent {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, var(--card-bg));
+}
+
+.settings-page__section-icon--warning {
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 12%, var(--card-bg));
+}
+
+.settings-page__section-icon--green {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 12%, var(--card-bg));
+}
+
+.settings-page__section-icon--red {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, var(--card-bg));
+}
+
+.settings-page__section-icon--neutral {
+  color: var(--text-muted);
+  background: var(--surface);
+}
+
+.settings-page__detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-page__detail {
+  min-width: 0;
+  padding-left: var(--space-4);
+  border-left: 1px solid var(--border-subtle);
+}
+
+.settings-page__theme-carousel {
+  min-width: 0;
+  padding-left: var(--space-4);
+  border-left: 1px solid var(--border-subtle);
+  display: flex;
+  gap: var(--space-2);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.settings-page__theme-preview {
+  appearance: none;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-3);
+  background: var(--card-bg);
+  color: var(--text-muted);
+  display: grid;
+  gap: var(--space-2);
+  min-width: 132px;
+  padding: var(--space-2);
+  font: inherit;
+  font-size: var(--fs-1);
+  font-weight: var(--fw-medium);
+  text-align: left;
+  cursor: pointer;
+}
+
+.settings-page__theme-preview:hover {
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.settings-page__theme-preview--active {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px var(--accent);
+  color: var(--accent);
+}
+
+.settings-page__theme-preview-copy {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.settings-page__theme-preview-copy > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-page__theme-preview-copy > span:last-child {
+  color: var(--text-muted);
+  font-size: var(--fs-0);
+  font-weight: var(--fw-regular);
+}
+
+.settings-theme-visual {
+  --theme-preview-bg: var(--bg);
+  --theme-preview-surface: var(--surface);
+  --theme-preview-card: var(--card-bg);
+  --theme-preview-border: var(--border);
+  --theme-preview-text: var(--text);
+  --theme-preview-muted: var(--text-muted);
+  --theme-preview-accent: var(--accent);
+  --theme-preview-accent-soft: var(--surface);
+  display: block;
+  min-width: 0;
+  width: 100%;
+}
+
+.settings-theme-visual__window {
+  display: grid;
+  grid-template-columns: 26% minmax(0, 1fr);
+  overflow: hidden;
+  height: 58px;
+  border: 1px solid var(--theme-preview-border);
+  border-radius: var(--r-2);
+  background: var(--theme-preview-bg);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--theme-preview-bg) 80%, transparent);
+}
+
+.settings-theme-visual--large .settings-theme-visual__window {
+  height: 122px;
+  border-radius: var(--r-3);
+}
+
+.settings-theme-visual__rail,
+.settings-theme-visual__canvas,
+.settings-theme-visual__panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.settings-theme-visual__rail {
+  gap: 6px;
+  padding: 8px 7px;
+  background: var(--theme-preview-surface);
+  border-right: 1px solid var(--theme-preview-border);
+}
+
+.settings-theme-visual--large .settings-theme-visual__rail {
+  gap: 10px;
+  padding: 14px 12px;
+}
+
+.settings-theme-visual__accent-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--theme-preview-accent);
+  box-shadow: 0 0 0 3px var(--theme-preview-accent-soft);
+}
+
+.settings-theme-visual--large .settings-theme-visual__accent-dot {
+  width: 18px;
+  height: 18px;
+}
+
+.settings-theme-visual__rail-line,
+.settings-theme-visual__line,
+.settings-theme-visual__button {
+  display: block;
+  border-radius: 999px;
+  background: var(--theme-preview-muted);
+  opacity: 0.42;
+}
+
+.settings-theme-visual__rail-line {
+  width: 70%;
+  height: 4px;
+}
+
+.settings-theme-visual__rail-line--short {
+  width: 46%;
+}
+
+.settings-theme-visual__canvas {
+  gap: 5px;
+  padding: 8px;
+  background: var(--theme-preview-bg);
+}
+
+.settings-theme-visual--large .settings-theme-visual__canvas {
+  gap: 9px;
+  padding: 14px;
+}
+
+.settings-theme-visual__font {
+  color: var(--theme-preview-text);
+  font-size: 12px;
+  font-weight: var(--fw-bold);
+  line-height: 1;
+}
+
+.settings-theme-visual--large .settings-theme-visual__font {
+  font-size: 20px;
+}
+
+.settings-theme-visual__line {
+  width: 58%;
+  height: 4px;
+}
+
+.settings-theme-visual--large .settings-theme-visual__line {
+  height: 6px;
+}
+
+.settings-theme-visual__line--wide {
+  width: 74%;
+}
+
+.settings-theme-visual__line--short {
+  width: 44%;
+}
+
+.settings-theme-visual__panel {
+  gap: 4px;
+  padding: 6px;
+  border: 1px solid var(--theme-preview-border);
+  border-radius: var(--r-2);
+  background: var(--theme-preview-card);
+}
+
+.settings-theme-visual--large .settings-theme-visual__panel {
+  gap: 7px;
+  padding: 10px;
+}
+
+.settings-theme-visual__chip {
+  display: block;
+  width: 28px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--theme-preview-accent);
+}
+
+.settings-theme-visual--large .settings-theme-visual__chip {
+  width: 44px;
+  height: 10px;
+}
+
+.settings-theme-visual__button {
+  width: 48%;
+  height: 6px;
+  background: var(--theme-preview-accent);
+  opacity: 1;
+}
+
+.settings-theme-visual--large .settings-theme-visual__button {
+  height: 9px;
+}
+
+.settings-page__section-action {
+  justify-content: space-between;
+}
+
+.settings-page__section-action,
+.settings-page__side-card .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settings-page__side-card {
+  border-color: var(--border-subtle);
+  border-radius: var(--r-3);
+  box-shadow: var(--shadow-1);
+}
+
+.settings-page__status-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.settings-page__status-icon,
+.settings-page__quick-link-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.settings-page__status-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--surface);
+}
+
+.settings-page__status-icon--ready {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 12%, var(--card-bg));
+}
+
+.settings-page__quick-link {
+  appearance: none;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: 36px;
+  padding: var(--space-2);
+  border-radius: var(--r-2);
+  font: inherit;
+  font-size: var(--fs-2);
+  text-align: left;
+  cursor: pointer;
+}
+
+.settings-page__quick-link:hover {
+  background: var(--surface);
+  color: var(--text);
+}
+
+.settings-page__version {
+  text-align: center;
+}
+
+@media (max-width: 1180px) {
+  .settings-page__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-page__side {
+    position: static;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .settings-page__version {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 780px) {
+  .settings-page__section-card {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+  }
+
+  .settings-page__section-card--with-carousel .settings-page__section-action {
+    grid-column: auto;
+  }
+
+  .settings-page__detail {
+    padding-top: var(--space-3);
+    padding-left: 0;
+    border-top: 1px solid var(--border-subtle);
+    border-left: 0;
+  }
+
+  .settings-page__theme-carousel {
+    padding-top: var(--space-3);
+    padding-left: 0;
+    border-top: 1px solid var(--border-subtle);
+    border-left: 0;
+  }
+
+  .settings-page__side {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .settings-page__nav {
+    margin-inline: calc(var(--space-4) * -1);
+    border-left: 0;
+    border-right: 0;
+    border-radius: 0;
+  }
+
+  .settings-page__detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.settings-subpage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  max-width: 960px;
+}
+
+.settings-subpage--wide {
+  max-width: 1120px;
+}
+
+.settings-subpage__intro {
+  max-width: 760px;
+}
+
+.settings-panel-card,
+.settings-list-card {
+  border-color: var(--border-subtle);
+  border-radius: var(--r-3);
+  box-shadow: var(--shadow-1);
+}
+
+.settings-list-card {
+  padding: var(--space-4);
+}
+
+.settings-theme-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.settings-theme-card {
+  appearance: none;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-3);
+  background: var(--card-bg);
+  color: var(--text);
+  display: grid;
+  gap: var(--space-3);
+  min-width: 0;
+  padding: var(--space-3);
+  font: inherit;
+  text-align: left;
+  box-shadow: var(--shadow-1);
+  cursor: pointer;
+}
+
+.settings-theme-card:hover {
+  border-color: var(--border);
+  box-shadow: var(--shadow-2);
+}
+
+.settings-theme-card--active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent), var(--shadow-1);
+}
+
+.settings-theme-card__body {
+  display: grid;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.settings-theme-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.settings-theme-card__title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+  font-size: var(--fs-3);
+  font-weight: var(--fw-semibold);
+  white-space: nowrap;
+}
+
+.settings-theme-card__badge {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: var(--fs-0);
+  font-weight: var(--fw-medium);
+}
+
+.settings-theme-card--active .settings-theme-card__badge {
+  background: color-mix(in srgb, var(--accent) 12%, var(--card-bg));
+  color: var(--accent);
+}
+
+.settings-theme-card__description {
+  color: var(--text-muted);
+  font-size: var(--fs-1);
+  line-height: 1.4;
+}
+
+.settings-theme-card__palette {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.settings-theme-card__palette > span {
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+}
+
+@media (max-width: 980px) {
+  .settings-theme-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .settings-theme-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/apps/ui/src/features/home/SettingsPage.tsx
+++ b/apps/ui/src/features/home/SettingsPage.tsx
@@ -1,18 +1,56 @@
-import { Stack, Text, Card, Row, Button } from '../../ui/primitives';
+import { Stack, Text, Card, Button } from '../../ui/primitives';
 import { useHomeCtx } from './HomeProvider';
 import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 import { useIsDesktop } from '../../app/hooks/useIsDesktop';
 import { useDocumentTitle } from '../../shared/hooks/useDocumentTitle';
 import { useNavigate } from 'react-router-dom';
 import { useCommandPalette } from '../../ui/components';
-import { MetaService } from '@taico/client';
+import { ChatProvidersService, MetaService } from '@taico/client';
+import { useTheme } from '../../app/providers/ThemeProvider';
+import type { Theme } from '../../app/providers/ThemeProvider';
+import { ProjectsService } from '../projects/api';
+import { useWorkers } from '../workers/useWorkers';
+import { SettingsThemeVisual } from './SettingsThemeVisual';
+import { SETTINGS_THEME_OPTIONS } from './settingsThemes';
+import {
+  Bot,
+  Box,
+  CheckCircle2,
+  ChevronRight,
+  Database,
+  ExternalLink,
+  FolderKanban,
+  KeyRound,
+  LayoutDashboard,
+  LockKeyhole,
+  Palette,
+  Server,
+  Sparkles,
+} from 'lucide-react';
+import './SettingsPage.css';
+
+type SettingsMetric = {
+  projects: number | null;
+  providers: {
+    configured: number;
+    total: number;
+    activeName: string | null;
+  } | null;
+};
 
 export function SettingsPage() {
   const { setSectionTitle } = useHomeCtx();
   const isDesktop = useIsDesktop();
   const navigate = useNavigate();
   const { registerCommands } = useCommandPalette();
+  const { theme, setTheme } = useTheme();
+  const { workers, isLoading: areWorkersLoading } = useWorkers();
   const [version, setVersion] = useState<{ backend: string; ui: string } | null>(null);
+  const [metrics, setMetrics] = useState<SettingsMetric>({
+    projects: null,
+    providers: null,
+  });
 
   // Set document title (browser tab)
   useDocumentTitle();
@@ -20,6 +58,7 @@ export function SettingsPage() {
   useEffect(() => {
     setSectionTitle('Settings');
     loadVersion();
+    loadMetrics();
   }, []);
 
   const loadVersion = async () => {
@@ -29,6 +68,24 @@ export function SettingsPage() {
     } catch (error) {
       console.error('Failed to load version:', error);
     }
+  };
+
+  const loadMetrics = async () => {
+    const [projectsResult, providersResult] = await Promise.allSettled([
+      ProjectsService.projectsControllerGetAllProjects(),
+      ChatProvidersService.chatProvidersControllerListChatProviders(),
+    ]);
+
+    setMetrics({
+      projects: projectsResult.status === 'fulfilled' ? projectsResult.value.length : null,
+      providers: providersResult.status === 'fulfilled'
+        ? {
+            configured: providersResult.value.filter((provider) => provider.isConfigured).length,
+            total: providersResult.value.length,
+            activeName: providersResult.value.find((provider) => provider.isActive)?.name ?? null,
+          }
+        : null,
+    });
   };
 
   // Register page-specific commands
@@ -88,176 +145,280 @@ export function SettingsPage() {
     return registerCommands(commands);
   }, [registerCommands, navigate]);
 
+  const connectedWorkers = workers.filter((worker) => {
+    const lastSeen = new Date(worker.lastSeenAt);
+    const diffMs = Date.now() - lastSeen.getTime();
+    return diffMs <= 2 * 60 * 1000;
+  }).length;
+
+  const settingGroups = [
+    {
+      title: 'Appearance',
+      description: 'Theme and visual preferences for Taico.',
+      icon: Palette,
+      iconTone: 'accent',
+      path: '/settings/appearance',
+      action: 'More themes',
+      detail: { label: 'Current theme', value: themeLabel(theme), tone: 'default' },
+      preview: (
+        <ThemePreviewCarousel
+          activeTheme={theme}
+          onSelect={(nextTheme) => setTheme(nextTheme)}
+        />
+      ),
+    },
+    {
+      title: 'Projects',
+      description: 'Project metadata and repository links.',
+      icon: FolderKanban,
+      iconTone: 'accent',
+      path: '/settings/projects',
+      action: 'Manage',
+      detail: { label: 'Projects', value: metrics.projects === null ? 'Unavailable' : String(metrics.projects), tone: 'default' },
+    },
+    {
+      title: 'AI & Chat',
+      description: 'Conversation providers and active chat routing.',
+      icon: Sparkles,
+      iconTone: 'warning',
+      path: '/settings/chat',
+      action: 'Configure',
+      detail: {
+        label: 'Active provider',
+        value: metrics.providers?.activeName ?? 'Not selected',
+        tone: metrics.providers?.activeName ? 'default' : 'muted',
+      },
+    },
+    {
+      title: 'Workers',
+      description: 'Background execution workers and harness health.',
+      icon: Server,
+      iconTone: 'green',
+      path: '/settings/workers',
+      action: 'Open workers',
+      detail: { label: 'Connected workers', value: areWorkersLoading ? 'Loading' : String(connectedWorkers), tone: 'default' },
+    },
+    {
+      title: 'Account',
+      description: 'Password and account-level access controls.',
+      icon: LockKeyhole,
+      iconTone: 'red',
+      path: '/settings/account',
+      action: 'Security',
+      detail: { label: 'Password', value: 'Change available', tone: 'default' },
+    },
+    {
+      title: 'Data',
+      description: 'Import and export workspace context blocks.',
+      icon: Database,
+      iconTone: 'neutral',
+      path: '/settings/data',
+      action: 'Import / export',
+      detail: { label: 'Export', value: 'Context blocks', tone: 'default' },
+    },
+  ];
+
   return (
-    <Stack spacing="6">
-      {isDesktop ?
-        <Text tone="muted">Customize your experience</Text>
-        : ''}
+    <div className="settings-page">
+      {isDesktop ? (
+        <Text tone="muted">Manage your workspace, execution, providers, and data.</Text>
+      ) : null}
 
-      <Card padding="5">
-        <Stack spacing="3">
-          <Stack spacing="1">
-            <Text size="4" weight="semibold">Account</Text>
-            <Text tone="muted">Manage your account security</Text>
-          </Stack>
-          <Row justify="space-between" align="center">
-            <Text size="2" tone="muted">Update your password</Text>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => navigate('/settings/account')}
+      <div className="settings-page__layout">
+        <main className="settings-page__main" aria-label="Settings sections">
+          <div className="settings-page__nav" aria-label="Settings shortcuts">
+            <button
+              className="settings-page__nav-item"
+              type="button"
+              onClick={() => navigate('/settings')}
+              aria-current="page"
             >
-              Change Password
-            </Button>
-          </Row>
-        </Stack>
-      </Card>
+              <LayoutDashboard size={16} strokeWidth={1.8} aria-hidden="true" />
+              <span>Overview</span>
+            </button>
+            {settingGroups.slice(0, 4).map((group) => {
+              const Icon = group.icon;
+              return (
+                <button
+                  key={group.title}
+                  className="settings-page__nav-item"
+                  type="button"
+                  onClick={() => navigate(group.path)}
+                >
+                  <Icon size={16} strokeWidth={1.8} aria-hidden="true" />
+                  <span>{group.title}</span>
+                </button>
+              );
+            })}
+          </div>
 
-      <Card padding="5">
-        <Stack spacing="3">
-          <Stack spacing="1">
-            <Text size="4" weight="semibold">Appearance</Text>
-            <Text tone="muted">Choose your preferred color theme</Text>
-          </Stack>
-          <Row justify="space-between" align="center">
-            <Text size="2" tone="muted">Pick a theme for the app</Text>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => navigate('/settings/appearance')}
-            >
-              Choose Theme
-            </Button>
-          </Row>
-        </Stack>
-      </Card>
+          <div className="settings-page__section-grid">
+            {settingGroups.map((group) => {
+              const Icon = group.icon;
+              return (
+                <Card
+                  key={group.title}
+                  padding="0"
+                  className={`settings-page__section-card ${group.preview ? 'settings-page__section-card--with-carousel' : ''}`}
+                >
+                  <div className="settings-page__section-header">
+                    <span className={`settings-page__section-icon settings-page__section-icon--${group.iconTone}`}>
+                      <Icon size={22} strokeWidth={1.8} aria-hidden="true" />
+                    </span>
+                    <Stack spacing="1">
+                      <Text size="3" weight="semibold">{group.title}</Text>
+                      <Text size="1" tone="muted">{group.description}</Text>
+                    </Stack>
+                  </div>
 
-      <Card padding="5">
-        <Stack spacing="3">
-          <Stack spacing="1">
-            <Text size="4" weight="semibold">Projects</Text>
-            <Text tone="muted">Manage your projects</Text>
-          </Stack>
-          <Row justify="space-between" align="center">
-            <Text size="2" tone="muted">View and edit project details</Text>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => navigate('/settings/projects')}
-            >
-              Manage Projects
-            </Button>
-          </Row>
-        </Stack>
-      </Card>
+                  {group.preview ?? (
+                    <div className="settings-page__detail">
+                      <Text size="1" tone="muted">{group.detail.label}</Text>
+                      <Text size="2" weight="medium" tone={group.detail.tone as 'default' | 'muted'}>
+                        {group.detail.value}
+                      </Text>
+                    </div>
+                  )}
 
-      <Card padding="5">
-        <Stack spacing="3">
-          <Stack spacing="1">
-            <Text size="4" weight="semibold">Chat</Text>
-            <Text tone="muted">Configure chat providers for conversations</Text>
-          </Stack>
-          <Row justify="space-between" align="center">
-            <Text size="2" tone="muted">Manage OpenAI and other providers</Text>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => navigate('/settings/chat')}
-            >
-              Configure Chat
-            </Button>
-          </Row>
-        </Stack>
-      </Card>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    fullWidth
+                    onClick={() => navigate(group.path)}
+                    className="settings-page__section-action"
+                  >
+                    <span>{group.action}</span>
+                    <ChevronRight size={16} strokeWidth={1.8} aria-hidden="true" />
+                  </Button>
+                </Card>
+              );
+            })}
+          </div>
+        </main>
 
-      <Card padding="5">
-        <Stack spacing="3">
-          <Stack spacing="1">
-            <Text size="4" weight="semibold">Workers</Text>
-            <Text tone="muted">Configure and manage background workers</Text>
-          </Stack>
-          <Row justify="space-between" align="center">
-            <Text size="2" tone="muted">Set up workers for task execution</Text>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => navigate('/settings/workers')}
-            >
-              Manage Workers
-            </Button>
-          </Row>
-        </Stack>
-      </Card>
+        <aside className="settings-page__side" aria-label="Settings status">
+          <Card padding="4" className="settings-page__side-card">
+            <Stack spacing="4">
+              <Text size="3" weight="semibold">Readiness</Text>
+              <StatusRow
+                icon={<CheckCircle2 size={16} strokeWidth={1.8} />}
+                label="Chat provider"
+                value={metrics.providers?.activeName ?? 'Needs active provider'}
+                isReady={Boolean(metrics.providers?.activeName)}
+              />
+              <StatusRow
+                icon={<Server size={16} strokeWidth={1.8} />}
+                label="Worker connection"
+                value={areWorkersLoading ? 'Checking' : connectedWorkers > 0 ? `${connectedWorkers} online` : 'No workers online'}
+                isReady={connectedWorkers > 0}
+              />
+              <StatusRow
+                icon={<FolderKanban size={16} strokeWidth={1.8} />}
+                label="Projects"
+                value={metrics.projects === null ? 'Checking' : `${metrics.projects} available`}
+                isReady={(metrics.projects ?? 0) > 0}
+              />
+            </Stack>
+          </Card>
 
-      <Card padding="5">
-        <Stack spacing="3">
-          <Stack spacing="1">
-            <Text size="4" weight="semibold">AI Providers</Text>
-            <Text tone="muted">View usage and quota for AI providers</Text>
-          </Stack>
-          <Row justify="space-between" align="center">
-            <Text size="2" tone="muted">Monitor Anthropic and OpenAI usage</Text>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => navigate('/settings/ai-providers')}
-            >
-              Settings
-            </Button>
-          </Row>
-        </Stack>
-      </Card>
+          <Card padding="4" className="settings-page__side-card">
+            <Stack spacing="3">
+              <Text size="3" weight="semibold">Quick links</Text>
+              <QuickLink icon={<Bot size={16} />} label="AI usage" onClick={() => navigate('/settings/ai-providers')} />
+              <QuickLink icon={<KeyRound size={16} />} label="Chat API keys" onClick={() => navigate('/settings/chat')} />
+              <QuickLink icon={<Box size={16} />} label="Setup walkthrough" onClick={() => navigate('/walkthrough')} />
+              <QuickLink icon={<ExternalLink size={16} />} label="Tools" onClick={() => navigate('/tools')} />
+            </Stack>
+          </Card>
 
-      <Card padding="5">
-        <Stack spacing="3">
-          <Stack spacing="1">
-            <Text size="4" weight="semibold">Import / Export</Text>
-            <Text tone="muted">Back up and restore workspace data</Text>
-          </Stack>
-          <Row justify="space-between" align="center">
-            <Text size="2" tone="muted">Export blocks and import archive files</Text>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => navigate('/settings/data')}
-            >
-              Manage Data
-            </Button>
-          </Row>
-        </Stack>
-      </Card>
+          {version ? (
+            <Text size="1" tone="muted" className="settings-page__version">
+              Taico v{version.backend} · UI v{version.ui}
+            </Text>
+          ) : null}
+        </aside>
+      </div>
+    </div>
+  );
+}
 
-      <Card padding="5">
-        <Stack spacing="3">
-          <Stack spacing="1">
-            <Text size="4" weight="semibold">Setup walkthrough</Text>
-            <Text tone="muted">Step-by-step guide to configuring Taico</Text>
-          </Stack>
-          <Row justify="space-between" align="center">
-            <Text size="2" tone="muted">Review setup steps and track your progress</Text>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => navigate('/walkthrough')}
-            >
-              Open walkthrough
-            </Button>
-          </Row>
-        </Stack>
-      </Card>
+function themeLabel(theme: string) {
+  return theme
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
 
-      {version && (
-        <div style={{
-          textAlign: 'center',
-          paddingTop: 'var(--space-6)',
-          marginTop: 'var(--space-4)',
-          borderTop: '1px solid var(--border)',
-        }}>
-          <Text size="1" tone="muted">
-            Taico v{version.backend} • UI v{version.ui}
-          </Text>
-        </div>
-      )}
-    </Stack>
+function ThemePreviewCarousel({
+  activeTheme,
+  onSelect,
+}: {
+  activeTheme: Theme;
+  onSelect: (theme: Theme) => void;
+}) {
+  return (
+    <div className="settings-page__theme-carousel" aria-label="Theme preview selector">
+      {SETTINGS_THEME_OPTIONS.map((themeOption) => {
+        const isActive = activeTheme === themeOption.value;
+
+        return (
+          <button
+            key={themeOption.value}
+            type="button"
+            className={`settings-page__theme-preview ${isActive ? 'settings-page__theme-preview--active' : ''}`}
+            onClick={() => onSelect(themeOption.value)}
+            aria-pressed={isActive}
+          >
+            <SettingsThemeVisual preview={themeOption.preview} />
+            <span className="settings-page__theme-preview-copy">
+              <span>{themeOption.label}</span>
+              <span>{themeOption.preview.font}</span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function StatusRow({
+  icon,
+  label,
+  value,
+  isReady,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  isReady: boolean;
+}) {
+  return (
+    <div className="settings-page__status-row">
+      <span className={`settings-page__status-icon ${isReady ? 'settings-page__status-icon--ready' : ''}`}>
+        {icon}
+      </span>
+      <div>
+        <Text size="2" weight="medium">{label}</Text>
+        <Text size="1" tone="muted">{value}</Text>
+      </div>
+    </div>
+  );
+}
+
+function QuickLink({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button className="settings-page__quick-link" type="button" onClick={onClick}>
+      <span className="settings-page__quick-link-icon" aria-hidden="true">{icon}</span>
+      <span>{label}</span>
+      <ChevronRight size={15} strokeWidth={1.8} aria-hidden="true" />
+    </button>
   );
 }

--- a/apps/ui/src/features/home/SettingsProjectCreatePage.tsx
+++ b/apps/ui/src/features/home/SettingsProjectCreatePage.tsx
@@ -1,0 +1,145 @@
+import { Stack, Text, Card, Button, Row } from '../../ui/primitives';
+import { useHomeCtx } from './HomeProvider';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ProjectsService } from '../projects/api';
+import { ErrorText } from '../../ui/primitives/ErrorText';
+import '../../auth/LoginPage.css';
+import './SettingsPage.css';
+import './SettingsProjectsPage.css';
+
+export function SettingsProjectCreatePage() {
+  const { setSectionTitle } = useHomeCtx();
+  const navigate = useNavigate();
+  const [slug, setSlug] = useState('');
+  const [description, setDescription] = useState('');
+  const [repoUrl, setRepoUrl] = useState('');
+  const [color, setColor] = useState('#0969da');
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    setSectionTitle('Create Project');
+  }, []);
+
+  const handleCreateProject = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError('');
+    setIsCreating(true);
+
+    try {
+      await ProjectsService.projectsControllerCreateProject({
+        slug: slug.trim(),
+        description: description.trim() || undefined,
+        repoUrl: repoUrl.trim() || undefined,
+        color,
+      });
+
+      navigate('/settings/projects');
+    } catch (err: any) {
+      setError(err?.body?.detail || 'Failed to create project');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <Stack spacing="6" className="settings-subpage">
+      <Text tone="muted" className="settings-subpage__intro">
+        Add a project tag and optional repository link.
+      </Text>
+
+      <Card padding="5" className="settings-panel-card">
+        <form onSubmit={handleCreateProject}>
+          <Stack spacing="4">
+            <Stack spacing="2">
+              <label htmlFor="project-slug" className="login-label">
+                <Text size="2" weight="medium">Slug</Text>
+              </label>
+              <input
+                id="project-slug"
+                value={slug}
+                onChange={(event) => setSlug(event.target.value)}
+                className="login-input"
+                placeholder="taico"
+                required
+                disabled={isCreating}
+              />
+            </Stack>
+
+            <Stack spacing="2">
+              <label htmlFor="project-description" className="login-label">
+                <Text size="2" weight="medium">Description</Text>
+              </label>
+              <textarea
+                id="project-description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                className="login-input"
+                placeholder="Project description"
+                rows={3}
+                disabled={isCreating}
+                style={{ resize: 'vertical', fontFamily: 'inherit' }}
+              />
+            </Stack>
+
+            <Stack spacing="2">
+              <label htmlFor="project-repo-url" className="login-label">
+                <Text size="2" weight="medium">Repository URL</Text>
+              </label>
+              <input
+                id="project-repo-url"
+                type="url"
+                value={repoUrl}
+                onChange={(event) => setRepoUrl(event.target.value)}
+                className="login-input"
+                placeholder="https://github.com/username/repo"
+                disabled={isCreating}
+              />
+            </Stack>
+
+            <Stack spacing="2">
+              <label htmlFor="project-color" className="login-label">
+                <Text size="2" weight="medium">Color</Text>
+              </label>
+              <input
+                id="project-color"
+                type="color"
+                value={color}
+                onChange={(event) => setColor(event.target.value)}
+                className="settings-projects__color-input"
+                disabled={isCreating}
+              />
+            </Stack>
+
+            {error ? (
+              <ErrorText size="2" weight="medium">
+                {error}
+              </ErrorText>
+            ) : null}
+
+            <Row justify="end" spacing="3">
+              <Button
+                type="button"
+                variant="secondary"
+                size="md"
+                onClick={() => navigate('/settings/projects')}
+                disabled={isCreating}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="md"
+                disabled={isCreating || !slug.trim()}
+              >
+                {isCreating ? 'Creating...' : 'Create project'}
+              </Button>
+            </Row>
+          </Stack>
+        </form>
+      </Card>
+    </Stack>
+  );
+}

--- a/apps/ui/src/features/home/SettingsProjectsPage.css
+++ b/apps/ui/src/features/home/SettingsProjectsPage.css
@@ -1,0 +1,22 @@
+.settings-projects__color-input {
+  width: 72px;
+  height: 40px;
+  padding: var(--space-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  background: var(--card-bg);
+  cursor: pointer;
+}
+
+.settings-projects__color-input:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.settings-projects__success {
+  color: var(--success);
+}
+
+.settings-projects__toolbar {
+  min-width: 0;
+}

--- a/apps/ui/src/features/home/SettingsProjectsPage.tsx
+++ b/apps/ui/src/features/home/SettingsProjectsPage.tsx
@@ -1,13 +1,17 @@
 import { Stack, Text, Card, Button, Row } from '../../ui/primitives';
 import { useHomeCtx } from './HomeProvider';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { ProjectsService } from '../projects/api';
 import type { ProjectResponseDto } from "@taico/client";
 import { ErrorText } from '../../ui/primitives/ErrorText';
 import '../../auth/LoginPage.css';
+import './SettingsPage.css';
+import './SettingsProjectsPage.css';
 
 export function SettingsProjectsPage() {
   const { setSectionTitle } = useHomeCtx();
+  const navigate = useNavigate();
   const [projects, setProjects] = useState<ProjectResponseDto[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
@@ -75,7 +79,7 @@ export function SettingsProjectsPage() {
 
   if (isLoading) {
     return (
-      <Stack spacing="6">
+      <Stack spacing="6" className="settings-subpage">
         <Text tone="muted">Loading projects...</Text>
       </Stack>
     );
@@ -83,7 +87,7 @@ export function SettingsProjectsPage() {
 
   if (error) {
     return (
-      <Stack spacing="6">
+      <Stack spacing="6" className="settings-subpage">
         <ErrorText>{error}</ErrorText>
         <Button variant="secondary" onClick={loadProjects}>
           Retry
@@ -93,16 +97,40 @@ export function SettingsProjectsPage() {
   }
 
   return (
-    <Stack spacing="6">
-      <Text tone="muted">Manage your projects</Text>
+    <Stack spacing="6" className="settings-subpage">
+      <Text tone="muted" className="settings-subpage__intro">
+        Manage project metadata and repository links used by task workflows.
+      </Text>
+
+      <Row justify="space-between" align="center" className="settings-projects__toolbar">
+        <Text size="3" weight="semibold">Projects</Text>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => navigate('/settings/projects/new')}
+        >
+          New project
+        </Button>
+      </Row>
 
       {projects.length === 0 ? (
-        <Card padding="5">
-          <Text tone="muted">No projects found</Text>
+        <Card padding="5" className="settings-panel-card">
+          <Stack spacing="3">
+            <Text tone="muted">No projects found</Text>
+            <Row>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => navigate('/settings/projects/new')}
+              >
+                Create project
+              </Button>
+            </Row>
+          </Stack>
         </Card>
       ) : (
         projects.map((project) => (
-          <Card key={project.id} padding="5">
+          <Card key={project.id} padding="5" className="settings-panel-card">
             <Stack spacing="4">
               <Stack spacing="2">
                 <Text size="4" weight="semibold">{project.slug}</Text>

--- a/apps/ui/src/features/home/SettingsThemeVisual.tsx
+++ b/apps/ui/src/features/home/SettingsThemeVisual.tsx
@@ -1,0 +1,46 @@
+import type { CSSProperties } from 'react';
+import type { SettingsThemePreview } from './settingsThemes';
+
+type SettingsThemeVisualProps = {
+  preview: SettingsThemePreview;
+  size?: 'compact' | 'large';
+};
+
+export function SettingsThemeVisual({ preview, size = 'compact' }: SettingsThemeVisualProps) {
+  const style = {
+    '--theme-preview-bg': preview.background,
+    '--theme-preview-surface': preview.surface,
+    '--theme-preview-card': preview.card,
+    '--theme-preview-border': preview.border,
+    '--theme-preview-text': preview.text,
+    '--theme-preview-muted': preview.muted,
+    '--theme-preview-accent': preview.accent,
+    '--theme-preview-accent-soft': preview.accentSoft,
+  } as CSSProperties;
+
+  return (
+    <span
+      className={`settings-theme-visual settings-theme-visual--${size}`}
+      style={style}
+      aria-hidden="true"
+    >
+      <span className="settings-theme-visual__window">
+        <span className="settings-theme-visual__rail">
+          <span className="settings-theme-visual__accent-dot" />
+          <span className="settings-theme-visual__rail-line" />
+          <span className="settings-theme-visual__rail-line settings-theme-visual__rail-line--short" />
+        </span>
+        <span className="settings-theme-visual__canvas">
+          <span className="settings-theme-visual__font">{preview.font === 'Mono' ? 'Aa' : 'Ag'}</span>
+          <span className="settings-theme-visual__line settings-theme-visual__line--wide" />
+          <span className="settings-theme-visual__panel">
+            <span className="settings-theme-visual__chip" />
+            <span className="settings-theme-visual__line" />
+            <span className="settings-theme-visual__line settings-theme-visual__line--short" />
+          </span>
+          <span className="settings-theme-visual__button" />
+        </span>
+      </span>
+    </span>
+  );
+}

--- a/apps/ui/src/features/home/SettingsWorkersPage.tsx
+++ b/apps/ui/src/features/home/SettingsWorkersPage.tsx
@@ -8,6 +8,7 @@ import {
   HeartCrack,
 } from "lucide-react";
 
+import './SettingsPage.css';
 import './SettingsWorkersPage.css';
 
 export function SettingsWorkersPage() {
@@ -43,21 +44,21 @@ export function SettingsWorkersPage() {
 
   if (isLoading) {
     return (
-      <Stack spacing="6">
+      <Stack spacing="6" className="settings-subpage">
         <Text>Loading...</Text>
       </Stack>
     );
   }
 
   return (
-    <Stack spacing="6">
-      <Text tone="muted">
+    <Stack spacing="6" className="settings-subpage">
+      <Text tone="muted" className="settings-subpage__intro">
         Workers execute tasks in the background. Configure workers to enable automated task execution.
       </Text>
 
       {error ? <ErrorText size="2" weight="medium">{error}</ErrorText> : null}
 
-      <Card padding="5">
+      <Card padding="5" className="settings-panel-card">
         <Stack spacing="4">
           <Stack spacing="1">
             <Text size="4" weight="semibold">
@@ -92,7 +93,7 @@ export function SettingsWorkersPage() {
         </Text>
 
         {workers.length === 0 ? (
-          <Card padding="5">
+          <Card padding="5" className="settings-panel-card">
             <Text tone="muted">
               No workers registered yet. Run the command above to start your first worker.
             </Text>
@@ -104,7 +105,7 @@ export function SettingsWorkersPage() {
             const lastSeenStr = lastSeenDate.toLocaleString();
 
             return (
-              <Card key={worker.id} padding="5">
+              <Card key={worker.id} padding="5" className="settings-panel-card">
                 <Stack spacing="3">
                   <Row justify="space-between" align="center">
                     <Stack spacing="1">

--- a/apps/ui/src/features/home/settingsThemes.ts
+++ b/apps/ui/src/features/home/settingsThemes.ts
@@ -1,0 +1,231 @@
+import type { Theme } from '../../app/providers/ThemeProvider';
+
+export type SettingsThemePreview = {
+  background: string;
+  surface: string;
+  card: string;
+  border: string;
+  text: string;
+  muted: string;
+  accent: string;
+  accentSoft: string;
+  font: string;
+};
+
+export type SettingsThemeOption = {
+  value: Theme;
+  label: string;
+  description: string;
+  preview: SettingsThemePreview;
+};
+
+export const SETTINGS_THEME_OPTIONS: SettingsThemeOption[] = [
+  {
+    value: 'light',
+    label: 'Light',
+    description: 'Clean light theme with a crisp blue accent.',
+    preview: {
+      background: '#ffffff',
+      surface: '#f6f8fa',
+      card: '#ffffff',
+      border: '#d1d9e0',
+      text: '#1f2328',
+      muted: '#59636e',
+      accent: '#0969da',
+      accentSoft: '#ddf4ff',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'dark',
+    label: 'Dark',
+    description: 'Low-light surfaces with GitHub-style blue highlights.',
+    preview: {
+      background: '#0d1117',
+      surface: '#161b22',
+      card: '#0d1117',
+      border: '#30363d',
+      text: '#e6edf3',
+      muted: '#8b949e',
+      accent: '#2f81f7',
+      accentSoft: '#1f6feb33',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'clarity',
+    label: 'Clarity',
+    description: 'Soft neutral surfaces for focused daytime work.',
+    preview: {
+      background: '#f7f7f5',
+      surface: '#f2f4f7',
+      card: '#ffffff',
+      border: '#d9dee5',
+      text: '#1f2328',
+      muted: '#66707a',
+      accent: '#3971d9',
+      accentSoft: '#e5efff',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'github',
+    label: 'GitHub',
+    description: 'GitHub-inspired neutrals with a green action color.',
+    preview: {
+      background: '#ffffff',
+      surface: '#f6f8fa',
+      card: '#ffffff',
+      border: '#d0d7de',
+      text: '#24292f',
+      muted: '#57606a',
+      accent: '#1f883d',
+      accentSoft: '#dafbe1',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'forest',
+    label: 'Forest',
+    description: 'Dark green workspace with softer natural contrast.',
+    preview: {
+      background: '#0f1a0f',
+      surface: '#152615',
+      card: '#102010',
+      border: '#2d4a2d',
+      text: '#e8f5e8',
+      muted: '#9bb89b',
+      accent: '#52c952',
+      accentSoft: '#1f4d2a',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'terminal',
+    label: 'Terminal',
+    description: 'Classic terminal green on a black interface.',
+    preview: {
+      background: '#000000',
+      surface: '#0a0a0a',
+      card: '#050505',
+      border: '#00aa00',
+      text: '#00ff00',
+      muted: '#00aa00',
+      accent: '#00dd00',
+      accentSoft: '#003b00',
+      font: 'Mono',
+    },
+  },
+  {
+    value: 'ai-vibes',
+    label: 'AI Vibes',
+    description: 'Deep purples with neon-like accents.',
+    preview: {
+      background: '#0c0716',
+      surface: '#1a102b',
+      card: '#130b21',
+      border: '#3b255f',
+      text: '#f5efff',
+      muted: '#c4b5db',
+      accent: '#a855f7',
+      accentSoft: '#3b1762',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'halo',
+    label: 'Halo',
+    description: 'Light background with cooler layered surfaces.',
+    preview: {
+      background: '#f9f9fc',
+      surface: '#eef1f9',
+      card: '#ffffff',
+      border: '#d8deef',
+      text: '#1f2937',
+      muted: '#667085',
+      accent: '#3b5bcc',
+      accentSoft: '#e6ebff',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'mono',
+    label: 'Mono',
+    description: 'Black and white minimalism with restrained contrast.',
+    preview: {
+      background: '#ffffff',
+      surface: '#f5f5f5',
+      card: '#ffffff',
+      border: '#d4d4d4',
+      text: '#111111',
+      muted: '#666666',
+      accent: '#111111',
+      accentSoft: '#eeeeee',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'terminal-amber',
+    label: 'Terminal Amber',
+    description: 'Warm terminal tones with a calm blue accent.',
+    preview: {
+      background: '#0b0a09',
+      surface: '#17130d',
+      card: '#120f0b',
+      border: '#3a2d16',
+      text: '#f5d78e',
+      muted: '#b9975b',
+      accent: '#8ab4f8',
+      accentSoft: '#1d2740',
+      font: 'Mono',
+    },
+  },
+  {
+    value: 'oceanic',
+    label: 'Oceanic',
+    description: 'Cool blues and teals for a calmer dark theme.',
+    preview: {
+      background: '#0c1b2a',
+      surface: '#102a3d',
+      card: '#0f2233',
+      border: '#1d4a5f',
+      text: '#e6fffb',
+      muted: '#9bd5d0',
+      accent: '#4fd1c5',
+      accentSoft: '#123c47',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'party',
+    label: 'Party',
+    description: 'Playful warm palette with saturated highlights.',
+    preview: {
+      background: '#fff7f0',
+      surface: '#fff0e0',
+      card: '#ffffff',
+      border: '#ffd4d4',
+      text: '#2d1b1b',
+      muted: '#7a5a5a',
+      accent: '#ff6b6b',
+      accentSoft: '#ffe3df',
+      font: 'Inter',
+    },
+  },
+  {
+    value: 'tribute',
+    label: 'Tribute',
+    description: 'Dark sidebar energy inspired by the previous UI.',
+    preview: {
+      background: '#0b1220',
+      surface: '#111827',
+      card: '#0f172a',
+      border: '#1e293b',
+      text: '#e5e7eb',
+      muted: '#94a3b8',
+      accent: '#2563eb',
+      accentSoft: '#172554',
+      font: 'Inter',
+    },
+  },
+];


### PR DESCRIPTION
## Summary

Redesigns the settings experience from a plain link list into a structured settings hub with consistent section cards, readiness/quick-link panels, and matching follow-up pages.

Adds visual theme previews in both the settings overview carousel and the Appearance page. The theme catalog is now shared, includes all available styles, and fixes the missing typed `party` theme.

Splits project creation out of the project management list: `/settings/projects` now manages existing projects, while `/settings/projects/new` owns the create flow.

## Validation

- `npm run build:dev`
- `npm -w apps/ui run build`
- Browser-checked `/settings`, `/settings/appearance`, `/settings/projects`, and `/settings/projects/new` on `localhost:2000`
- Checked browser console for errors on the settings theme pages
