### PR TITLE
Add task graph filters

### DIFF
--- a/apps/ui/src/features/tasks/TaskDependenciesPage.css
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.css
@@ -52,17 +52,19 @@
 }
 
 .task-dependencies-controls {
+  position: absolute;
+  top: var(--space-4);
+  right: var(--space-4);
   z-index: 4;
   display: flex;
-  flex: 0 0 auto;
   flex-direction: column;
   gap: var(--space-2);
-  margin-bottom: var(--space-3);
-  padding: var(--space-3);
+  width: min(420px, calc(100% - var(--space-8)));
+  padding: var(--space-2);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-3);
-  background: color-mix(in srgb, var(--surface) 94%, transparent);
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.1);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.08);
   backdrop-filter: blur(8px);
 }
 
@@ -78,7 +80,7 @@
 }
 
 .task-dependencies-controls__label {
-  flex: 0 0 44px;
+  flex: 0 0 34px;
   color: var(--text-muted);
   font-size: var(--fs-1);
   font-weight: var(--fw-medium);
@@ -87,6 +89,7 @@
 .task-dependencies-controls__summary {
   color: var(--text-muted);
   font-size: var(--fs-1);
+  line-height: 1.3;
 }
 
 .task-dependencies-segmented {
@@ -101,7 +104,8 @@
 
 .task-dependencies-segmented__button,
 .task-dependencies-tag,
-.task-dependencies-tags__clear {
+.task-dependencies-tags__clear,
+.task-dependencies-tag-picker__option {
   border: 1px solid transparent;
   border-radius: var(--r-2);
   background: transparent;
@@ -118,7 +122,8 @@
 
 .task-dependencies-segmented__button:hover,
 .task-dependencies-tag:hover,
-.task-dependencies-tags__clear:hover {
+.task-dependencies-tags__clear:hover,
+.task-dependencies-tag-picker__option:hover {
   border-color: var(--border);
   background: var(--surface);
 }
@@ -131,6 +136,14 @@
 }
 
 .task-dependencies-tags {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.task-dependencies-selected-tags {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-1);
@@ -156,10 +169,85 @@
   font-size: 10px;
 }
 
+.task-dependencies-tag__remove {
+  color: var(--text-muted);
+  font-size: var(--fs-1);
+  line-height: 1;
+}
+
 .task-dependencies-tags__empty,
 .task-dependencies-tags__clear {
   min-height: 28px;
   padding: 4px var(--space-2);
+  color: var(--text-muted);
+  font-size: var(--fs-1);
+}
+
+.task-dependencies-tag-picker {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+}
+
+.task-dependencies-tag-picker__input {
+  width: 100%;
+  min-height: 30px;
+  padding: 5px var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-2);
+  background: var(--card-bg);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-1);
+}
+
+.task-dependencies-tag-picker__input:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.task-dependencies-tag-picker__menu {
+  position: absolute;
+  top: calc(100% + var(--space-1));
+  right: 0;
+  left: 0;
+  z-index: 5;
+  display: grid;
+  gap: var(--space-1);
+  max-height: 220px;
+  overflow: auto;
+  padding: var(--space-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-2);
+  background: var(--surface);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.14);
+}
+
+.task-dependencies-tag-picker__option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  min-height: 30px;
+  padding: 5px var(--space-2);
+  text-align: left;
+}
+
+.task-dependencies-tag-picker__option-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-dependencies-tag-picker__option-count {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.task-dependencies-tag-picker__empty {
+  padding: var(--space-2);
   color: var(--text-muted);
   font-size: var(--fs-1);
 }

--- a/apps/ui/src/features/tasks/TaskDependenciesPage.css
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.css
@@ -51,6 +51,119 @@
   text-align: center;
 }
 
+.task-dependencies-controls {
+  z-index: 4;
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-3);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(8px);
+}
+
+.task-dependencies-controls__row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.task-dependencies-controls__row--tags {
+  align-items: flex-start;
+}
+
+.task-dependencies-controls__label {
+  flex: 0 0 44px;
+  color: var(--text-muted);
+  font-size: var(--fs-1);
+  font-weight: var(--fw-medium);
+}
+
+.task-dependencies-controls__summary {
+  color: var(--text-muted);
+  font-size: var(--fs-1);
+}
+
+.task-dependencies-segmented {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-3);
+  background: var(--card-bg);
+}
+
+.task-dependencies-segmented__button,
+.task-dependencies-tag,
+.task-dependencies-tags__clear {
+  border: 1px solid transparent;
+  border-radius: var(--r-2);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.task-dependencies-segmented__button {
+  padding: 6px var(--space-2);
+  font-size: var(--fs-1);
+  font-weight: var(--fw-medium);
+}
+
+.task-dependencies-segmented__button:hover,
+.task-dependencies-tag:hover,
+.task-dependencies-tags__clear:hover {
+  border-color: var(--border);
+  background: var(--surface);
+}
+
+.task-dependencies-segmented__button--active,
+.task-dependencies-tag--selected {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--text);
+}
+
+.task-dependencies-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.task-dependencies-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  max-width: 190px;
+  padding: 4px var(--space-2);
+  overflow: hidden;
+  font-size: var(--fs-1);
+  font-weight: var(--fw-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-dependencies-tag__count {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.task-dependencies-tags__empty,
+.task-dependencies-tags__clear {
+  min-height: 28px;
+  padding: 4px var(--space-2);
+  color: var(--text-muted);
+  font-size: var(--fs-1);
+}
+
 .task-dependencies-toolbar {
   z-index: 3;
   display: inline-flex;
@@ -242,5 +355,14 @@
 @media (max-width: 700px) {
   .task-dependencies-canvas {
     padding: var(--space-3);
+  }
+
+  .task-dependencies-controls__row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .task-dependencies-controls__label {
+    flex-basis: auto;
   }
 }

--- a/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
@@ -32,6 +32,13 @@ type DependencyGraph = {
   height: number;
 };
 
+type GraphMode = "dependencies" | "all";
+
+type GraphTagFilter = {
+  name: string;
+  count: number;
+};
+
 const NODE_WIDTH = 228;
 const NODE_HEIGHT = 48;
 const LAYER_GAP = 112;
@@ -49,6 +56,8 @@ export function TaskDependenciesPage(): React.JSX.Element {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [graphMode, setGraphMode] = useState<GraphMode>("dependencies");
+  const [selectedTagNames, setSelectedTagNames] = useState<string[]>([]);
 
   useDocumentTitle();
 
@@ -56,11 +65,28 @@ export function TaskDependenciesPage(): React.JSX.Element {
     setSectionTitle("Dependencies");
   }, [setSectionTitle]);
 
-  const graph = useMemo(() => buildDependencyGraph(tasks), [tasks]);
+  const availableTagFilters = useMemo(() => getAvailableTagFilters(tasks), [tasks]);
+  const filteredTasks = useMemo(() => filterTasksByTags(tasks, selectedTagNames), [tasks, selectedTagNames]);
+  const graph = useMemo(() => buildDependencyGraph(filteredTasks, { includeAllTasks: graphMode === "all" }), [filteredTasks, graphMode]);
   const activeTaskIds = useMemo(() => new Set(active.map((execution) => execution.taskId)), [active]);
   const activeStatusByTaskId = useMemo(() => {
     return new Map(active.map((execution) => [execution.taskId, execution.taskStatus as TaskStatus]));
   }, [active]);
+  const hasSelectedTags = selectedTagNames.length > 0;
+  const graphModeLabel = graphMode === "all" ? "all tasks" : "tasks with dependencies";
+
+  const toggleTagFilter = useCallback((tagName: string) => {
+    setSelectedTagNames((currentTagNames) => {
+      if (currentTagNames.includes(tagName)) {
+        return currentTagNames.filter((currentTagName) => currentTagName !== tagName);
+      }
+      return [...currentTagNames, tagName];
+    });
+  }, []);
+
+  const clearTagFilters = useCallback(() => {
+    setSelectedTagNames([]);
+  }, []);
 
   const applyZoom = useCallback((nextZoomValue: number, focusPoint?: { x: number; y: number }) => {
     const viewport = viewportRef.current;
@@ -141,10 +167,63 @@ export function TaskDependenciesPage(): React.JSX.Element {
   return (
     <div className="task-dependencies-page">
       <div className="task-dependencies-canvas" aria-label="Task dependency graph">
+        <div className="task-dependencies-controls" aria-label="Dependency graph filters">
+          <div className="task-dependencies-controls__row">
+            <span className="task-dependencies-controls__label">Show</span>
+            <div className="task-dependencies-segmented" role="group" aria-label="Graph task scope">
+              <button
+                className={`task-dependencies-segmented__button ${graphMode === "dependencies" ? "task-dependencies-segmented__button--active" : ""}`}
+                type="button"
+                onClick={() => setGraphMode("dependencies")}
+              >
+                With dependencies
+              </button>
+              <button
+                className={`task-dependencies-segmented__button ${graphMode === "all" ? "task-dependencies-segmented__button--active" : ""}`}
+                type="button"
+                onClick={() => setGraphMode("all")}
+              >
+                All tasks
+              </button>
+            </div>
+          </div>
+          <div className="task-dependencies-controls__row task-dependencies-controls__row--tags">
+            <span className="task-dependencies-controls__label">Tags</span>
+            <div className="task-dependencies-tags" aria-label="Tag filters">
+              {availableTagFilters.length === 0 ? (
+                <span className="task-dependencies-tags__empty">No tags</span>
+              ) : (
+                availableTagFilters.map((tag) => {
+                  const isSelected = selectedTagNames.includes(tag.name);
+                  return (
+                    <button
+                      key={tag.name}
+                      className={`task-dependencies-tag ${isSelected ? "task-dependencies-tag--selected" : ""}`}
+                      type="button"
+                      onClick={() => toggleTagFilter(tag.name)}
+                      aria-pressed={isSelected}
+                    >
+                      {tag.name}
+                      <span className="task-dependencies-tag__count">{tag.count}</span>
+                    </button>
+                  );
+                })
+              )}
+              {hasSelectedTags ? (
+                <button className="task-dependencies-tags__clear" type="button" onClick={clearTagFilters}>
+                  Clear
+                </button>
+              ) : null}
+            </div>
+          </div>
+          <span className="task-dependencies-controls__summary">
+            Showing {graph.nodes.length} {graphModeLabel}{hasSelectedTags ? ` matching ${selectedTagNames.length} tag${selectedTagNames.length === 1 ? "" : "s"}` : ""}.
+          </span>
+        </div>
         {graph.nodes.length === 0 ? (
           <div className="task-dependencies-empty">
-            <Text size="3" weight="semibold">No dependency graph yet</Text>
-            <Text tone="muted">Add dependencies to tasks and they will appear here as task-to-blocker connections.</Text>
+            <Text size="3" weight="semibold">No tasks match this graph</Text>
+            <Text tone="muted">Adjust the task scope or tag filters to show more tasks.</Text>
           </div>
         ) : (
           <>
@@ -265,9 +344,9 @@ function ConnectionLayer({ connections, width, height }: { connections: GraphCon
   );
 }
 
-function buildDependencyGraph(tasks: Task[]): DependencyGraph {
+function buildDependencyGraph(tasks: Task[], options: { includeAllTasks: boolean }): DependencyGraph {
   const taskById = new Map(tasks.map((task) => [task.id, task]));
-  const graphTaskIds = new Set<string>();
+  const graphTaskIds = new Set<string>(options.includeAllTasks ? tasks.map((task) => task.id) : []);
 
   for (const task of tasks) {
     const knownDependencies = task.dependsOnIds.filter((dependencyId) => taskById.has(dependencyId));
@@ -387,6 +466,29 @@ function buildDependencyGraph(tasks: Task[]): DependencyGraph {
   const height = CANVAS_PADDING * 2 + maxRows * NODE_HEIGHT + Math.max(maxRows - 1, 0) * ROW_GAP;
 
   return { nodes, connections, width, height };
+}
+
+function getAvailableTagFilters(tasks: Task[]): GraphTagFilter[] {
+  const countByTagName = new Map<string, number>();
+
+  for (const task of tasks) {
+    for (const tag of task.tags) {
+      countByTagName.set(tag.name, (countByTagName.get(tag.name) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(countByTagName.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((firstTag, secondTag) => firstTag.name.localeCompare(secondTag.name));
+}
+
+function filterTasksByTags(tasks: Task[], selectedTagNames: string[]): Task[] {
+  if (selectedTagNames.length === 0) {
+    return tasks;
+  }
+
+  const selectedTagNameSet = new Set(selectedTagNames);
+  return tasks.filter((task) => task.tags.some((tag) => selectedTagNameSet.has(tag.name)));
 }
 
 function getConnectedOrder(task: Task | undefined, orderByTaskId: Map<string, number>): number {

--- a/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
@@ -8,6 +8,8 @@ import { useTasksCtx } from "./TasksProvider";
 import type { Task } from "./types";
 import { useExecutions } from "../executions/useExecutions";
 import { getTaskStatusTag } from "./taskStatusTag";
+import { MetaService } from "./api";
+import type { MetaTagResponseDto } from "@taico/client/v2";
 import "./TaskDependenciesPage.css";
 
 type GraphConnection = {
@@ -57,10 +59,14 @@ export function TaskDependenciesPage(): React.JSX.Element {
   const { active } = useExecutions();
   const navigate = useNavigate();
   const viewportRef = useRef<HTMLDivElement | null>(null);
+  const tagPickerRef = useRef<HTMLDivElement | null>(null);
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [graphMode, setGraphMode] = useState<GraphMode>("dependencies");
   const [selectedTagNames, setSelectedTagNames] = useState<string[]>([]);
+  const [availableTags, setAvailableTags] = useState<MetaTagResponseDto[]>([]);
+  const [tagSearchQuery, setTagSearchQuery] = useState("");
+  const [isTagPickerOpen, setIsTagPickerOpen] = useState(false);
 
   useDocumentTitle();
 
@@ -68,7 +74,35 @@ export function TaskDependenciesPage(): React.JSX.Element {
     setSectionTitle("Dependencies");
   }, [setSectionTitle]);
 
-  const availableTagFilters = useMemo(() => getAvailableTagFilters(tasks), [tasks]);
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    void MetaService.MetaController_getAllTags({ signal: abortController.signal })
+      .then(setAvailableTags)
+      .catch((tagsError: unknown) => {
+        if (abortController.signal.aborted) {
+          return;
+        }
+        console.error("Failed to load dependency graph tags:", tagsError);
+      });
+
+    return () => abortController.abort();
+  }, []);
+
+  const availableTagFilters = useMemo(() => getAvailableTagFilters(tasks, availableTags), [availableTags, tasks]);
+  const availableTagFilterByName = useMemo(() => new Map(availableTagFilters.map((tag) => [tag.name, tag])), [availableTagFilters]);
+  const selectedTagFilters = useMemo(() => {
+    return selectedTagNames.map((tagName) => availableTagFilterByName.get(tagName) ?? { name: tagName, count: 0 });
+  }, [availableTagFilterByName, selectedTagNames]);
+  const tagPickerOptions = useMemo(() => {
+    const selectedTagNameSet = new Set(selectedTagNames);
+    const normalizedQuery = tagSearchQuery.trim().toLowerCase();
+
+    return availableTagFilters
+      .filter((tag) => !selectedTagNameSet.has(tag.name))
+      .filter((tag) => normalizedQuery.length === 0 || tag.name.toLowerCase().includes(normalizedQuery))
+      .slice(0, 8);
+  }, [availableTagFilters, selectedTagNames, tagSearchQuery]);
   const filteredTasks = useMemo(() => filterTasksByTags(tasks, selectedTagNames), [tasks, selectedTagNames]);
   const activeTaskIds = useMemo(() => new Set(active.map((execution) => execution.taskId)), [active]);
   const activeStatusByTaskId = useMemo(() => {
@@ -81,18 +115,60 @@ export function TaskDependenciesPage(): React.JSX.Element {
   const hasSelectedTags = selectedTagNames.length > 0;
   const graphModeLabel = graphMode === "all" ? "all tasks" : "tasks with dependencies";
 
-  const toggleTagFilter = useCallback((tagName: string) => {
+  useEffect(() => {
+    if (!isTagPickerOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (tagPickerRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      setIsTagPickerOpen(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [isTagPickerOpen]);
+
+  const addTagFilter = useCallback((tagName: string) => {
     setSelectedTagNames((currentTagNames) => {
       if (currentTagNames.includes(tagName)) {
-        return currentTagNames.filter((currentTagName) => currentTagName !== tagName);
+        return currentTagNames;
       }
       return [...currentTagNames, tagName];
     });
+    setTagSearchQuery("");
+    setIsTagPickerOpen(false);
+  }, []);
+
+  const removeTagFilter = useCallback((tagName: string) => {
+    setSelectedTagNames((currentTagNames) => currentTagNames.filter((currentTagName) => currentTagName !== tagName));
   }, []);
 
   const clearTagFilters = useCallback(() => {
     setSelectedTagNames([]);
   }, []);
+
+  const handleTagSearchKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const [firstOption] = tagPickerOptions;
+      if (firstOption) {
+        addTagFilter(firstOption.name);
+      }
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setIsTagPickerOpen(false);
+    }
+  }, [addTagFilter, tagPickerOptions]);
 
   const applyZoom = useCallback((nextZoomValue: number, focusPoint?: { x: number; y: number }) => {
     const viewport = viewportRef.current;
@@ -196,30 +272,76 @@ export function TaskDependenciesPage(): React.JSX.Element {
           <div className="task-dependencies-controls__row task-dependencies-controls__row--tags">
             <span className="task-dependencies-controls__label">Tags</span>
             <div className="task-dependencies-tags" aria-label="Tag filters">
-              {availableTagFilters.length === 0 ? (
-                <span className="task-dependencies-tags__empty">No tags</span>
-              ) : (
-                availableTagFilters.map((tag) => {
-                  const isSelected = selectedTagNames.includes(tag.name);
-                  return (
+              <div className="task-dependencies-selected-tags" aria-label="Selected tag filters">
+                {selectedTagFilters.length === 0 ? (
+                  <span className="task-dependencies-tags__empty">No filters</span>
+                ) : (
+                  selectedTagFilters.map((tag) => (
                     <button
                       key={tag.name}
-                      className={`task-dependencies-tag ${isSelected ? "task-dependencies-tag--selected" : ""}`}
+                      className="task-dependencies-tag task-dependencies-tag--selected"
                       type="button"
-                      onClick={() => toggleTagFilter(tag.name)}
-                      aria-pressed={isSelected}
+                      onClick={() => removeTagFilter(tag.name)}
+                      aria-label={`Remove ${tag.name} filter`}
                     >
                       {tag.name}
                       <span className="task-dependencies-tag__count">{tag.count}</span>
+                      <span className="task-dependencies-tag__remove" aria-hidden="true">×</span>
                     </button>
-                  );
-                })
-              )}
-              {hasSelectedTags ? (
-                <button className="task-dependencies-tags__clear" type="button" onClick={clearTagFilters}>
-                  Clear
-                </button>
-              ) : null}
+                  ))
+                )}
+                {hasSelectedTags ? (
+                  <button className="task-dependencies-tags__clear" type="button" onClick={clearTagFilters}>
+                    Clear
+                  </button>
+                ) : null}
+              </div>
+              <div className="task-dependencies-tag-picker" ref={tagPickerRef}>
+                <input
+                  className="task-dependencies-tag-picker__input"
+                  type="search"
+                  value={tagSearchQuery}
+                  placeholder="Add tag filter"
+                  aria-label="Add tag filter"
+                  aria-expanded={isTagPickerOpen}
+                  aria-controls="task-dependencies-tag-picker-list"
+                  onChange={(event) => {
+                    setTagSearchQuery(event.target.value);
+                    setIsTagPickerOpen(true);
+                  }}
+                  onFocus={() => setIsTagPickerOpen(true)}
+                  onKeyDown={handleTagSearchKeyDown}
+                />
+                {isTagPickerOpen ? (
+                  <div
+                    id="task-dependencies-tag-picker-list"
+                    className="task-dependencies-tag-picker__menu"
+                    role="listbox"
+                    aria-label="Available tag filters"
+                  >
+                    {tagPickerOptions.length === 0 ? (
+                      <span className="task-dependencies-tag-picker__empty">
+                        {availableTagFilters.length === selectedTagNames.length ? "No more tags" : "No matching tags"}
+                      </span>
+                    ) : (
+                      tagPickerOptions.map((tag) => (
+                        <button
+                          key={tag.name}
+                          className="task-dependencies-tag-picker__option"
+                          type="button"
+                          role="option"
+                          aria-selected="false"
+                          onMouseDown={(event) => event.preventDefault()}
+                          onClick={() => addTagFilter(tag.name)}
+                        >
+                          <span className="task-dependencies-tag-picker__option-name">{tag.name}</span>
+                          <span className="task-dependencies-tag-picker__option-count">{tag.count}</span>
+                        </button>
+                      ))
+                    )}
+                  </div>
+                ) : null}
+              </div>
             </div>
           </div>
           <span className="task-dependencies-controls__summary">
@@ -492,12 +614,18 @@ function buildDependencyGraph(
   return { nodes, connections, width, height };
 }
 
-function getAvailableTagFilters(tasks: Task[]): GraphTagFilter[] {
+function getAvailableTagFilters(tasks: Task[], availableTags: MetaTagResponseDto[]): GraphTagFilter[] {
   const countByTagName = new Map<string, number>();
 
   for (const task of tasks) {
     for (const tag of task.tags) {
       countByTagName.set(tag.name, (countByTagName.get(tag.name) ?? 0) + 1);
+    }
+  }
+
+  for (const tag of availableTags) {
+    if (!countByTagName.has(tag.name)) {
+      countByTagName.set(tag.name, 0);
     }
   }
 

--- a/apps/ui/src/features/tasks/api.ts
+++ b/apps/ui/src/features/tasks/api.ts
@@ -9,9 +9,11 @@ const client = new ApiClient({
 
 export const TasksService = client.task;
 export const ActorsService = client.actors;
+export const MetaService = client.meta;
 
 // Export API client for easier access to all endpoints
 export const api = {
   task: client.task,
   actor: client.actors,
+  meta: client.meta,
 };


### PR DESCRIPTION
## Summary
- Adds an all-vs-with-dependencies scope control to the task dependency graph.
- Adds multi-select tag/project filtering derived from loaded task tags.
- Keeps dependency edges limited to visible tasks so filtered graphs stay focused.

## Validation
- npm run build:dev
- npm run dev:5

## Notes
- `npm run dev:1` and `npm run dev:2` initialized but their backend ports were already occupied; `dev:5` started successfully.
- The known AppInitRunner prompt context block startup error appeared but did not block app startup.