### PR TITLE
[codex] Add tasks board dependency toggle

### DIFF
--- a/apps/ui/src/app/shells/IosShell.css
+++ b/apps/ui/src/app/shells/IosShell.css
@@ -81,6 +81,10 @@
   pointer-events: none;
 }
 
+.ios-shell__main__top-actions {
+  padding: 0 var(--space-2) var(--space-3);
+}
+
 .ios-shell__main__top-padding {
   padding: var(--space-2);
 }

--- a/apps/ui/src/app/shells/IosShell.tsx
+++ b/apps/ui/src/app/shells/IosShell.tsx
@@ -17,6 +17,7 @@ export interface IosShellProps {
   sectionTitle: string;
   children: ReactNode;
   navItems: NavegationItem[];
+  topActions?: ReactNode;
 }
 
 function BottomNavContent({
@@ -246,6 +247,11 @@ export function IosShell(props: IosShellProps): React.JSX.Element {
           {props.sectionTitle}
           {/* </Text> */}
         </div>
+        {props.topActions ? (
+          <div className="ios-shell__main__top-actions">
+            {props.topActions}
+          </div>
+        ) : null}
         <div ref={mainSectionTitleBottomSentinelRef} className="ios-shell__main__section-title-bottom-sentinel" />
         <div className="ios-shell__main__top-sentinel" />
         {props.children}

--- a/apps/ui/src/features/tasks/TaskDependenciesPage.css
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.css
@@ -59,13 +59,12 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  width: min(420px, calc(100% - var(--space-8)));
+  width: min(340px, calc(100% - var(--space-8)));
   padding: var(--space-2);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-3);
-  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  background: var(--surface);
   box-shadow: 0 8px 22px rgba(0, 0, 0, 0.08);
-  backdrop-filter: blur(8px);
 }
 
 .task-dependencies-controls__row {
@@ -436,6 +435,11 @@
 @media (max-width: 700px) {
   .task-dependencies-canvas {
     padding: var(--space-3);
+  }
+
+  .task-dependencies-controls {
+    right: var(--space-3);
+    width: min(300px, calc(100% - var(--space-6)));
   }
 
   .task-dependencies-controls__row {

--- a/apps/ui/src/features/tasks/TasksLayout.css
+++ b/apps/ui/src/features/tasks/TasksLayout.css
@@ -4,6 +4,55 @@
   gap: var(--space-2);
 }
 
+.tasks-layout__view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-3);
+  background: var(--card-bg);
+}
+
+.tasks-layout__view-toggle-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-height: 30px;
+  padding: 0 var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--r-2);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-1);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+}
+
+.tasks-layout__view-toggle-button:hover {
+  border-color: var(--border);
+  background: var(--surface);
+}
+
+.tasks-layout__view-toggle-button--active {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.tasks-layout__mobile-view-toggle {
+  width: 100%;
+}
+
+.tasks-layout__mobile-view-toggle .tasks-layout__view-toggle {
+  width: 100%;
+}
+
+.tasks-layout__mobile-view-toggle .tasks-layout__view-toggle-button {
+  flex: 1 1 0;
+  justify-content: center;
+}
+
 .tasks-layout__header-button {
   display: inline-flex;
   align-items: center;

--- a/apps/ui/src/features/tasks/TasksLayout.tsx
+++ b/apps/ui/src/features/tasks/TasksLayout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { CalendarDays, GitBranch } from "lucide-react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { CalendarDays, GitBranch, LayoutDashboard } from "lucide-react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useIsDesktop } from "../../app/hooks/useIsDesktop";
 import { DesktopShell } from "../../app/shells/DesktopShell";
 import { IosShell } from "../../app/shells/IosShell";
@@ -16,7 +16,23 @@ export function TasksLayout(): React.JSX.Element {
   const isDesktop = useIsDesktop();
   const { sectionTitle, shippedCelebrationTrigger } = useTasksCtx();
   const navigate = useNavigate();
+  const location = useLocation();
   const [activeScheduleCount, setActiveScheduleCount] = useState<number | null>(null);
+  const isDependencyView = location.pathname === "/tasks/dependencies";
+  const isBoardView = [
+    "/tasks/not-started",
+    "/tasks/in-progress",
+    "/tasks/in-review",
+    "/tasks/done",
+  ].includes(location.pathname);
+  const viewToggle = (
+    <TaskViewToggle
+      isBoardView={isBoardView}
+      isDependencyView={isDependencyView}
+      onBoardClick={() => navigate('/tasks/not-started')}
+      onDependenciesClick={() => navigate('/tasks/dependencies')}
+    />
+  );
 
   useEffect(() => {
     let isMounted = true;
@@ -48,15 +64,7 @@ export function TasksLayout(): React.JSX.Element {
           sectionTitle={sectionTitle}
           headerActions={(
             <div className="tasks-layout__header-actions">
-              <Button
-                size="sm"
-                variant="ghost"
-                className="tasks-layout__header-button"
-                onClick={() => navigate('/tasks/dependencies')}
-              >
-                <GitBranch className="tasks-layout__header-icon" size={16} strokeWidth={1.5} absoluteStrokeWidth />
-                Dependencies
-              </Button>
+              {viewToggle}
               <Button
                 size="sm"
                 variant="ghost"
@@ -79,9 +87,45 @@ export function TasksLayout(): React.JSX.Element {
           appTitle="Tasks"
           sectionTitle={sectionTitle}
           navItems={TASKS_STATUS_NAV}
+          topActions={<div className="tasks-layout__mobile-view-toggle">{viewToggle}</div>}
         >
           <Outlet />
         </IosShell>}
     </div>
   )
+}
+
+function TaskViewToggle({
+  isBoardView,
+  isDependencyView,
+  onBoardClick,
+  onDependenciesClick,
+}: {
+  isBoardView: boolean;
+  isDependencyView: boolean;
+  onBoardClick: () => void;
+  onDependenciesClick: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="tasks-layout__view-toggle" role="group" aria-label="Task view">
+      <button
+        className={`tasks-layout__view-toggle-button${isBoardView ? " tasks-layout__view-toggle-button--active" : ""}`}
+        type="button"
+        aria-pressed={isBoardView}
+        onClick={onBoardClick}
+      >
+        <LayoutDashboard className="tasks-layout__header-icon" size={16} strokeWidth={1.5} absoluteStrokeWidth />
+        Board
+      </button>
+      <button
+        className={`tasks-layout__view-toggle-button${isDependencyView ? " tasks-layout__view-toggle-button--active" : ""}`}
+        type="button"
+        aria-pressed={isDependencyView}
+        onClick={onDependenciesClick}
+      >
+        <GitBranch className="tasks-layout__header-icon" size={16} strokeWidth={1.5} absoluteStrokeWidth />
+        Dependencies
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Replace the desktop-only Dependencies header action with a Board / Dependencies segmented toggle.
- Add a mobile top-actions slot to `IosShell` so the same toggle remains visible in compact task views.
- Tighten the dependency graph filter panel and make it solid instead of translucent.

## Impact
Users can switch between the task board and dependency graph from both desktop and mobile layouts without the toggle disappearing at the responsive breakpoint.

## Validation
- `npm -w apps/ui run build`
- In-app browser check at `/tasks/dependencies` for mobile toggle visibility and Board <-> Dependencies navigation.
- In-app browser reload after dependency filter panel styling changes.