### PR TITLE
Fix parent thread race fallback

### DIFF
--- a/apps/backend/src/tasks/tasks.service.create-task-in-thread.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.create-task-in-thread.spec.ts
@@ -24,7 +24,8 @@ describe('TasksService.createTaskInThread', () => {
       createThread: jest
         .fn()
         .mockRejectedValue(new ParentTaskThreadAlreadyExistsError('parent-task-1')),
-      findThreadByTaskId: jest.fn().mockResolvedValue({ id: 'thread-1' }),
+      findThreadByParentTaskId: jest.fn().mockResolvedValue({ id: 'thread-1' }),
+      findThreadByTaskId: jest.fn(),
       attachTask: jest.fn().mockResolvedValue({ id: 'thread-1' }),
     };
 
@@ -57,7 +58,10 @@ describe('TasksService.createTaskInThread', () => {
       parentTaskId: 'parent-task-1',
       taskIds: ['child-task-1'],
     });
-    expect(threadsService.findThreadByTaskId).toHaveBeenCalledWith('parent-task-1');
+    expect(threadsService.findThreadByParentTaskId).toHaveBeenCalledWith(
+      'parent-task-1',
+    );
+    expect(threadsService.findThreadByTaskId).not.toHaveBeenCalled();
     expect(threadsService.attachTask).toHaveBeenCalledWith(
       'thread-1',
       'child-task-1',

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -239,7 +239,7 @@ export class TasksService {
         newTaskId: task.id,
       });
 
-      thread = await this.threadsService.findThreadByTaskId(parentTaskId);
+      thread = await this.threadsService.findThreadByParentTaskId(parentTaskId);
       if (!thread) {
         throw error;
       }

--- a/apps/backend/src/threads/threads.service.spec.ts
+++ b/apps/backend/src/threads/threads.service.spec.ts
@@ -372,6 +372,42 @@ describe('ThreadsService - Parent Task ID', () => {
         expect(result).toBeNull();
       });
     });
+
+    describe('3.4. Find Thread by Parent Task ID', () => {
+      it('should find a thread directly by parent task ID', async () => {
+        threadRepository.findOne.mockResolvedValue(mockThread);
+
+        const result = await service.findThreadByParentTaskId('parent-task-uuid');
+
+        expect(result).toBeDefined();
+        expect(result?.parentTaskId).toBe('parent-task-uuid');
+        expect(threadRepository.findOne).toHaveBeenCalledWith({
+          where: { parentTaskId: 'parent-task-uuid' },
+          relations: [
+            'createdByActor',
+            'tasks',
+            'tasks.assigneeActor',
+            'tasks.createdByActor',
+            'tasks.tags',
+            'tasks.comments',
+            'tasks.inputRequests',
+            'referencedContextBlocks',
+            'tags',
+            'participants',
+          ],
+        });
+      });
+
+      it('should return null when no thread exists for parent task ID', async () => {
+        threadRepository.findOne.mockResolvedValue(null);
+
+        const result = await service.findThreadByParentTaskId(
+          'non-existent-parent-task-uuid',
+        );
+
+        expect(result).toBeNull();
+      });
+    });
   });
 
   describe('Thread Deletion Tests', () => {

--- a/apps/backend/src/threads/threads.service.ts
+++ b/apps/backend/src/threads/threads.service.ts
@@ -659,6 +659,37 @@ export class ThreadsService {
     return threads.map((thread) => this.mapThreadToResult(thread));
   }
 
+  async findThreadByParentTaskId(
+    parentTaskId: string,
+  ): Promise<ThreadResult | null> {
+    this.logger.log({
+      message: 'Finding thread by parent task ID',
+      parentTaskId,
+    });
+
+    const thread = await this.threadRepository.findOne({
+      where: { parentTaskId },
+      relations: [
+        'createdByActor',
+        'tasks',
+        'tasks.assigneeActor',
+        'tasks.createdByActor',
+        'tasks.tags',
+        'tasks.comments',
+        'tasks.inputRequests',
+        'referencedContextBlocks',
+        'tags',
+        'participants',
+      ],
+    });
+
+    if (!thread) {
+      return null;
+    }
+
+    return this.mapThreadToResult(thread);
+  }
+
   async findThreadsByStateBlockId(stateBlockId: string): Promise<ThreadResult[]> {
     this.logger.log({
       message: 'Finding threads by state block ID',


### PR DESCRIPTION
## Summary
- Add a direct `ThreadsService.findThreadByParentTaskId` lookup against `threads.parent_task_id`.
- Use the direct parent-thread lookup in `TasksService.createTaskInThread` after `ParentTaskThreadAlreadyExistsError` so fallback no longer depends on the `thread_tasks` join row.
- Update service specs to assert the fallback avoids `findThreadByTaskId` and cover the new parent lookup.

## Validation
- `npm run build:dev` passed.
- `timeout 35s npm run dev:2` started backend successfully at `http://localhost:2006`; observed expected AppInitRunner prompt-block error during startup.

## Notes
- Focused Jest specs could not be executed with the current repo config: default backend test command does not resolve `src/*` imports, and an inline mapper then fails on ESM parsing for `@taico/errors` before specs run.