### PR TITLE
Add arrows to dependency graph connectors

### DIFF
--- a/apps/ui/src/features/tasks/TaskDependenciesPage.css
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.css
@@ -426,6 +426,10 @@
   vector-effect: non-scaling-stroke;
 }
 
+.task-dependencies-connection-arrow {
+  fill: color-mix(in srgb, var(--text-muted) 48%, transparent);
+}
+
 @keyframes dependency-spin {
   to {
     transform: rotate(360deg);

--- a/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
@@ -518,6 +518,19 @@ function getVisibleGraphStatusTag(status: TaskStatus, hasActiveExecution = false
 function ConnectionLayer({ connections, width, height }: { connections: GraphConnection[]; width: number; height: number }) {
   return (
     <svg className="task-dependencies-connections" width={width} height={height} viewBox={`0 0 ${width} ${height}`} aria-hidden="true">
+      <defs>
+        <marker
+          id="task-dependencies-connection-arrow"
+          markerWidth="8"
+          markerHeight="8"
+          refX="7"
+          refY="4"
+          orient="auto"
+          markerUnits="strokeWidth"
+        >
+          <path className="task-dependencies-connection-arrow" d="M 0 0 L 8 4 L 0 8 Z" />
+        </marker>
+      </defs>
       {connections.map((connection) => {
         const distance = Math.max(80, connection.endX - connection.startX);
         const handle = Math.min(140, distance * 0.5);
@@ -526,6 +539,7 @@ function ConnectionLayer({ connections, width, height }: { connections: GraphCon
             key={`${connection.fromTaskId}-${connection.toTaskId}`}
             d={`M ${connection.startX} ${connection.startY} C ${connection.startX + handle} ${connection.startY}, ${connection.endX - handle} ${connection.endY}, ${connection.endX} ${connection.endY}`}
             className="task-dependencies-connection"
+            markerEnd="url(#task-dependencies-connection-arrow)"
           />
         );
       })}


### PR DESCRIPTION
## Summary
- Add SVG arrow markers to dependency graph connector paths so flow direction points toward the right-hand task.
- Reuse the existing muted connector color for arrowheads to preserve the dependency view styling.

## Validation
- npm run build:dev
- npm run dev:1 (startup reached, then port 2003 was already in use)
- npm run dev:2 (started on http://localhost:2006; stopped by validation timeout)

## Technical Debt
- None.