### PR TITLE
Show queued run counts

### DIFF
--- a/apps/backend/src/executions/queue/task-execution-queue.service.ts
+++ b/apps/backend/src/executions/queue/task-execution-queue.service.ts
@@ -24,7 +24,7 @@ export class TaskExecutionQueueService {
 
     const [items, total] = await this.taskExecutionQueueRepository.findAndCount({
       relations: ['task'],
-      order: { taskId: 'ASC' },
+      order: { createdAt: 'ASC' },
       skip,
       take: limit,
     });

--- a/apps/ui/src/features/executions/ExecutionsPage.css
+++ b/apps/ui/src/features/executions/ExecutionsPage.css
@@ -11,6 +11,11 @@
   align-items: center;
 }
 
+.executions-hero__summary {
+  display: grid;
+  gap: var(--space-1);
+}
+
 .executions-worker-status {
   display: inline-flex;
   align-items: center;
@@ -40,6 +45,10 @@
   outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: var(--r-1);
+}
+
+.executions-run-counts {
+  padding-left: calc(var(--space-1) + var(--fs-1));
 }
 
 .executions-empty-card {
@@ -226,6 +235,10 @@
   .executions-detail-topbar {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .executions-run-counts {
+    padding-left: 0;
   }
 
   .executions-detail-topbar {

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -30,7 +30,7 @@ export function ExecutionsPage() {
   const navigate = useNavigate();
   const { actors } = useActorsCtx();
   const { showToast, showError } = useToast();
-  const { queue, active, history, isLoading, hasLoadedOnce, error, loadExecutions } = useExecutions();
+  const { queue, active, history, totals, isLoading, hasLoadedOnce, error, loadExecutions } = useExecutions();
   const { workers } = useWorkers();
   const [interruptingExecutions, setInterruptingExecutions] = useState<Set<string>>(() => new Set());
 
@@ -97,7 +97,7 @@ export function ExecutionsPage() {
             </Text>
           </div>
           <Text as="div" size="2" tone="muted" className="executions-run-counts">
-            {queue.length.toLocaleString()} queued · {active.length.toLocaleString()} running · {history.length.toLocaleString()} finished
+            {totals.queue.toLocaleString()} queued · {totals.active.toLocaleString()} running · {totals.history.toLocaleString()} finished
           </Text>
         </div>
         {error ? <span className="executions-error-copy">Fetch failed</span> : null}

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -73,26 +73,31 @@ export function ExecutionsPage() {
   return (
     <div className="executions-page">
       <div className="executions-hero">
-        <div className="executions-worker-status">
-          <span
-            className="executions-worker-status__indicator"
-            style={{ color: connectedWorkersCount > 0 ? "var(--success)" : "var(--danger)" }}
-            aria-label={connectedWorkersCount > 0 ? "Workers connected" : "No workers connected"}
-          >
-            ●
-          </span>
-          <Text as="span" size="2" tone="muted">
-            {connectedWorkersCount > 0
-              ? `${connectedWorkersCount} worker${connectedWorkersCount !== 1 ? "s" : ""} connected`
-              : "no worker connected"}
-            {" · "}
-            <button
-              type="button"
-              className="executions-worker-status__link"
-              onClick={() => navigate("/settings/workers")}
+        <div className="executions-hero__summary">
+          <div className="executions-worker-status">
+            <span
+              className="executions-worker-status__indicator"
+              style={{ color: connectedWorkersCount > 0 ? "var(--success)" : "var(--danger)" }}
+              aria-label={connectedWorkersCount > 0 ? "Workers connected" : "No workers connected"}
             >
-              configure
-            </button>
+              ●
+            </span>
+            <Text as="span" size="2" tone="muted">
+              {connectedWorkersCount > 0
+                ? `${connectedWorkersCount} worker${connectedWorkersCount !== 1 ? "s" : ""} connected`
+                : "no worker connected"}
+              {" · "}
+              <button
+                type="button"
+                className="executions-worker-status__link"
+                onClick={() => navigate("/settings/workers")}
+              >
+                configure
+              </button>
+            </Text>
+          </div>
+          <Text as="div" size="2" tone="muted" className="executions-run-counts">
+            {queue.length.toLocaleString()} queued · {active.length.toLocaleString()} running · {history.length.toLocaleString()} finished
           </Text>
         </div>
         {error ? <span className="executions-error-copy">Fetch failed</span> : null}

--- a/apps/ui/src/features/executions/useExecutions.ts
+++ b/apps/ui/src/features/executions/useExecutions.ts
@@ -12,6 +12,12 @@ import type {
 const EXECUTIONS_POLL_INTERVAL_MS = 5000;
 const SOCKET_URL = getUIWebSocketUrl('/tasks');
 
+type ExecutionTotals = {
+  queue: number;
+  active: number;
+  history: number;
+};
+
 export const useExecutions = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
@@ -21,6 +27,7 @@ export const useExecutions = () => {
   const [queue, setQueue] = useState<TaskExecutionQueueEntryResponseDto[]>([]);
   const [active, setActive] = useState<ActiveTaskExecutionResponseDto[]>([]);
   const [history, setHistory] = useState<TaskExecutionHistoryResponseDto[]>([]);
+  const [totals, setTotals] = useState<ExecutionTotals>({ queue: 0, active: 0, history: 0 });
   const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
   const inFlightRef = useRef(false);
 
@@ -50,6 +57,11 @@ export const useExecutions = () => {
       setQueue(queueResponse.items);
       setActive(activeResponse.items);
       setHistory(historyResponse.items);
+      setTotals({
+        queue: queueResponse.total,
+        active: activeResponse.total,
+        history: historyResponse.total,
+      });
       setLastUpdatedAt(new Date().toISOString());
       setError(null);
     } catch (err) {
@@ -107,6 +119,7 @@ export const useExecutions = () => {
     queue,
     active,
     history,
+    totals,
     loadExecutions,
     lastUpdatedAt,
   };


### PR DESCRIPTION
## Summary
- Confirmed the Runs page already prepends execution queue entries before active and historical runs.
- Orders queue results by insertion time so the oldest queued task appears first.
- Adds queued/running/finished counts to the Runs page header so queued work is visible even before scanning the list.

## Validation
- npm run build:dev
- timeout 35s npm run dev:3

## Notes
- `dev:1` and `dev:2` were unavailable because their backend ports were already in use.
- `dev:3` logged the expected AppInitRunner prompt context block error, then started successfully on `http://localhost:2010` before the bounded timeout stopped it.