### PR TITLE
Center task status icons

### DIFF
--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -1051,8 +1051,8 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
               onClick={() => handleChangeStatus(status as TaskStatus)}
               disabled={isLoading}
             >
-              <Stack spacing='0'>
-                <Icon size={16} />
+              <Stack spacing='1' align='center'>
+                <Icon size={20} />
                 <div>{info.label}</div>
               </Stack>
             </Button>


### PR DESCRIPTION
## Summary
- Center the restored Lucide icons in task detail status buttons.
- Increase status icon size from 16px to 20px and add the existing small stack gap so the buttons regain height without changing `size='sm'` horizontal padding.

## Validation
- `npm run build:dev`
- `CHOKIDAR_USEPOLLING=true npm run dev:3` (UI ready on 2008, UI v1 ready on 2009, backend ready on 2010; existing AppInitRunner prompt context block error still appears during startup)

## Technical Debt
- None introduced.