### PR TITLE
Update task list pagination by status

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -9766,12 +9766,12 @@
           },
           "limit": {
             "type": "number",
-            "description": "Number of items per page",
+            "description": "Number of items per status per page when no status filter is provided",
             "example": 20
           },
           "totalPages": {
             "type": "number",
-            "description": "Total number of pages",
+            "description": "Total number of pages based on the largest matching status bucket",
             "example": 3
           }
         },

--- a/apps/backend/src/tasks/dto/service/tasks.service.types.ts
+++ b/apps/backend/src/tasks/dto/service/tasks.service.types.ts
@@ -148,6 +148,7 @@ export type ListTasksResult = {
   total: number;
   page: number;
   limit: number;
+  totalPages: number;
 };
 
 export type SearchTasksInput = {

--- a/apps/backend/src/tasks/dto/task-list-response.dto.ts
+++ b/apps/backend/src/tasks/dto/task-list-response.dto.ts
@@ -25,13 +25,13 @@ export class TaskListResponseDto {
   page!: number;
 
   @ApiProperty({
-    description: 'Number of items per page',
+    description: 'Number of items per status per page when no status filter is provided',
     example: 20,
   })
   limit!: number;
 
   @ApiProperty({
-    description: 'Total number of pages',
+    description: 'Total number of pages based on the largest matching status bucket',
     example: 3,
   })
   totalPages!: number;

--- a/apps/backend/src/tasks/tasks.controller.ts
+++ b/apps/backend/src/tasks/tasks.controller.ts
@@ -223,7 +223,7 @@ export class TasksController {
       total: result.total,
       page: result.page,
       limit: result.limit,
-      totalPages: Math.ceil(result.total / result.limit),
+      totalPages: result.totalPages,
     };
   }
 

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { Repository, In } from 'typeorm';
+import { Repository, In, SelectQueryBuilder } from 'typeorm';
 import { TaskEntity } from './task.entity';
 import { TaskStatus } from './enums';
 import { CommentEntity } from './comment.entity';
@@ -497,65 +497,84 @@ export class TasksService {
 
     const skip = (input.page - 1) * input.limit;
 
-    // If tag filter is provided, use query builder for join
-    if (input.tag) {
-      const queryBuilder = this.taskRepository
-        .createQueryBuilder('task')
-        .leftJoinAndSelect('task.comments', 'comments')
-        .leftJoinAndSelect('comments.commenterActor', 'commenterActor')
-        .leftJoinAndSelect('task.artefacts', 'artefacts')
-        .leftJoinAndSelect('task.inputRequests', 'inputRequests')
-        .leftJoinAndSelect('task.tags', 'tags')
-        .leftJoinAndSelect('task.assigneeActor', 'assigneeActor')
-        .leftJoinAndSelect('task.createdByActor', 'createdByActor')
-        .innerJoin('task.tags', 'filterTag')
-        .where('filterTag.name = :tagName', { tagName: input.tag });
+    const result = await this.taskRepository.manager.transaction(async (manager) => {
+      const taskRepository = manager.getRepository(TaskEntity);
 
-      if (input.assignee) {
-        queryBuilder.andWhere('assigneeActor.slug = :assignee', {
-          assignee: input.assignee,
-        });
-      }
       if (input.status) {
-        queryBuilder.andWhere('task.status = :status', {
-          status: input.status,
-        });
-      }
-      if (input.updatedAfter) {
-        queryBuilder.andWhere('task.updatedAt >= :updatedAfter', {
-          updatedAfter: input.updatedAfter,
-        });
-      }
-      if (input.sessionId) {
-        queryBuilder.andWhere('task.sessionId = :sessionId', {
-          sessionId: input.sessionId,
-        });
+        const queryBuilder = this.createListTasksQuery(taskRepository, input)
+          .orderBy('task.updatedAt', 'DESC')
+          .skip(skip)
+          .take(input.limit);
+        const [tasks, total] = await queryBuilder.getManyAndCount();
+
+        return {
+          tasks,
+          total,
+          totalPages: Math.ceil(total / input.limit),
+        };
       }
 
-      queryBuilder
-        .orderBy('task.updatedAt', 'DESC')
-        .skip(skip)
-        .take(input.limit);
+      const tasks: TaskEntity[] = [];
+      const totalsByStatus: number[] = [];
 
-      const [tasks, total] = await queryBuilder.getManyAndCount();
+      for (const status of Object.values(TaskStatus)) {
+        const count = await this.createListTasksQuery(
+          taskRepository,
+          input,
+          status,
+        ).getCount();
+        totalsByStatus.push(count);
 
-      this.logger.log({
-        message: 'Tasks listed',
-        count: tasks.length,
-        total,
-        page: input.page,
-      });
+        if (count <= skip) {
+          continue;
+        }
+
+        const statusTasks = await this.createListTasksQuery(
+          taskRepository,
+          input,
+          status,
+        )
+          .orderBy('task.updatedAt', 'DESC')
+          .skip(skip)
+          .take(input.limit)
+          .getMany();
+        tasks.push(...statusTasks);
+      }
+
+      tasks.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 
       return {
-        items: tasks.map((task) => this.mapTaskToResult(task)),
-        total,
-        page: input.page,
-        limit: input.limit,
+        tasks,
+        total: totalsByStatus.reduce((sum, count) => sum + count, 0),
+        totalPages: Math.max(
+          0,
+          ...totalsByStatus.map((count) => Math.ceil(count / input.limit)),
+        ),
       };
-    }
+    });
 
-    // Standard filtering - need to use query builder for assignee filtering by slug
-    const queryBuilder = this.taskRepository
+    this.logger.log({
+      message: 'Tasks listed',
+      count: result.tasks.length,
+      total: result.total,
+      page: input.page,
+    });
+
+    return {
+      items: result.tasks.map((task) => this.mapTaskToResult(task)),
+      total: result.total,
+      page: input.page,
+      limit: input.limit,
+      totalPages: result.totalPages,
+    };
+  }
+
+  private createListTasksQuery(
+    taskRepository: Repository<TaskEntity>,
+    input: ListTasksInput,
+    status?: TaskStatus,
+  ): SelectQueryBuilder<TaskEntity> {
+    const queryBuilder = taskRepository
       .createQueryBuilder('task')
       .leftJoinAndSelect('task.comments', 'comments')
       .leftJoinAndSelect('comments.commenterActor', 'commenterActor')
@@ -566,14 +585,19 @@ export class TasksService {
       .leftJoinAndSelect('task.assigneeActor', 'assigneeActor')
       .leftJoinAndSelect('task.createdByActor', 'createdByActor');
 
+    if (input.tag) {
+      queryBuilder
+        .innerJoin('task.tags', 'filterTag')
+        .where('filterTag.name = :tagName', { tagName: input.tag });
+    }
     if (input.assignee) {
       queryBuilder.andWhere('assigneeActor.slug = :assignee', {
         assignee: input.assignee,
       });
     }
-    if (input.status) {
+    if (status ?? input.status) {
       queryBuilder.andWhere('task.status = :status', {
-        status: input.status,
+        status: status ?? input.status,
       });
     }
     if (input.updatedAfter) {
@@ -587,23 +611,7 @@ export class TasksService {
       });
     }
 
-    queryBuilder.orderBy('task.updatedAt', 'DESC').skip(skip).take(input.limit);
-
-    const [tasks, total] = await queryBuilder.getManyAndCount();
-
-    this.logger.log({
-      message: 'Tasks listed',
-      count: tasks.length,
-      total,
-      page: input.page,
-    });
-
-    return {
-      items: tasks.map((task) => this.mapTaskToResult(task)),
-      total,
-      page: input.page,
-      limit: input.limit,
-    };
+    return queryBuilder;
   }
 
   async getTaskById(taskId: string): Promise<TaskResult> {

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -9766,12 +9766,12 @@
           },
           "limit": {
             "type": "number",
-            "description": "Number of items per page",
+            "description": "Number of items per status per page when no status filter is provided",
             "example": 20
           },
           "totalPages": {
             "type": "number",
-            "description": "Total number of pages",
+            "description": "Total number of pages based on the largest matching status bucket",
             "example": 3
           }
         },

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -3836,12 +3836,12 @@ export interface components {
              */
             page: number;
             /**
-             * @description Number of items per page
+             * @description Number of items per status per page when no status filter is provided
              * @example 20
              */
             limit: number;
             /**
-             * @description Total number of pages
+             * @description Total number of pages based on the largest matching status bucket
              * @example 3
              */
             totalPages: number;

--- a/packages/client/src/v1/client/models/TaskListResponseDto.ts
+++ b/packages/client/src/v1/client/models/TaskListResponseDto.ts
@@ -17,11 +17,11 @@ export type TaskListResponseDto = {
      */
     page: number;
     /**
-     * Number of items per page
+     * Number of items per status per page when no status filter is provided
      */
     limit: number;
     /**
-     * Total number of pages
+     * Total number of pages based on the largest matching status bucket
      */
     totalPages: number;
 };


### PR DESCRIPTION
## Summary
- Return up to the requested limit for each task status when listing tasks without a status filter.
- Compute task list pagination from the largest matching status bucket so not-started work is not hidden behind done/review tasks.
- Regenerate OpenAPI and client artifacts for the updated task-list metadata descriptions.

## Validation
- `npm run build:dev`
- `npm run dev:2` started the backend on `http://localhost:2006` and both Vite apps became ready; Vite then hit the host `ENOSPC` file-watcher limit.

## Technical Debt
- No new debt identified. The implementation uses multiple per-status queries inside one transaction rather than a window-function query because the existing TypeORM relation loading path is easier to preserve safely.