### PR TITLE
Fix task view toggle on detail routes

### DIFF
--- a/apps/ui/src/features/tasks/TasksLayout.tsx
+++ b/apps/ui/src/features/tasks/TasksLayout.tsx
@@ -25,6 +25,7 @@ export function TasksLayout(): React.JSX.Element {
     "/tasks/in-review",
     "/tasks/done",
   ].includes(location.pathname);
+  const showViewToggle = isBoardView || isDependencyView;
   const viewToggle = (
     <TaskViewToggle
       isBoardView={isBoardView}
@@ -64,7 +65,7 @@ export function TasksLayout(): React.JSX.Element {
           sectionTitle={sectionTitle}
           headerActions={(
             <div className="tasks-layout__header-actions">
-              {viewToggle}
+              {showViewToggle ? viewToggle : null}
               <Button
                 size="sm"
                 variant="ghost"
@@ -87,7 +88,7 @@ export function TasksLayout(): React.JSX.Element {
           appTitle="Tasks"
           sectionTitle={sectionTitle}
           navItems={TASKS_STATUS_NAV}
-          topActions={<div className="tasks-layout__mobile-view-toggle">{viewToggle}</div>}
+          topActions={showViewToggle ? <div className="tasks-layout__mobile-view-toggle">{viewToggle}</div> : undefined}
         >
           <Outlet />
         </IosShell>}


### PR DESCRIPTION
## Summary
- Gate the tasks board/dependency view toggle to board status routes and the dependency route.
- Prevent the mobile task detail and schedule routes from receiving the toggle as shell top actions.
- Keep the existing schedule header action available on desktop while hiding the unrelated view toggle outside list/dependency views.

## Validation
- `npm run build:dev`
- `npm run dev:1` hit `EADDRINUSE :::2003`, then `npm run dev:2` started successfully on `http://localhost:2006` with the expected AppInitRunner prompt context block error.

## Technical Debt
- None introduced.