### PR TITLE
Rename dependency view title

### DIFF
--- a/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
@@ -77,7 +77,7 @@ export function TaskDependenciesPage(): React.JSX.Element {
   useDocumentTitle();
 
   useEffect(() => {
-    setSectionTitle("Dependencies");
+    setSectionTitle("Tasks");
   }, [setSectionTitle]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Rename the task dependency view section title from \`Dependencies\` to \`Tasks\`.
- Leave the existing dependency route and navigation label unchanged because this change targets the view title only.

## Validation
- \`npm run build:dev\`
- \`timeout 45s npm run dev:3\`

## Technical Debt
- None.