### PR TITLE
Project task assignees into thread participants

### DIFF
--- a/apps/backend/src/threads/thread-task-assignment-projector.service.spec.ts
+++ b/apps/backend/src/threads/thread-task-assignment-projector.service.spec.ts
@@ -1,0 +1,87 @@
+import { TaskAssignedEvent } from '../tasks/events/tasks.events';
+import { ActorType } from '../identity-provider/enums';
+import type { TaskEntity } from '../tasks/task.entity';
+import type { ThreadResult } from './dto/service/threads.service.types';
+import type { ThreadsService } from './threads.service';
+
+jest.mock('./threads.service', () => ({
+  ThreadsService: class ThreadsService {},
+}));
+
+import { ThreadTaskAssignmentProjectorService } from './thread-task-assignment-projector.service';
+
+describe('ThreadTaskAssignmentProjectorService', () => {
+  let service: ThreadTaskAssignmentProjectorService;
+  let threadsService: jest.Mocked<Pick<ThreadsService, 'findThreadByTaskId' | 'addParticipant'>>;
+
+  const assignedTask = {
+    id: 'task-1',
+    name: 'Assigned task',
+    assigneeActorId: 'actor-2',
+  } as TaskEntity;
+
+  const thread = {
+    id: 'thread-1',
+    participants: [
+      {
+        id: 'actor-1',
+        type: ActorType.HUMAN,
+        slug: 'actor-1',
+        displayName: 'Actor One',
+        avatarUrl: null,
+        introduction: null,
+      },
+    ],
+  } as ThreadResult;
+
+  beforeEach(() => {
+    threadsService = {
+      findThreadByTaskId: jest.fn(),
+      addParticipant: jest.fn(),
+    };
+
+    service = new ThreadTaskAssignmentProjectorService(
+      threadsService as unknown as ThreadsService,
+    );
+  });
+
+  it('adds a newly assigned actor to the containing thread participants', async () => {
+    threadsService.findThreadByTaskId.mockResolvedValue(thread);
+
+    await service.onTaskAssigned(new TaskAssignedEvent({ id: 'actor-1' }, assignedTask));
+
+    expect(threadsService.findThreadByTaskId).toHaveBeenCalledWith('task-1');
+    expect(threadsService.addParticipant).toHaveBeenCalledWith('thread-1', 'actor-2');
+  });
+
+  it('does nothing when the assigned task is not in a thread', async () => {
+    threadsService.findThreadByTaskId.mockResolvedValue(null);
+
+    await service.onTaskAssigned(new TaskAssignedEvent({ id: 'actor-1' }, assignedTask));
+
+    expect(threadsService.findThreadByTaskId).toHaveBeenCalledWith('task-1');
+    expect(threadsService.addParticipant).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the assignee is already a thread participant', async () => {
+    threadsService.findThreadByTaskId.mockResolvedValue({
+      ...thread,
+      participants: [
+        ...thread.participants,
+        {
+          id: 'actor-2',
+          type: ActorType.AGENT,
+          slug: 'actor-2',
+          displayName: 'Actor Two',
+          avatarUrl: null,
+          introduction: null,
+        },
+      ],
+    });
+
+    await service.onTaskAssigned(new TaskAssignedEvent({ id: 'actor-1' }, assignedTask));
+
+    expect(threadsService.findThreadByTaskId).toHaveBeenCalledWith('task-1');
+    expect(threadsService.addParticipant).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/threads/thread-task-assignment-projector.service.ts
+++ b/apps/backend/src/threads/thread-task-assignment-projector.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { TaskAssignedEvent } from '../tasks/events/tasks.events';
+import { ThreadsService } from './threads.service';
+
+@Injectable()
+export class ThreadTaskAssignmentProjectorService {
+  constructor(private readonly threadsService: ThreadsService) {}
+
+  @OnEvent(TaskAssignedEvent.INTERNAL)
+  async onTaskAssigned(event: TaskAssignedEvent): Promise<void> {
+    const assigneeActorId = event.payload.assigneeActorId;
+    if (!assigneeActorId) {
+      return;
+    }
+
+    const thread = await this.threadsService.findThreadByTaskId(event.payload.id);
+    if (!thread) {
+      return;
+    }
+
+    if (thread.participants.some((participant) => participant.id === assigneeActorId)) {
+      return;
+    }
+
+    await this.threadsService.addParticipant(thread.id, assigneeActorId);
+  }
+}

--- a/apps/backend/src/threads/threads.module.ts
+++ b/apps/backend/src/threads/threads.module.ts
@@ -21,6 +21,7 @@ import { OpenAiMcpServerFactoryService } from './openai-mcp-server-factory.servi
 import { ThreadTitleService } from './thread-title.service';
 import { ThreadStateReconcilerService } from './thread-state-reconciler.service';
 import { ChatProvidersModule } from '../chat-providers/chat-providers.module';
+import { ThreadTaskAssignmentProjectorService } from './thread-task-assignment-projector.service';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { ChatProvidersModule } from '../chat-providers/chat-providers.module';
     OpenAiMcpServerFactoryService,
     ThreadTitleService,
     ThreadStateReconcilerService,
+    ThreadTaskAssignmentProjectorService,
   ],
   exports: [ThreadsService],
 })

--- a/apps/backend/src/threads/threads.service.spec.ts
+++ b/apps/backend/src/threads/threads.service.spec.ts
@@ -570,6 +570,74 @@ describe('ThreadsService - Parent Task ID', () => {
         expect(addParticipantSpy).not.toHaveBeenCalled();
       });
     });
+
+    describe('Participant Tests', () => {
+      it('should add participants through relation insert to avoid overwriting concurrent additions', async () => {
+        const threadWithParticipant = {
+          ...mockThread,
+          participants: [mockActor],
+        } as ThreadEntity;
+        const relationQueryBuilder = {
+          relation: jest.fn().mockReturnThis(),
+          of: jest.fn().mockReturnThis(),
+          add: jest.fn().mockResolvedValue(undefined),
+        };
+
+        threadRepository.createQueryBuilder.mockReturnValue(
+          relationQueryBuilder as any,
+        );
+        threadRepository.findOne
+          .mockResolvedValueOnce(mockThread)
+          .mockResolvedValueOnce(threadWithParticipant);
+        actorRepository.findOne.mockResolvedValue(mockActor);
+
+        const result = await service.addParticipant('thread-uuid', 'actor-uuid');
+
+        expect(relationQueryBuilder.relation).toHaveBeenCalledWith(
+          ThreadEntity,
+          'participants',
+        );
+        expect(relationQueryBuilder.of).toHaveBeenCalledWith('thread-uuid');
+        expect(relationQueryBuilder.add).toHaveBeenCalledWith('actor-uuid');
+        expect(threadRepository.save).not.toHaveBeenCalled();
+        expect(result.participants).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: 'actor-uuid' })]),
+        );
+      });
+
+      it('should treat duplicate participant relation insert as idempotent success', async () => {
+        const threadWithParticipant = {
+          ...mockThread,
+          participants: [mockActor],
+        } as ThreadEntity;
+        const relationQueryBuilder = {
+          relation: jest.fn().mockReturnThis(),
+          of: jest.fn().mockReturnThis(),
+          add: jest.fn().mockRejectedValue(
+            new QueryFailedError('INSERT INTO thread_participants ...', [], {
+              code: 'SQLITE_CONSTRAINT',
+              message:
+                'UNIQUE constraint failed: thread_participants.thread_id, thread_participants.actor_id',
+            } as any),
+          ),
+        };
+
+        threadRepository.createQueryBuilder.mockReturnValue(
+          relationQueryBuilder as any,
+        );
+        threadRepository.findOne
+          .mockResolvedValueOnce(mockThread)
+          .mockResolvedValueOnce(threadWithParticipant);
+        actorRepository.findOne.mockResolvedValue(mockActor);
+
+        const result = await service.addParticipant('thread-uuid', 'actor-uuid');
+
+        expect(relationQueryBuilder.add).toHaveBeenCalledWith('actor-uuid');
+        expect(result.participants).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: 'actor-uuid' })]),
+        );
+      });
+    });
   });
 
   describe('Thread Update Tests', () => {

--- a/apps/backend/src/threads/threads.service.spec.ts
+++ b/apps/backend/src/threads/threads.service.spec.ts
@@ -488,6 +488,87 @@ describe('ThreadsService - Parent Task ID', () => {
         expect(result.parentTaskId).toBe('parent-task-uuid');
         expect(result.tasks.length).toBe(1);
       });
+
+      it('should add the attached task assignee as a participant', async () => {
+        const assignedActor = {
+          ...mockActor,
+          id: 'assigned-actor-uuid',
+          slug: 'assigned-actor',
+          displayName: 'Assigned Actor',
+        } as ActorEntity;
+        const assignedTask = {
+          ...mockParentTask,
+          id: 'assigned-task-uuid',
+          name: 'Assigned Task',
+          assigneeActorId: assignedActor.id,
+        } as TaskEntity;
+        const threadWithAssignedTask = {
+          ...mockThread,
+          tasks: [mockParentTask, assignedTask],
+          participants: [assignedActor],
+        } as ThreadEntity;
+        const relationQueryBuilder = {
+          relation: jest.fn().mockReturnThis(),
+          of: jest.fn().mockReturnThis(),
+          add: jest.fn().mockResolvedValue(undefined),
+        };
+        const addParticipantSpy = jest
+          .spyOn(service, 'addParticipant')
+          .mockResolvedValue(threadWithAssignedTask as any);
+
+        threadRepository.createQueryBuilder.mockReturnValue(
+          relationQueryBuilder as any,
+        );
+        threadRepository.findOne
+          .mockResolvedValueOnce(mockThread)
+          .mockResolvedValueOnce(threadWithAssignedTask);
+        taskRepository.findOne.mockResolvedValue(assignedTask);
+
+        const result = await service.attachTask(
+          'thread-uuid',
+          'assigned-task-uuid',
+        );
+
+        expect(addParticipantSpy).toHaveBeenCalledWith(
+          'thread-uuid',
+          'assigned-actor-uuid',
+        );
+        expect(result.participants).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: 'assigned-actor-uuid' }),
+          ]),
+        );
+      });
+
+      it('should not add the attached task assignee when already participating', async () => {
+        const assignedTask = {
+          ...mockParentTask,
+          id: 'assigned-task-uuid',
+          assigneeActorId: mockActor.id,
+        } as TaskEntity;
+        const threadWithParticipant = {
+          ...mockThread,
+          participants: [mockActor],
+        } as ThreadEntity;
+        const relationQueryBuilder = {
+          relation: jest.fn().mockReturnThis(),
+          of: jest.fn().mockReturnThis(),
+          add: jest.fn().mockResolvedValue(undefined),
+        };
+        const addParticipantSpy = jest.spyOn(service, 'addParticipant');
+
+        threadRepository.createQueryBuilder.mockReturnValue(
+          relationQueryBuilder as any,
+        );
+        threadRepository.findOne
+          .mockResolvedValueOnce(threadWithParticipant)
+          .mockResolvedValueOnce(threadWithParticipant);
+        taskRepository.findOne.mockResolvedValue(assignedTask);
+
+        await service.attachTask('thread-uuid', 'assigned-task-uuid');
+
+        expect(addParticipantSpy).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/backend/src/threads/threads.service.ts
+++ b/apps/backend/src/threads/threads.service.ts
@@ -599,10 +599,19 @@ export class ThreadsService {
       throw new ActorNotFoundForThreadError(actorId);
     }
 
-    // Add participant if not already present
     if (!thread.participants.some((p) => p.id === actorId)) {
-      thread.participants.push(actor);
-      await this.threadRepository.save(thread);
+      try {
+        await this.threadRepository
+          .createQueryBuilder()
+          .relation(ThreadEntity, 'participants')
+          .of(threadId)
+          .add(actorId);
+      } catch (error) {
+        if (!this.isThreadParticipantUniqueViolation(error)) {
+          throw error;
+        }
+      }
+
       this.logger.log({
         message: 'Participant added to thread',
         threadId,
@@ -932,6 +941,28 @@ export class ThreadsService {
       message.includes('thread_tasks')
       && message.includes('thread_id')
       && message.includes('task_id')
+    );
+  }
+
+  private isThreadParticipantUniqueViolation(error: unknown): boolean {
+    if (!(error instanceof QueryFailedError)) {
+      return false;
+    }
+
+    const driverError = (error as any).driverError;
+    const code = driverError?.code;
+    const message = driverError?.message ?? '';
+
+    const isUniqueConstraintCode =
+      code === 'SQLITE_CONSTRAINT' || code === '23505';
+    if (!isUniqueConstraintCode) {
+      return false;
+    }
+
+    return (
+      message.includes('thread_participants')
+      && message.includes('thread_id')
+      && message.includes('actor_id')
     );
   }
 

--- a/apps/backend/src/threads/threads.service.ts
+++ b/apps/backend/src/threads/threads.service.ts
@@ -390,7 +390,7 @@ export class ThreadsService {
       taskId,
     });
 
-    await this.getThreadWithRelations(threadId);
+    const thread = await this.getThreadWithRelations(threadId);
     const task = await this.taskRepository.findOne({ where: { id: taskId } });
 
     if (!task) {
@@ -419,6 +419,15 @@ export class ThreadsService {
         threadId,
         taskId,
       });
+    }
+
+    if (
+      task.assigneeActorId &&
+      !thread.participants.some(
+        (participant) => participant.id === task.assigneeActorId,
+      )
+    ) {
+      await this.addParticipant(threadId, task.assigneeActorId);
     }
 
     const updatedThread = await this.getThreadWithRelations(threadId);


### PR DESCRIPTION
## Summary
- Add a threads-module event projector for `TaskAssignedEvent` that adds assigned actors to containing thread participants.
- Reconcile an already-assigned task assignee into participants immediately when the task is attached to a thread.
- Make thread participant additions concurrency-safe by inserting the join relation directly instead of saving stale participant snapshots.
- Keep non-threaded assignments, unassigned tasks, already-present participants, and duplicate participant inserts as no-ops.
- Add focused backend unit coverage for assignment projection, attach-time participant reconciliation, and participant relation insertion/idempotence.

## Validation
- `npm -w apps/backend run test -- thread-task-assignment-projector.service.spec.ts --runInBand`
- `npm -w apps/backend run test -- threads.service.spec.ts --runInBand` attempted, but blocked by existing Jest `src/*` alias resolution issue (`Cannot find module 'src/agents/agent-tool-permission-scope.entity'`).
- `npm run build:dev`
- `npm run dev:5` reached `Application is running on: http://localhost:2016`; expected AppInitRunner prompt-block error appeared during startup.

## Technical Debt
- Backend focused Jest specs that import full entity graphs still do not resolve `src/*` aliases consistently in this workspace.