### PR TITLE
Restore Lucide icons to status buttons in Task Detail view

### DIFF
--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -1041,19 +1041,23 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
       </DataRowContainer>
 
       <DataRowContainer className='task-detail-page__status-buttons'>
-        {Object.entries(TASKS_STATUS).map(([status, info]) => (
-          <Button
-            key={status}
-            size='sm'
-            variant={status === task.status ? 'primary' : 'secondary'}
-            onClick={() => handleChangeStatus(status as TaskStatus)}
-            disabled={isLoading}
-          >
-            <Stack spacing='0'>
-              <div>{info.label}</div>
-            </Stack>
-          </Button>
-        ))}
+        {Object.entries(TASKS_STATUS).map(([status, info]) => {
+          const Icon = info.icon;
+          return (
+            <Button
+              key={status}
+              size='sm'
+              variant={status === task.status ? 'primary' : 'secondary'}
+              onClick={() => handleChangeStatus(status as TaskStatus)}
+              disabled={isLoading}
+            >
+              <Stack spacing='0'>
+                <Icon size={16} />
+                <div>{info.label}</div>
+              </Stack>
+            </Button>
+          );
+        })}
       </DataRowContainer>
 
       <Button


### PR DESCRIPTION
## Summary

Restores the Lucide icon components (Inbox, Hammer, Eye, Rocket) to the status buttons in the Task Detail view. These icons were missing from the buttons, causing them to appear shorter than expected.

## Changes

- Modified `TaskDetailPage.tsx` to render the icon component from `TASKS_STATUS` for each status button
- Icons are displayed above the button labels with size 16
- Maintains `size='sm'` to prevent mobile overflow while restoring proper button height

## Test Plan

- ✅ `npm run build:dev` - Build passes
- ✅ Visual inspection confirms buttons now have proper height matching delete/assign buttons
- ✅ No mobile overflow issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)