### PR TITLE
Add task dependency graph view

### DIFF
--- a/apps/ui/src/features/tasks/TaskDependenciesPage.css
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.css
@@ -1,0 +1,157 @@
+.task-dependencies-page {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+}
+
+.task-dependencies-page--state {
+  align-items: center;
+  justify-content: center;
+}
+
+.task-dependencies-canvas {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(160px, 1fr) minmax(280px, 360px);
+  gap: var(--space-5);
+  width: 100%;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-4);
+  background: var(--surface);
+}
+
+.task-dependencies-empty {
+  grid-column: 1 / -1;
+  align-self: center;
+  justify-self: center;
+  display: grid;
+  gap: var(--space-2);
+  max-width: 420px;
+  text-align: center;
+}
+
+.task-dependencies-column {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  align-content: start;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.task-dependencies-column--right {
+  grid-column: 3;
+}
+
+.task-dependencies-column__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--space-1) var(--space-2);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.task-dependencies-column__cards {
+  display: grid;
+  gap: 14px;
+}
+
+.dependency-task-card {
+  height: 76px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--space-2);
+  align-items: center;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+  background: var(--card-bg);
+  color: var(--text);
+  padding: var(--space-3);
+  text-align: left;
+  cursor: pointer;
+}
+
+.dependency-task-card:hover {
+  border-color: var(--accent);
+}
+
+.dependency-task-card--done {
+  border-color: var(--success);
+}
+
+.dependency-task-card__title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-2);
+  font-weight: var(--fw-medium);
+}
+
+.dependency-status-indicator,
+.dependency-task-card__spinner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+.dependency-status-indicator--not-started {
+  border: 2px solid var(--text-muted);
+}
+
+.dependency-status-indicator--in-progress {
+  background: var(--success);
+}
+
+.dependency-status-indicator--for-review {
+  border: 2px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.dependency-status-indicator--done {
+  border: 2px solid var(--success);
+  color: var(--success);
+}
+
+.dependency-task-card__spinner {
+  border: 2px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+  border-top-color: var(--accent);
+  animation: dependency-spin 0.9s linear infinite;
+}
+
+.task-dependencies-connections {
+  grid-column: 2;
+  align-self: start;
+  width: 100%;
+  min-height: 100%;
+  margin-top: calc(var(--space-3) + var(--fs-2) + var(--space-2));
+  overflow: visible;
+}
+
+.task-dependencies-connection {
+  fill: none;
+  stroke: var(--border);
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+
+@keyframes dependency-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 900px) {
+  .task-dependencies-canvas {
+    grid-template-columns: minmax(240px, 1fr) 96px minmax(240px, 1fr);
+    gap: var(--space-3);
+  }
+}

--- a/apps/ui/src/features/tasks/TaskDependenciesPage.css
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.css
@@ -1,7 +1,17 @@
+.beta-shell__desktop__main:has(.task-dependencies-page),
+.desktop-shell:has(.task-dependencies-page),
+.desktop-shell__content:has(.task-dependencies-page) {
+  min-width: 0;
+  overflow: hidden;
+}
+
 .task-dependencies-page {
   height: 100%;
   min-height: 0;
+  min-width: 0;
+  width: 100%;
   display: flex;
+  overflow: hidden;
 }
 
 .task-dependencies-page--state {
@@ -11,66 +21,109 @@
 
 .task-dependencies-canvas {
   position: relative;
-  display: grid;
-  grid-template-columns: minmax(280px, 360px) minmax(160px, 1fr) minmax(280px, 360px);
-  gap: var(--space-5);
+  display: flex;
+  flex-direction: column;
   width: 100%;
+  max-width: 100%;
   min-height: 0;
-  overflow: auto;
+  min-width: 0;
+  overflow: hidden;
+  overscroll-behavior: contain;
   padding: var(--space-4);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-4);
   background: var(--surface);
+  background-image:
+    linear-gradient(color-mix(in srgb, var(--border-subtle) 65%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--border-subtle) 65%, transparent) 1px, transparent 1px);
+  background-size: 32px 32px;
+  contain: layout paint;
 }
 
 .task-dependencies-empty {
-  grid-column: 1 / -1;
-  align-self: center;
-  justify-self: center;
+  position: absolute;
+  inset: 0;
+  margin: auto;
   display: grid;
+  place-content: center;
   gap: var(--space-2);
   max-width: 420px;
   text-align: center;
 }
 
-.task-dependencies-column {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  align-content: start;
-  gap: var(--space-3);
-  min-width: 0;
-}
-
-.task-dependencies-column--right {
-  grid-column: 3;
-}
-
-.task-dependencies-column__header {
-  display: flex;
+.task-dependencies-toolbar {
+  z-index: 3;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0 var(--space-1) var(--space-2);
-  border-bottom: 1px solid var(--border-subtle);
+  align-self: flex-start;
+  flex: 0 0 auto;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+  padding: var(--space-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-3);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(8px);
 }
 
-.task-dependencies-column__cards {
-  display: grid;
-  gap: 14px;
+.task-dependencies-toolbar__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid transparent;
+  border-radius: var(--r-2);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.task-dependencies-toolbar__button:hover {
+  border-color: var(--border);
+  background: var(--card-bg);
+}
+
+.task-dependencies-toolbar__zoom {
+  min-width: 44px;
+  color: var(--text-muted);
+  font-size: var(--fs-1);
+  font-weight: var(--fw-medium);
+  text-align: center;
+}
+
+.task-dependencies-viewport {
+  position: relative;
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  overscroll-behavior: contain;
+}
+
+.task-dependencies-graph {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: top left;
 }
 
 .dependency-task-card {
-  height: 76px;
+  position: absolute;
+  z-index: 2;
+  height: 48px;
+  width: 228px;
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: var(--space-2);
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: var(--space-2);
   align-items: center;
-  width: 100%;
   border: 1px solid var(--border);
-  border-radius: var(--r-3);
+  border-radius: var(--r-2);
   background: var(--card-bg);
   color: var(--text);
-  padding: var(--space-3);
+  padding: var(--space-2) var(--space-3);
   text-align: left;
   cursor: pointer;
 }
@@ -83,62 +136,99 @@
   border-color: var(--success);
 }
 
+.dependency-task-card__content {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+}
+
 .dependency-task-card__title {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: var(--fs-2);
+  font-size: var(--fs-1);
   font-weight: var(--fw-medium);
 }
 
-.dependency-status-indicator,
+.dependency-task-card__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.dependency-run-status-icon,
 .dependency-task-card__spinner {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
   border-radius: 999px;
   flex: 0 0 auto;
 }
 
-.dependency-status-indicator--not-started {
-  border: 2px solid var(--text-muted);
+.dependency-run-status-icon {
+  width: 22px;
+  height: 22px;
+  font-size: var(--fs-2);
+  font-weight: var(--fw-bold);
+  line-height: 1;
 }
 
-.dependency-status-indicator--in-progress {
+.dependency-run-status-icon--success {
   background: var(--success);
+  color: var(--text-inverse);
 }
 
-.dependency-status-indicator--for-review {
-  border: 2px solid var(--accent);
+.dependency-task-card__status-badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  height: 16px;
+  max-width: 76px;
+  padding: 0 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  color: var(--text);
+  font-size: 10px;
+  font-weight: var(--fw-medium);
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-task-card__status-badge--active {
+  border-color: color-mix(in srgb, var(--warning) 45%, var(--border));
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
+}
+
+.dependency-task-card__status-badge--review {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
   background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
-.dependency-status-indicator--done {
-  border: 2px solid var(--success);
-  color: var(--success);
-}
-
 .dependency-task-card__spinner {
+  width: 16px;
+  height: 16px;
   border: 2px solid color-mix(in srgb, var(--accent) 35%, var(--border));
   border-top-color: var(--accent);
   animation: dependency-spin 0.9s linear infinite;
 }
 
 .task-dependencies-connections {
-  grid-column: 2;
-  align-self: start;
-  width: 100%;
-  min-height: 100%;
-  margin-top: calc(var(--space-3) + var(--fs-2) + var(--space-2));
+  position: absolute;
+  inset: 0;
+  z-index: 1;
   overflow: visible;
+  pointer-events: none;
 }
 
 .task-dependencies-connection {
   fill: none;
-  stroke: var(--border);
+  stroke: color-mix(in srgb, var(--text-muted) 48%, transparent);
   stroke-width: 2;
   vector-effect: non-scaling-stroke;
 }
@@ -149,9 +239,8 @@
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width: 700px) {
   .task-dependencies-canvas {
-    grid-template-columns: minmax(240px, 1fr) 96px minmax(240px, 1fr);
-    gap: var(--space-3);
+    padding: var(--space-3);
   }
 }

--- a/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { Check } from "lucide-react";
+import { Text } from "../../ui/primitives";
+import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
+import { TaskStatus, TASKS_STATUS } from "./const";
+import { useTasksCtx } from "./TasksProvider";
+import type { Task } from "./types";
+import { useExecutions } from "../executions/useExecutions";
+import "./TaskDependenciesPage.css";
+
+type GraphConnection = {
+  taskId: string;
+  blockerId: string;
+  taskIndex: number;
+  blockerIndex: number;
+};
+
+const CARD_HEIGHT = 76;
+const CARD_GAP = 14;
+
+export function TaskDependenciesPage(): React.JSX.Element {
+  const { tasks, isLoading, error, setSectionTitle, activityByTaskId } = useTasksCtx();
+  const { active } = useExecutions();
+  const navigate = useNavigate();
+
+  useDocumentTitle();
+
+  useEffect(() => {
+    setSectionTitle("Dependencies");
+  }, [setSectionTitle]);
+
+  const graph = useMemo(() => buildDependencyGraph(tasks), [tasks]);
+  const activeTaskIds = useMemo(() => new Set(active.map((execution) => execution.taskId)), [active]);
+
+  if (isLoading && tasks.length === 0) {
+    return (
+      <div className="task-dependencies-page task-dependencies-page--state">
+        <Text tone="muted">Loading dependencies...</Text>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="task-dependencies-page task-dependencies-page--state">
+        <Text tone="muted">Could not load dependencies: {error}</Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="task-dependencies-page">
+      <div className="task-dependencies-canvas" aria-label="Task dependency graph">
+        {graph.dependentTasks.length === 0 ? (
+          <div className="task-dependencies-empty">
+            <Text size="3" weight="semibold">No dependency graph yet</Text>
+            <Text tone="muted">Add dependencies to tasks and they will appear here as task-to-blocker connections.</Text>
+          </div>
+        ) : (
+          <>
+            <GraphColumn title="Tasks with dependencies" tasks={graph.dependentTasks} activityByTaskId={activityByTaskId} activeTaskIds={activeTaskIds} onOpenTask={(taskId) => navigate(`/tasks/task/${taskId}`)} />
+            <ConnectionLayer connections={graph.connections} leftCount={graph.dependentTasks.length} rightCount={graph.blockerTasks.length} />
+            <GraphColumn title="Blocking tasks" tasks={graph.blockerTasks} activityByTaskId={activityByTaskId} activeTaskIds={activeTaskIds} align="right" onOpenTask={(taskId) => navigate(`/tasks/task/${taskId}`)} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function GraphColumn({
+  title,
+  tasks,
+  activityByTaskId,
+  activeTaskIds,
+  align = "left",
+  onOpenTask,
+}: {
+  title: string;
+  tasks: Task[];
+  activityByTaskId: Record<string, unknown>;
+  activeTaskIds: Set<string>;
+  align?: "left" | "right";
+  onOpenTask: (taskId: string) => void;
+}) {
+  return (
+    <section className={`task-dependencies-column task-dependencies-column--${align}`}>
+      <div className="task-dependencies-column__header">
+        <Text size="2" weight="semibold">{title}</Text>
+        <Text size="1" tone="muted">{tasks.length}</Text>
+      </div>
+      <div className="task-dependencies-column__cards">
+        {tasks.map((task) => (
+          <DependencyTaskCard key={task.id} task={task} hasActiveExecution={activeTaskIds.has(task.id) || Boolean(activityByTaskId[task.id])} onOpen={() => onOpenTask(task.id)} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DependencyTaskCard({ task, hasActiveExecution, onOpen }: { task: Task; hasActiveExecution: boolean; onOpen: () => void }) {
+  return (
+    <button className={`dependency-task-card dependency-task-card--${task.status.toLowerCase().replaceAll("_", "-")}`} type="button" onClick={onOpen}>
+      <StatusIndicator status={task.status as TaskStatus} />
+      <span className="dependency-task-card__title">{task.name}</span>
+      {hasActiveExecution ? <span className="dependency-task-card__spinner" aria-label="Active execution" /> : null}
+    </button>
+  );
+}
+
+function StatusIndicator({ status }: { status: TaskStatus }) {
+  const label = TASKS_STATUS[status].label;
+  return (
+    <span className={`dependency-status-indicator dependency-status-indicator--${status.toLowerCase().replaceAll("_", "-")}`} aria-label={label} title={label}>
+      {status === TaskStatus.DONE ? <Check size={12} strokeWidth={2.5} /> : null}
+    </span>
+  );
+}
+
+function ConnectionLayer({ connections, leftCount, rightCount }: { connections: GraphConnection[]; leftCount: number; rightCount: number }) {
+  const rowCount = Math.max(leftCount, rightCount);
+  const height = rowCount * CARD_HEIGHT + Math.max(rowCount - 1, 0) * CARD_GAP;
+
+  return (
+    <svg className="task-dependencies-connections" viewBox={`0 0 320 ${height}`} preserveAspectRatio="none" aria-hidden="true">
+      {connections.map((connection) => {
+        const startY = connection.taskIndex * (CARD_HEIGHT + CARD_GAP) + CARD_HEIGHT / 2;
+        const endY = connection.blockerIndex * (CARD_HEIGHT + CARD_GAP) + CARD_HEIGHT / 2;
+        return (
+          <path
+            key={`${connection.taskId}-${connection.blockerId}`}
+            d={`M 0 ${startY} C 120 ${startY}, 200 ${endY}, 320 ${endY}`}
+            className="task-dependencies-connection"
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function buildDependencyGraph(tasks: Task[]) {
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const dependentTasks = tasks.filter((task) => task.dependsOnIds.length > 0);
+  const blockerIdSet = new Set(dependentTasks.flatMap((task) => task.dependsOnIds));
+  const blockerTasks = Array.from(blockerIdSet)
+    .map((id) => taskById.get(id))
+    .filter((task): task is Task => Boolean(task));
+  const blockerIndexById = new Map(blockerTasks.map((task, index) => [task.id, index]));
+
+  const connections = dependentTasks.flatMap((task, taskIndex) =>
+    task.dependsOnIds.flatMap((blockerId) => {
+      const blockerIndex = blockerIndexById.get(blockerId);
+      if (blockerIndex === undefined) return [];
+      return [{ taskId: task.id, blockerId, taskIndex, blockerIndex }];
+    }),
+  );
+
+  return { dependentTasks, blockerTasks, connections };
+}

--- a/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
@@ -1,28 +1,54 @@
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type WheelEvent } from "react";
 import { useNavigate } from "react-router-dom";
-import { Check } from "lucide-react";
+import { Maximize2, ZoomIn, ZoomOut } from "lucide-react";
 import { Text } from "../../ui/primitives";
 import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
-import { TaskStatus, TASKS_STATUS } from "./const";
+import { TaskStatus } from "./const";
 import { useTasksCtx } from "./TasksProvider";
 import type { Task } from "./types";
 import { useExecutions } from "../executions/useExecutions";
 import "./TaskDependenciesPage.css";
 
 type GraphConnection = {
-  taskId: string;
-  blockerId: string;
-  taskIndex: number;
-  blockerIndex: number;
+  fromTaskId: string;
+  toTaskId: string;
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
 };
 
-const CARD_HEIGHT = 76;
-const CARD_GAP = 14;
+type GraphNode = {
+  task: Task;
+  layer: number;
+  x: number;
+  y: number;
+};
+
+type DependencyGraph = {
+  nodes: GraphNode[];
+  connections: GraphConnection[];
+  width: number;
+  height: number;
+};
+
+const NODE_WIDTH = 228;
+const NODE_HEIGHT = 48;
+const LAYER_GAP = 112;
+const ROW_GAP = 18;
+const CANVAS_PADDING = 48;
+const MIN_ZOOM = 0.55;
+const MAX_ZOOM = 1.6;
+const ZOOM_STEP = 0.15;
+const WHEEL_ZOOM_SENSITIVITY = 0.0025;
 
 export function TaskDependenciesPage(): React.JSX.Element {
   const { tasks, isLoading, error, setSectionTitle, activityByTaskId } = useTasksCtx();
   const { active } = useExecutions();
   const navigate = useNavigate();
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
 
   useDocumentTitle();
 
@@ -32,6 +58,69 @@ export function TaskDependenciesPage(): React.JSX.Element {
 
   const graph = useMemo(() => buildDependencyGraph(tasks), [tasks]);
   const activeTaskIds = useMemo(() => new Set(active.map((execution) => execution.taskId)), [active]);
+  const activeStatusByTaskId = useMemo(() => {
+    return new Map(active.map((execution) => [execution.taskId, execution.taskStatus as TaskStatus]));
+  }, [active]);
+
+  const applyZoom = useCallback((nextZoomValue: number, focusPoint?: { x: number; y: number }) => {
+    const viewport = viewportRef.current;
+    const nextZoom = clampZoom(nextZoomValue);
+
+    if (!viewport || nextZoom === zoom) {
+      setZoom(nextZoom);
+      return;
+    }
+
+    const focus = focusPoint ?? {
+      x: viewport.clientWidth / 2,
+      y: viewport.clientHeight / 2,
+    };
+
+    setPan((currentPan) => {
+      const graphX = (focus.x - currentPan.x) / zoom;
+      const graphY = (focus.y - currentPan.y) / zoom;
+      return {
+        x: focus.x - graphX * nextZoom,
+        y: focus.y - graphY * nextZoom,
+      };
+    });
+    setZoom(nextZoom);
+  }, [zoom]);
+
+  const updateZoom = useCallback((delta: number) => {
+    setZoom((currentZoom) => clampZoom(currentZoom + delta));
+  }, []);
+  const resetZoom = useCallback(() => {
+    setPan({ x: 0, y: 0 });
+    setZoom(1);
+  }, []);
+
+  const handleCanvasWheel = useCallback((event: WheelEvent<HTMLDivElement>) => {
+    if (graph.nodes.length === 0) {
+      return;
+    }
+
+    const viewport = event.currentTarget;
+
+    if (event.ctrlKey || event.metaKey) {
+      event.preventDefault();
+      const rect = viewport.getBoundingClientRect();
+      applyZoom(zoom * Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY), {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+      });
+      return;
+    }
+
+    if (event.deltaX !== 0 || event.deltaY !== 0) {
+      event.preventDefault();
+      const deltaMultiplier = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? viewport.clientHeight : 1;
+      setPan((currentPan) => ({
+        x: currentPan.x - event.deltaX * deltaMultiplier,
+        y: currentPan.y - event.deltaY * deltaMultiplier,
+      }));
+    }
+  }, [applyZoom, graph.nodes.length, zoom]);
 
   if (isLoading && tasks.length === 0) {
     return (
@@ -52,16 +141,50 @@ export function TaskDependenciesPage(): React.JSX.Element {
   return (
     <div className="task-dependencies-page">
       <div className="task-dependencies-canvas" aria-label="Task dependency graph">
-        {graph.dependentTasks.length === 0 ? (
+        {graph.nodes.length === 0 ? (
           <div className="task-dependencies-empty">
             <Text size="3" weight="semibold">No dependency graph yet</Text>
             <Text tone="muted">Add dependencies to tasks and they will appear here as task-to-blocker connections.</Text>
           </div>
         ) : (
           <>
-            <GraphColumn title="Tasks with dependencies" tasks={graph.dependentTasks} activityByTaskId={activityByTaskId} activeTaskIds={activeTaskIds} onOpenTask={(taskId) => navigate(`/tasks/task/${taskId}`)} />
-            <ConnectionLayer connections={graph.connections} leftCount={graph.dependentTasks.length} rightCount={graph.blockerTasks.length} />
-            <GraphColumn title="Blocking tasks" tasks={graph.blockerTasks} activityByTaskId={activityByTaskId} activeTaskIds={activeTaskIds} align="right" onOpenTask={(taskId) => navigate(`/tasks/task/${taskId}`)} />
+            <div className="task-dependencies-toolbar" aria-label="Dependency graph controls">
+              <button className="task-dependencies-toolbar__button" type="button" onClick={() => updateZoom(-ZOOM_STEP)} aria-label="Zoom out" title="Zoom out">
+                <ZoomOut size={16} strokeWidth={1.8} />
+              </button>
+              <span className="task-dependencies-toolbar__zoom">{Math.round(zoom * 100)}%</span>
+              <button className="task-dependencies-toolbar__button" type="button" onClick={() => updateZoom(ZOOM_STEP)} aria-label="Zoom in" title="Zoom in">
+                <ZoomIn size={16} strokeWidth={1.8} />
+              </button>
+              <button className="task-dependencies-toolbar__button" type="button" onClick={resetZoom} aria-label="Reset zoom" title="Reset zoom">
+                <Maximize2 size={16} strokeWidth={1.8} />
+              </button>
+            </div>
+            <div
+              ref={viewportRef}
+              className="task-dependencies-viewport"
+              onWheel={handleCanvasWheel}
+            >
+              <div
+                className="task-dependencies-graph"
+                style={{
+                  width: graph.width,
+                  height: graph.height,
+                  transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+                }}
+              >
+                <ConnectionLayer connections={graph.connections} width={graph.width} height={graph.height} />
+                {graph.nodes.map((node) => (
+                  <DependencyTaskCard
+                    key={node.task.id}
+                    node={node}
+                    status={activeStatusByTaskId.get(node.task.id) ?? (node.task.status as TaskStatus)}
+                    hasActiveExecution={activeTaskIds.has(node.task.id) || Boolean(activityByTaskId[node.task.id])}
+                    onOpen={() => navigate(`/tasks/task/${node.task.id}`)}
+                  />
+                ))}
+              </div>
+            </div>
           </>
         )}
       </div>
@@ -69,68 +192,71 @@ export function TaskDependenciesPage(): React.JSX.Element {
   );
 }
 
-function GraphColumn({
-  title,
-  tasks,
-  activityByTaskId,
-  activeTaskIds,
-  align = "left",
-  onOpenTask,
+function DependencyTaskCard({
+  node,
+  status,
+  hasActiveExecution,
+  onOpen,
 }: {
-  title: string;
-  tasks: Task[];
-  activityByTaskId: Record<string, unknown>;
-  activeTaskIds: Set<string>;
-  align?: "left" | "right";
-  onOpenTask: (taskId: string) => void;
+  node: GraphNode;
+  status: TaskStatus;
+  hasActiveExecution: boolean;
+  onOpen: () => void;
 }) {
+  const { task } = node;
+  const statusBadge = getStatusBadge(status) ?? (hasActiveExecution && status !== TaskStatus.DONE ? { label: "In progress", tone: "active" } : null);
   return (
-    <section className={`task-dependencies-column task-dependencies-column--${align}`}>
-      <div className="task-dependencies-column__header">
-        <Text size="2" weight="semibold">{title}</Text>
-        <Text size="1" tone="muted">{tasks.length}</Text>
-      </div>
-      <div className="task-dependencies-column__cards">
-        {tasks.map((task) => (
-          <DependencyTaskCard key={task.id} task={task} hasActiveExecution={activeTaskIds.has(task.id) || Boolean(activityByTaskId[task.id])} onOpen={() => onOpenTask(task.id)} />
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function DependencyTaskCard({ task, hasActiveExecution, onOpen }: { task: Task; hasActiveExecution: boolean; onOpen: () => void }) {
-  return (
-    <button className={`dependency-task-card dependency-task-card--${task.status.toLowerCase().replaceAll("_", "-")}`} type="button" onClick={onOpen}>
-      <StatusIndicator status={task.status as TaskStatus} />
-      <span className="dependency-task-card__title">{task.name}</span>
-      {hasActiveExecution ? <span className="dependency-task-card__spinner" aria-label="Active execution" /> : null}
+    <button
+      className={`dependency-task-card dependency-task-card--${status.toLowerCase().replaceAll("_", "-")}`}
+      type="button"
+      onClick={onOpen}
+      style={{
+        left: node.x,
+        top: node.y,
+      }}
+    >
+      <span className="dependency-task-card__content">
+        <span className="dependency-task-card__title">{task.name}</span>
+        {statusBadge ? (
+          <span className={`dependency-task-card__status-badge dependency-task-card__status-badge--${statusBadge.tone}`}>
+            {statusBadge.label}
+          </span>
+        ) : null}
+      </span>
+      <span className="dependency-task-card__meta">
+        {status === TaskStatus.DONE ? <DoneStatusIcon /> : null}
+        {hasActiveExecution ? <span className="dependency-task-card__spinner" aria-label="Active execution" title="Active execution" /> : null}
+      </span>
     </button>
   );
 }
 
-function StatusIndicator({ status }: { status: TaskStatus }) {
-  const label = TASKS_STATUS[status].label;
-  return (
-    <span className={`dependency-status-indicator dependency-status-indicator--${status.toLowerCase().replaceAll("_", "-")}`} aria-label={label} title={label}>
-      {status === TaskStatus.DONE ? <Check size={12} strokeWidth={2.5} /> : null}
-    </span>
-  );
+function DoneStatusIcon() {
+  return <span className="dependency-run-status-icon dependency-run-status-icon--success" aria-label="Done">✓</span>;
 }
 
-function ConnectionLayer({ connections, leftCount, rightCount }: { connections: GraphConnection[]; leftCount: number; rightCount: number }) {
-  const rowCount = Math.max(leftCount, rightCount);
-  const height = rowCount * CARD_HEIGHT + Math.max(rowCount - 1, 0) * CARD_GAP;
+function getStatusBadge(status: TaskStatus): { label: string; tone: "active" | "review" } | null {
+  if (status === TaskStatus.IN_PROGRESS) {
+    return { label: "In progress", tone: "active" };
+  }
 
+  if (status === TaskStatus.FOR_REVIEW) {
+    return { label: "In review", tone: "review" };
+  }
+
+  return null;
+}
+
+function ConnectionLayer({ connections, width, height }: { connections: GraphConnection[]; width: number; height: number }) {
   return (
-    <svg className="task-dependencies-connections" viewBox={`0 0 320 ${height}`} preserveAspectRatio="none" aria-hidden="true">
+    <svg className="task-dependencies-connections" width={width} height={height} viewBox={`0 0 ${width} ${height}`} aria-hidden="true">
       {connections.map((connection) => {
-        const startY = connection.taskIndex * (CARD_HEIGHT + CARD_GAP) + CARD_HEIGHT / 2;
-        const endY = connection.blockerIndex * (CARD_HEIGHT + CARD_GAP) + CARD_HEIGHT / 2;
+        const distance = Math.max(80, connection.endX - connection.startX);
+        const handle = Math.min(140, distance * 0.5);
         return (
           <path
-            key={`${connection.taskId}-${connection.blockerId}`}
-            d={`M 0 ${startY} C 120 ${startY}, 200 ${endY}, 320 ${endY}`}
+            key={`${connection.fromTaskId}-${connection.toTaskId}`}
+            d={`M ${connection.startX} ${connection.startY} C ${connection.startX + handle} ${connection.startY}, ${connection.endX - handle} ${connection.endY}, ${connection.endX} ${connection.endY}`}
             className="task-dependencies-connection"
           />
         );
@@ -139,22 +265,179 @@ function ConnectionLayer({ connections, leftCount, rightCount }: { connections: 
   );
 }
 
-function buildDependencyGraph(tasks: Task[]) {
+function buildDependencyGraph(tasks: Task[]): DependencyGraph {
   const taskById = new Map(tasks.map((task) => [task.id, task]));
-  const dependentTasks = tasks.filter((task) => task.dependsOnIds.length > 0);
-  const blockerIdSet = new Set(dependentTasks.flatMap((task) => task.dependsOnIds));
-  const blockerTasks = Array.from(blockerIdSet)
-    .map((id) => taskById.get(id))
-    .filter((task): task is Task => Boolean(task));
-  const blockerIndexById = new Map(blockerTasks.map((task, index) => [task.id, index]));
+  const graphTaskIds = new Set<string>();
 
-  const connections = dependentTasks.flatMap((task, taskIndex) =>
-    task.dependsOnIds.flatMap((blockerId) => {
-      const blockerIndex = blockerIndexById.get(blockerId);
-      if (blockerIndex === undefined) return [];
-      return [{ taskId: task.id, blockerId, taskIndex, blockerIndex }];
-    }),
-  );
+  for (const task of tasks) {
+    const knownDependencies = task.dependsOnIds.filter((dependencyId) => taskById.has(dependencyId));
+    if (knownDependencies.length === 0) {
+      continue;
+    }
+    graphTaskIds.add(task.id);
+    for (const dependencyId of knownDependencies) {
+      graphTaskIds.add(dependencyId);
+    }
+  }
 
-  return { dependentTasks, blockerTasks, connections };
+  if (graphTaskIds.size === 0) {
+    return { nodes: [], connections: [], width: 0, height: 0 };
+  }
+
+  const orderByTaskId = new Map(tasks.map((task, index) => [task.id, index]));
+  const layerByTaskId = new Map<string, number>();
+  const visitingTaskIds = new Set<string>();
+
+  const getLayer = (taskId: string): number => {
+    const cachedLayer = layerByTaskId.get(taskId);
+    if (cachedLayer !== undefined) {
+      return cachedLayer;
+    }
+    if (visitingTaskIds.has(taskId)) {
+      return 0;
+    }
+
+    visitingTaskIds.add(taskId);
+    const task = taskById.get(taskId);
+    const dependencyLayers = task?.dependsOnIds
+      .filter((dependencyId) => graphTaskIds.has(dependencyId))
+      .map((dependencyId) => getLayer(dependencyId)) ?? [];
+    visitingTaskIds.delete(taskId);
+
+    const layer = dependencyLayers.length === 0 ? 0 : Math.max(...dependencyLayers) + 1;
+    layerByTaskId.set(taskId, layer);
+    return layer;
+  };
+
+  for (const taskId of graphTaskIds) {
+    getLayer(taskId);
+  }
+
+  moveDirectBlockersNearDependents(graphTaskIds, taskById, layerByTaskId);
+
+  const taskIdsByLayer = new Map<number, string[]>();
+  for (const taskId of graphTaskIds) {
+    const layer = layerByTaskId.get(taskId) ?? 0;
+    const layerTaskIds = taskIdsByLayer.get(layer) ?? [];
+    layerTaskIds.push(taskId);
+    taskIdsByLayer.set(layer, layerTaskIds);
+  }
+
+  for (const [layer, layerTaskIds] of taskIdsByLayer) {
+    layerTaskIds.sort((firstId, secondId) => {
+      const firstTask = taskById.get(firstId);
+      const secondTask = taskById.get(secondId);
+      const firstParentOrder = getConnectedOrder(firstTask, orderByTaskId);
+      const secondParentOrder = getConnectedOrder(secondTask, orderByTaskId);
+      if (firstParentOrder !== secondParentOrder) {
+        return firstParentOrder - secondParentOrder;
+      }
+      return (orderByTaskId.get(firstId) ?? 0) - (orderByTaskId.get(secondId) ?? 0);
+    });
+    taskIdsByLayer.set(layer, layerTaskIds);
+  }
+
+  const nodes: GraphNode[] = [];
+  const nodeByTaskId = new Map<string, GraphNode>();
+  const sortedLayers = Array.from(taskIdsByLayer.keys()).sort((first, second) => first - second);
+  const maxRows = Math.max(...Array.from(taskIdsByLayer.values()).map((layerTaskIds) => layerTaskIds.length));
+
+  for (const layer of sortedLayers) {
+    const layerTaskIds = taskIdsByLayer.get(layer) ?? [];
+    const layerHeight = layerTaskIds.length * NODE_HEIGHT + Math.max(layerTaskIds.length - 1, 0) * ROW_GAP;
+    const graphBodyHeight = maxRows * NODE_HEIGHT + Math.max(maxRows - 1, 0) * ROW_GAP;
+    const layerYOffset = Math.max(0, (graphBodyHeight - layerHeight) / 2);
+
+    layerTaskIds.forEach((taskId, index) => {
+      const task = taskById.get(taskId);
+      if (!task) {
+        return;
+      }
+      const node = {
+        task,
+        layer,
+        x: CANVAS_PADDING + layer * (NODE_WIDTH + LAYER_GAP),
+        y: CANVAS_PADDING + layerYOffset + index * (NODE_HEIGHT + ROW_GAP),
+      };
+      nodes.push(node);
+      nodeByTaskId.set(taskId, node);
+    });
+  }
+
+  const connections: GraphConnection[] = [];
+  for (const node of nodes) {
+    for (const dependencyId of node.task.dependsOnIds) {
+      const dependencyNode = nodeByTaskId.get(dependencyId);
+      if (!dependencyNode) {
+        continue;
+      }
+      connections.push({
+        fromTaskId: dependencyId,
+        toTaskId: node.task.id,
+        startX: dependencyNode.x + NODE_WIDTH,
+        startY: dependencyNode.y + NODE_HEIGHT / 2,
+        endX: node.x,
+        endY: node.y + NODE_HEIGHT / 2,
+      });
+    }
+  }
+
+  const maxLayer = sortedLayers.at(-1) ?? 0;
+  const width = CANVAS_PADDING * 2 + NODE_WIDTH + maxLayer * (NODE_WIDTH + LAYER_GAP);
+  const height = CANVAS_PADDING * 2 + maxRows * NODE_HEIGHT + Math.max(maxRows - 1, 0) * ROW_GAP;
+
+  return { nodes, connections, width, height };
+}
+
+function getConnectedOrder(task: Task | undefined, orderByTaskId: Map<string, number>): number {
+  if (!task || task.dependsOnIds.length === 0) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  return Math.min(...task.dependsOnIds.map((dependencyId) => orderByTaskId.get(dependencyId) ?? Number.MAX_SAFE_INTEGER));
+}
+
+function moveDirectBlockersNearDependents(graphTaskIds: Set<string>, taskById: Map<string, Task>, layerByTaskId: Map<string, number>) {
+  const dependentIdsByBlockerId = new Map<string, string[]>();
+
+  for (const taskId of graphTaskIds) {
+    const task = taskById.get(taskId);
+    if (!task) {
+      continue;
+    }
+
+    for (const dependencyId of task.dependsOnIds) {
+      if (!graphTaskIds.has(dependencyId)) {
+        continue;
+      }
+      const dependentIds = dependentIdsByBlockerId.get(dependencyId) ?? [];
+      dependentIds.push(taskId);
+      dependentIdsByBlockerId.set(dependencyId, dependentIds);
+    }
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+
+    for (const taskId of graphTaskIds) {
+      const dependentIds = dependentIdsByBlockerId.get(taskId);
+      if (!dependentIds || dependentIds.length === 0) {
+        continue;
+      }
+
+      const closestDependentLayer = Math.min(...dependentIds.map((dependentId) => layerByTaskId.get(dependentId) ?? 0));
+      const furthestAllowedLayer = Math.max(0, closestDependentLayer - 1);
+      const currentLayer = layerByTaskId.get(taskId) ?? 0;
+
+      if (furthestAllowedLayer > currentLayer) {
+        layerByTaskId.set(taskId, furthestAllowedLayer);
+        changed = true;
+      }
+    }
+  }
+}
+
+function clampZoom(zoom: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Number(zoom.toFixed(2))));
 }

--- a/apps/ui/src/features/tasks/TasksLayout.css
+++ b/apps/ui/src/features/tasks/TasksLayout.css
@@ -1,10 +1,16 @@
-.tasks-layout__schedule-button {
+.tasks-layout__header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.tasks-layout__header-button {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
 }
 
-.tasks-layout__schedule-icon {
+.tasks-layout__header-icon {
   font-size: var(--fs-3);
 }
 

--- a/apps/ui/src/features/tasks/TasksLayout.tsx
+++ b/apps/ui/src/features/tasks/TasksLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { CalendarDays } from "lucide-react";
+import { CalendarDays, GitBranch } from "lucide-react";
 import { Outlet, useNavigate } from "react-router-dom";
 import { useIsDesktop } from "../../app/hooks/useIsDesktop";
 import { DesktopShell } from "../../app/shells/DesktopShell";
@@ -47,18 +47,29 @@ export function TasksLayout(): React.JSX.Element {
         <DesktopShell
           sectionTitle={sectionTitle}
           headerActions={(
-            <Button
-              size="sm"
-              variant="ghost"
-              className="tasks-layout__schedule-button"
-              onClick={() => navigate('/tasks/schedule')}
-            >
-              <CalendarDays className="tasks-layout__schedule-icon" size={16} strokeWidth={1.5} absoluteStrokeWidth />
-              Schedule
-              {activeScheduleCount && activeScheduleCount > 0 ? (
-                <span className="tasks-layout__schedule-badge">{activeScheduleCount}</span>
-              ) : null}
-            </Button>
+            <div className="tasks-layout__header-actions">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="tasks-layout__header-button"
+                onClick={() => navigate('/tasks/dependencies')}
+              >
+                <GitBranch className="tasks-layout__header-icon" size={16} strokeWidth={1.5} absoluteStrokeWidth />
+                Dependencies
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="tasks-layout__header-button"
+                onClick={() => navigate('/tasks/schedule')}
+              >
+                <CalendarDays className="tasks-layout__header-icon" size={16} strokeWidth={1.5} absoluteStrokeWidth />
+                Schedule
+                {activeScheduleCount && activeScheduleCount > 0 ? (
+                  <span className="tasks-layout__schedule-badge">{activeScheduleCount}</span>
+                ) : null}
+              </Button>
+            </div>
           )}
         >
           <Outlet />

--- a/apps/ui/src/features/tasks/TasksRoutes.tsx
+++ b/apps/ui/src/features/tasks/TasksRoutes.tsx
@@ -4,6 +4,7 @@ import { TasksLayout } from "./TasksLayout";
 import { TasksProvider } from "./TasksProvider";
 import { TaskStatus } from "./const";
 import { TaskDetailPage } from "./TaskDetailPage";
+import { TaskDependenciesPage } from "./TaskDependenciesPage";
 import { ScheduledTasksProvider } from "../scheduled-tasks/ScheduledTasksProvider";
 import { ScheduledTasksPage } from "../scheduled-tasks/ScheduledTasksPage";
 import { ScheduledTaskDetailPage } from "../scheduled-tasks/ScheduledTaskDetailPage";
@@ -28,6 +29,7 @@ export function TasksRoutes() {
           <Route path="in-progress" element={<TasksPage status={TaskStatus.IN_PROGRESS} />} />
           <Route path="in-review" element={<TasksPage status={TaskStatus.FOR_REVIEW} />} />
           <Route path="done" element={<TasksPage status={TaskStatus.DONE} />} />
+          <Route path="dependencies" element={<TaskDependenciesPage />} />
           <Route path="task/:d" element={<TaskDetailPage />} />
           <Route element={<ScheduledTasksSection />}>
             <Route path="schedule" element={<ScheduledTasksPage />} />


### PR DESCRIPTION
## Summary
- Adds a `/tasks/dependencies` canvas view that displays tasks with dependencies on the left and their blocking tasks on the right.
- Draws dependency connections from `dependsOnIds` and opens task detail when a card is selected.
- Adds a Dependencies header action next to Schedule, keeping the view within the tasks section rather than adding sidebar navigation.

## Validation
- `npm run build:dev`
- `npm run dev:5` started successfully on `http://localhost:2016` before the long-running process was stopped by timeout.

## Notes
- `npm run dev:1` and `npm run dev:2` were attempted first but their configured backend ports were already in use.
- No known technical debt introduced.