### PR TITLE
Add markdown rendering to thread messages

### DIFF
--- a/apps/ui/src/features/threads/ThreadChat.css
+++ b/apps/ui/src/features/threads/ThreadChat.css
@@ -170,3 +170,164 @@
   border-top: 1px solid var(--border-subtle);
   padding-top: var(--space-3);
 }
+
+/* Markdown content styling */
+.thread-chat__message-content {
+  font-size: var(--fs-2);
+  line-height: var(--lh-normal);
+  color: var(--text);
+}
+
+/* Headings */
+.thread-chat__message-content h1 {
+  margin-top: var(--space-4);
+  margin-bottom: var(--space-3);
+  font-size: var(--fs-5);
+  font-weight: var(--fw-semibold);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.thread-chat__message-content h2 {
+  margin-top: var(--space-4);
+  margin-bottom: var(--space-3);
+  font-size: var(--fs-4);
+  font-weight: var(--fw-semibold);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.thread-chat__message-content h3,
+.thread-chat__message-content h4,
+.thread-chat__message-content h5,
+.thread-chat__message-content h6 {
+  margin-top: var(--space-3);
+  margin-bottom: var(--space-2);
+  font-weight: var(--fw-semibold);
+}
+
+.thread-chat__message-content h3 {
+  font-size: var(--fs-3);
+}
+
+.thread-chat__message-content h4,
+.thread-chat__message-content h5,
+.thread-chat__message-content h6 {
+  font-size: var(--fs-2);
+}
+
+/* Paragraphs */
+.thread-chat__message-content p {
+  margin-bottom: var(--space-2);
+}
+
+.thread-chat__message-content p:last-child {
+  margin-bottom: 0;
+}
+
+/* Lists */
+.thread-chat__message-content ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+  margin-bottom: var(--space-2);
+}
+
+.thread-chat__message-content ol {
+  list-style-type: decimal;
+  padding-left: 1.5rem;
+  margin-bottom: var(--space-2);
+}
+
+.thread-chat__message-content li {
+  margin-bottom: var(--space-1);
+}
+
+.thread-chat__message-content li:last-child {
+  margin-bottom: 0;
+}
+
+/* Code */
+.thread-chat__message-content code {
+  background-color: var(--theme-surface);
+  padding: 0.125rem var(--space-1);
+  border-radius: var(--space-1);
+  border: 1px solid var(--border-subtle);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.9em;
+}
+
+.thread-chat__message-content pre {
+  background-color: var(--theme-surface);
+  padding: var(--space-2);
+  border-radius: var(--space-1);
+  border: 1px solid var(--border-subtle);
+  overflow-x: auto;
+  margin-bottom: var(--space-2);
+}
+
+.thread-chat__message-content pre code {
+  background-color: transparent;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+}
+
+/* Blockquotes */
+.thread-chat__message-content blockquote {
+  margin: var(--space-2) 0;
+  padding-left: var(--space-3);
+  border-left: 3px solid var(--border);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* Links */
+.thread-chat__message-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.thread-chat__message-content a:hover {
+  text-decoration-color: var(--accent);
+}
+
+/* Tables */
+.thread-chat__message-content table {
+  border-collapse: collapse;
+  margin-top: var(--space-2);
+  margin-bottom: var(--space-2);
+  width: 100%;
+  font-size: var(--fs-1);
+}
+
+.thread-chat__message-content th,
+.thread-chat__message-content td {
+  padding: var(--space-1) var(--space-2);
+  text-align: left;
+  border: 1px solid var(--border-subtle);
+}
+
+.thread-chat__message-content th {
+  font-weight: var(--fw-semibold);
+  background: var(--surface);
+}
+
+.thread-chat__message-content tr:nth-child(even) {
+  background: color-mix(in srgb, var(--surface) 30%, transparent);
+}
+
+/* Horizontal rule */
+.thread-chat__message-content hr {
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  margin: var(--space-3) 0;
+}
+
+/* Images */
+.thread-chat__message-content img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--space-1);
+  margin: var(--space-2) 0;
+}

--- a/apps/ui/src/features/threads/ThreadChat.tsx
+++ b/apps/ui/src/features/threads/ThreadChat.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "../../auth";
 import { useDraftState } from "../../shared/hooks/useDraftState";
 import { useChatReadiness } from "../chat-providers/useChatReadiness";
 import { ChatSetupCallout } from "../chat-providers/ChatSetupCallout";
+import Markdown from "marked-react";
 import "./ThreadChat.css";
 
 interface ThreadChatProps {
@@ -127,7 +128,9 @@ export function ThreadChat({ threadId }: ThreadChatProps) {
                   </Text>
                 </div>
 
-                <Text size="2">{message.content}</Text>
+                <div className="thread-chat__message-content">
+                  <Markdown>{message.content}</Markdown>
+                </div>
               </div>
             );
           })
@@ -147,7 +150,9 @@ export function ThreadChat({ threadId }: ThreadChatProps) {
               </Text>
             </div>
 
-            <Text size="2">{agentResponseStream.content}</Text>
+            <div className="thread-chat__message-content">
+              <Markdown>{agentResponseStream.content}</Markdown>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Thread messages now render markdown content using the `marked-react` library
- Added comprehensive CSS styles for markdown elements in thread chat
- Applied markdown rendering to both regular messages and streaming agent responses

## Changes
1. **ThreadChat.tsx**:
   - Imported `Markdown` component from `marked-react`
   - Wrapped message content with `<Markdown>` component
   - Wrapped streaming agent response content with `<Markdown>` component
   - Added wrapper div with class `thread-chat__message-content` for styling

2. **ThreadChat.css**:
   - Added comprehensive markdown styles including:
     - Headings (h1-h6) with proper hierarchy and spacing
     - Paragraphs with appropriate bottom margins
     - Lists (ordered and unordered) with proper indentation
     - Code blocks (inline and block) with background and borders
     - Blockquotes with left border and italic styling
     - Links with accent color
     - Tables with borders and alternating row colors
     - Horizontal rules and images

## Test Plan
- [x] Ran `npm run build:dev` - build succeeded
- [x] Ran `npm run dev:3` - app starts successfully
- [ ] Manual testing: Send messages with markdown syntax in threads view
- [ ] Verify headings, lists, code blocks, and other markdown elements render correctly
- [ ] Check that streaming agent responses also render markdown

## Notes
The styles are adapted from the context block markdown styles but sized appropriately for the chat message context. The `marked-react` library was already a dependency in the project, so no new dependencies were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)