### PR TITLE
Fix old task detail disappearing after list refresh

### DIFF
--- a/apps/ui/src/features/tasks/useTasks.ts
+++ b/apps/ui/src/features/tasks/useTasks.ts
@@ -76,6 +76,14 @@ export const useTasks = () => {
     });
   };
 
+  const mergeTasks = (existingTasks: Task[], incomingTasks: Task[]): Task[] => {
+    const incomingIds = new Set(incomingTasks.map(task => task.id));
+    return sortTasks([
+      ...incomingTasks,
+      ...existingTasks.filter(task => !incomingIds.has(task.id)),
+    ]);
+  };
+
   // Create task
   const createTask = async (task: CreateTaskDto) => {
     return await TasksService.TasksController_createTask({ body: task });
@@ -123,7 +131,7 @@ export const useTasks = () => {
         page: 1,
         limit: TASKS_PAGE_SIZE,
       });
-      setTasks(sortTasks(response.items));
+      setTasks(prev => mergeTasks(prev, response.items));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load tasks');
     } finally {


### PR DESCRIPTION
## Summary
- Merge paginated task list responses into the existing UI task cache instead of replacing it wholesale.
- Preserve tasks fetched directly by ID so old task detail routes keep rendering after the `/tasks?page=1&limit=100` request resolves.

## Validation
- `npm run build:dev`
- `timeout 45s npm run dev:1` (backend started successfully; expected AppInitRunner prompt-block error appeared)

## Technical Debt
- The task provider still uses one shared array for paginated list data and directly hydrated detail/dependency data. A future split between list cache and entity cache would make this behavior less implicit.