### PR TITLE
Show assignees on active dependency cards

### DIFF
--- a/apps/ui/src/features/tasks/TaskDependenciesPage.css
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.css
@@ -366,6 +366,22 @@
   font-weight: var(--fw-medium);
 }
 
+.dependency-task-card__status-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.dependency-task-card__assignee {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--fs-1);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .dependency-task-card__meta {
   display: inline-flex;
   align-items: center;

--- a/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
@@ -471,6 +471,8 @@ function DependencyTaskCard({
 }) {
   const { task } = node;
   const statusTag = getVisibleGraphStatusTag(status, hasActiveExecution);
+  const assigneeSlug = task.assigneeActor?.slug;
+  const shouldShowAssigneeSlug = Boolean(assigneeSlug && (status === TaskStatus.IN_PROGRESS || status === TaskStatus.FOR_REVIEW));
 
   return (
     <button
@@ -485,11 +487,14 @@ function DependencyTaskCard({
     >
       <span className="dependency-task-card__content">
         <span className="dependency-task-card__title">{task.name}</span>
-        {statusTag ? (
-          <Chip color={statusTag.color} className="dependency-task-card__status-chip">
-            {statusTag.label}
-          </Chip>
-        ) : null}
+        <span className="dependency-task-card__status-row">
+          {statusTag ? (
+            <Chip color={statusTag.color} className="dependency-task-card__status-chip">
+              {statusTag.label}
+            </Chip>
+          ) : null}
+          {shouldShowAssigneeSlug ? <span className="dependency-task-card__assignee">@{assigneeSlug}</span> : null}
+        </span>
       </span>
       <span className="dependency-task-card__meta">
         {status === TaskStatus.DONE ? <DoneStatusIcon /> : null}


### PR DESCRIPTION
## Summary
- Show assignee slugs on dependency graph cards when tasks are in progress or in review.
- Keep the existing status chip visible and truncate long assignee slugs within the card.

## Validation
- npm run build:dev
- npm run dev:2 (booted at http://localhost:2006; expected AppInitRunner prompt-block error appeared)

## Technical Debt
- None.