### PR TITLE
Focus dependency graph on task route

### DIFF
--- a/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDependenciesPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent, type WheelEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Maximize2, ZoomIn, ZoomOut } from "lucide-react";
 import { Chip, Text } from "../../ui/primitives";
 import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
@@ -60,9 +60,11 @@ export function TaskDependenciesPage(): React.JSX.Element {
   const { tasks, isLoading, error, setSectionTitle, activityByTaskId } = useTasksCtx();
   const { active } = useExecutions();
   const navigate = useNavigate();
+  const { taskId: focusedTaskId } = useParams<{ taskId?: string }>();
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const panRef = useRef({ x: 0, y: 0 });
   const panDragRef = useRef<{ pointerId: number; startClientX: number; startClientY: number; startPanX: number; startPanY: number } | null>(null);
+  const focusedTaskIdRef = useRef<string | undefined>(undefined);
   const tagPickerRef = useRef<HTMLDivElement | null>(null);
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
@@ -122,8 +124,8 @@ export function TaskDependenciesPage(): React.JSX.Element {
     return new Set(Object.values(activityByTaskId).filter(isActiveExecutionActivity).map((activity) => activity.taskId));
   }, [activityByTaskId]);
   const graph = useMemo(
-    () => buildDependencyGraph(filteredTasks, activeStatusByTaskId, activeTaskIds, activityActiveTaskIds, { includeAllTasks: graphMode === "all", hideDonePaths }),
-    [activeStatusByTaskId, activeTaskIds, activityActiveTaskIds, filteredTasks, graphMode, hideDonePaths],
+    () => buildDependencyGraph(filteredTasks, activeStatusByTaskId, activeTaskIds, activityActiveTaskIds, { includeAllTasks: graphMode === "all", hideDonePaths, focusedTaskId }),
+    [activeStatusByTaskId, activeTaskIds, activityActiveTaskIds, filteredTasks, focusedTaskId, graphMode, hideDonePaths],
   );
   const hasSelectedTags = selectedTagNames.length > 0;
   const graphCountLabel = `${graph.nodes.length} shown`;
@@ -215,9 +217,25 @@ export function TaskDependenciesPage(): React.JSX.Element {
     setZoom((currentZoom) => clampZoom(currentZoom + delta));
   }, []);
   const resetZoom = useCallback(() => {
-    setPan({ x: 0, y: 0 });
+    setPan(getInitialGraphPan(graph, viewportRef.current, focusedTaskId));
     setZoom(1);
-  }, []);
+  }, [focusedTaskId, graph]);
+
+  useEffect(() => {
+    const shouldCenterFocusedTask = focusedTaskId && focusedTaskIdRef.current !== focusedTaskId;
+    if (!shouldCenterFocusedTask || graph.nodes.length === 0) {
+      return;
+    }
+
+    const focusedNode = graph.nodes.find((node) => node.task.id === focusedTaskId);
+    if (!focusedNode) {
+      return;
+    }
+
+    focusedTaskIdRef.current = focusedTaskId;
+    setZoom(1);
+    setPan(getPanForNode(focusedNode, viewportRef.current));
+  }, [focusedTaskId, graph]);
 
   const handleCanvasWheel = useCallback((event: WheelEvent<HTMLDivElement>) => {
     if (graph.nodes.length === 0) {
@@ -575,10 +593,14 @@ function buildDependencyGraph(
   activeStatusByTaskId: Map<string, TaskStatus>,
   activeTaskIds: Set<string>,
   activityActiveTaskIds: Set<string>,
-  options: { includeAllTasks: boolean; hideDonePaths: boolean },
+  options: { includeAllTasks: boolean; hideDonePaths: boolean; focusedTaskId?: string },
 ): DependencyGraph {
   const taskById = new Map(tasks.map((task) => [task.id, task]));
   const graphTaskIds = new Set<string>(options.includeAllTasks ? tasks.map((task) => task.id) : []);
+
+  if (options.focusedTaskId && taskById.has(options.focusedTaskId)) {
+    graphTaskIds.add(options.focusedTaskId);
+  }
 
   for (const task of tasks) {
     const knownDependencies = task.dependsOnIds.filter((dependencyId) => taskById.has(dependencyId));
@@ -596,7 +618,7 @@ function buildDependencyGraph(
   }
 
   if (options.hideDonePaths) {
-    hideDoneOnlyPaths(graphTaskIds, taskById, activeStatusByTaskId);
+    hideDoneOnlyPaths(graphTaskIds, taskById, activeStatusByTaskId, options.focusedTaskId);
   }
 
   if (graphTaskIds.size === 0) {
@@ -747,7 +769,7 @@ function filterTasksByTags(tasks: Task[], selectedTagNames: string[]): Task[] {
   return tasks.filter((task) => task.tags.some((tag) => selectedTagNameSet.has(tag.name)));
 }
 
-function hideDoneOnlyPaths(graphTaskIds: Set<string>, taskById: Map<string, Task>, activeStatusByTaskId: Map<string, TaskStatus>) {
+function hideDoneOnlyPaths(graphTaskIds: Set<string>, taskById: Map<string, Task>, activeStatusByTaskId: Map<string, TaskStatus>, focusedTaskId?: string) {
   const dependencyIdsByTaskId = new Map<string, string[]>();
   const dependentIdsByTaskId = new Map<string, string[]>();
 
@@ -768,6 +790,10 @@ function hideDoneOnlyPaths(graphTaskIds: Set<string>, taskById: Map<string, Task
   }
 
   for (const taskId of Array.from(graphTaskIds)) {
+    if (taskId === focusedTaskId) {
+      continue;
+    }
+
     if (!isDoneGraphTask(taskId, taskById, activeStatusByTaskId)) {
       continue;
     }
@@ -900,6 +926,22 @@ function moveDirectBlockersNearDependents(graphTaskIds: Set<string>, taskById: M
       }
     }
   }
+}
+
+function getInitialGraphPan(graph: DependencyGraph, viewport: HTMLDivElement | null, focusedTaskId?: string) {
+  const focusedNode = focusedTaskId ? graph.nodes.find((node) => node.task.id === focusedTaskId) : undefined;
+  return focusedNode ? getPanForNode(focusedNode, viewport) : { x: 0, y: 0 };
+}
+
+function getPanForNode(node: GraphNode, viewport: HTMLDivElement | null) {
+  if (!viewport) {
+    return { x: 0, y: 0 };
+  }
+
+  return {
+    x: viewport.clientWidth / 2 - node.x - NODE_WIDTH / 2,
+    y: viewport.clientHeight / 2 - node.y - node.height / 2,
+  };
 }
 
 function clampZoom(zoom: number): number {

--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -735,7 +735,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
               size="sm"
               variant="ghost"
               className="task-detail-page__dependency-graph-button"
-              onClick={() => navigate('/tasks/dependencies')}
+              onClick={() => navigate(`/tasks/dependencies/${task.id}`)}
             >
               <GitBranch className="task-detail-page__dependency-graph-icon" size={14} strokeWidth={1.5} absoluteStrokeWidth />
               View graph

--- a/apps/ui/src/features/tasks/TasksLayout.tsx
+++ b/apps/ui/src/features/tasks/TasksLayout.tsx
@@ -18,7 +18,7 @@ export function TasksLayout(): React.JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
   const [activeScheduleCount, setActiveScheduleCount] = useState<number | null>(null);
-  const isDependencyView = location.pathname === "/tasks/dependencies";
+  const isDependencyView = location.pathname === "/tasks/dependencies" || location.pathname.startsWith("/tasks/dependencies/");
   const isBoardView = [
     "/tasks/not-started",
     "/tasks/in-progress",

--- a/apps/ui/src/features/tasks/TasksRoutes.tsx
+++ b/apps/ui/src/features/tasks/TasksRoutes.tsx
@@ -30,6 +30,7 @@ export function TasksRoutes() {
           <Route path="in-review" element={<TasksPage status={TaskStatus.FOR_REVIEW} />} />
           <Route path="done" element={<TasksPage status={TaskStatus.DONE} />} />
           <Route path="dependencies" element={<TaskDependenciesPage />} />
+          <Route path="dependencies/:taskId" element={<TaskDependenciesPage />} />
           <Route path="task/:d" element={<TaskDetailPage />} />
           <Route element={<ScheduledTasksSection />}>
             <Route path="schedule" element={<ScheduledTasksPage />} />


### PR DESCRIPTION
## Summary
- Add a `/tasks/dependencies/:taskId` route for task-focused dependency graph links.
- Center the dependency graph on the focused task and preserve it in the graph even when it has no dependency edges or completed-only paths are hidden.
- Update task detail `View graph` links to target the task-focused graph route.

## Validation
- `npm run build:dev`
- `npm run dev:1` reached startup but port 2003 was already in use.
- `npm run dev:2` reached startup but port 2006 was already in use.
- `npm run dev:3` started successfully on `http://localhost:2010` before the long-running process was stopped by timeout.

## Technical Debt
- None noted.