### PR TITLE
Fix: Update existing projects with new data during creation

### DIFF
--- a/apps/backend/src/meta/projects.service.ts
+++ b/apps/backend/src/meta/projects.service.ts
@@ -62,8 +62,14 @@ export class ProjectsService {
         tagId: tag.id,
       });
     } else {
+      // Update existing project with new data
+      project.slug = input.slug;
+      project.description = input.description;
+      project.repoUrl = input.repoUrl;
+      project = await this.projectRepository.save(project);
+
       this.logger.log({
-        message: 'Project already exists',
+        message: 'Project already exists, updated with new data',
         projectId: project.id,
         slug: project.slug,
       });


### PR DESCRIPTION
## Summary

Fixed a bug where GitHub URL (and other fields) were not being saved when creating a project from the settings page.

## Root Cause

In `ProjectsService.createProject()`, when a project with the same tag already existed, the method would return the existing project without updating it with the new data. This caused fields like `repoUrl` to not be saved if a project creation was retried or if the tag existed from a previous attempt.

## Changes

- Modified `apps/backend/src/meta/projects.service.ts` to update existing projects with new data (slug, description, repoUrl) instead of just returning them unchanged
- Updated log message to indicate when a project is updated vs created

## Test Plan

- ✅ Ran `npm run build:dev` - all packages compile successfully
- ✅ Ran `npm run dev:1` - application starts without errors
- ✅ Verified TypeScript compilation passes

## Technical Debt

None identified for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)