### PR TITLE
Handle Claude overloaded errors

### DIFF
--- a/apps/worker/src/runners/ClaudeAgentRunner.ts
+++ b/apps/worker/src/runners/ClaudeAgentRunner.ts
@@ -10,6 +10,12 @@ import {
   TokenUsage,
 } from "./AgentRunner.js";
 import { DEFAULT_AGENT_ALLOWED_TOOLS } from '@taico/shared';
+import {
+  AgentOverloadedError,
+  isOverloadedErrorMessage,
+} from "../task-execution-errors.js";
+
+const MAX_OVERLOADED_RESUME_ATTEMPTS = 1;
 
 export class ClaudeAgentRunner extends BaseAgentRunner {
   readonly kind = 'claude';
@@ -78,63 +84,88 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
       });
     }
 
-    const stream = query({
-      prompt: ctx.prompt,
-      options: {
-        cwd: ctx.cwd,
-        // resume: ctx.resume,
-        persistSession: true,
-        settingSources: ['user', 'project', 'local'],
-        ...(ctx.options ?? {}),
-        mcpServers,
-        allowedTools: ctx.allowedTools ?? [...DEFAULT_AGENT_ALLOWED_TOOLS],
-        abortController,
-      },
-    });
+    let latestSessionId = ctx.resume;
+    let overloadedResumeAttempts = 0;
 
-    for await (const msg of stream) {
-      // session capture
-      if (
-        msg?.type === 'system' &&
-        msg?.subtype === 'init' &&
-        typeof msg.session_id === 'string'
-      ) {
-        await setSession(msg.session_id);
-      }
+    while (true) {
+      try {
+        const stream = query({
+          prompt: ctx.prompt,
+          options: {
+            cwd: ctx.cwd,
+            persistSession: true,
+            settingSources: ['user', 'project', 'local'],
+            ...(ctx.options ?? {}),
+            ...(latestSessionId ? { resume: latestSessionId } : {}),
+            mcpServers,
+            allowedTools: ctx.allowedTools ?? [...DEFAULT_AGENT_ALLOWED_TOOLS],
+            abortController,
+          },
+        });
 
-      const toolCalls = formatter.extractToolCallNames(msg);
-      for (const toolName of toolCalls) {
-        await onToolCall?.(toolName);
-      }
+        for await (const msg of stream) {
+          // session capture
+          if (
+            msg?.type === 'system' &&
+            msg?.subtype === 'init' &&
+            typeof msg.session_id === 'string'
+          ) {
+            latestSessionId = msg.session_id;
+            await setSession(msg.session_id);
+          }
 
-      const usage = extractClaudeTokenUsage(msg);
-      if (usage) {
-        if (usage.mode === 'absolute') {
-          await onTokenUsage?.(applyAbsoluteUsage(cumulativeUsage, usage.usage));
-        } else {
-          await onTokenUsage?.(applySnapshotUsage(cumulativeUsage, usage.usage));
-        }
-      }
+          const toolCalls = formatter.extractToolCallNames(msg);
+          for (const toolName of toolCalls) {
+            await onToolCall?.(toolName);
+          }
 
-      // map → string
-      const text = formatter.format(msg);
-      if (text) await emit(text);
+          const usage = extractClaudeTokenUsage(msg);
+          if (usage) {
+            if (usage.mode === 'absolute') {
+              await onTokenUsage?.(applyAbsoluteUsage(cumulativeUsage, usage.usage));
+            } else {
+              await onTokenUsage?.(applySnapshotUsage(cumulativeUsage, usage.usage));
+            }
+          }
 
-      if (msg.type === 'result' && msg.subtype === 'success') {
-        // Check if this is an error result (e.g., quota limit)
-        if (msg.is_error === true) {
-          if (onError) {
-            await onError({
-              message: typeof msg.result === 'string' ? msg.result : 'Unknown error',
-              rawMessage: msg,
-            });
+          // map → string
+          const text = formatter.format(msg);
+          if (text) await emit(text);
+
+          if (msg.type === 'result' && msg.subtype === 'success') {
+            // Check if this is an error result (e.g., quota limit)
+            if (msg.is_error === true) {
+              if (onError) {
+                await onError({
+                  message: typeof msg.result === 'string' ? msg.result : 'Unknown error',
+                  rawMessage: msg,
+                });
+              }
+            }
+            finalResult = msg.result;
           }
         }
-        finalResult = msg.result;
+
+        return finalResult;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (
+          isOverloadedErrorMessage(message) &&
+          latestSessionId &&
+          overloadedResumeAttempts < MAX_OVERLOADED_RESUME_ATTEMPTS
+        ) {
+          overloadedResumeAttempts += 1;
+          await emit(`Claude API is overloaded; resuming session ${latestSessionId}.`);
+          continue;
+        }
+
+        if (isOverloadedErrorMessage(message)) {
+          throw new AgentOverloadedError(message, error);
+        }
+
+        throw error;
       }
     }
-
-    return finalResult;
   }
 }
 

--- a/apps/worker/src/task-execution-errors.ts
+++ b/apps/worker/src/task-execution-errors.ts
@@ -13,6 +13,13 @@ const QUOTA_MESSAGE_PATTERNS: RegExp[] = [
   /usage\s*limit/i,
 ];
 
+const OVERLOADED_MESSAGE_PATTERNS: RegExp[] = [
+  /overloaded_error/i,
+  /api\s*error:\s*529/i,
+  /\b529\b.*\boverloaded\b/i,
+  /\boverloaded\b/i,
+];
+
 export class TaskExecutionError extends Error {
   readonly displayMessage: string;
 
@@ -62,6 +69,12 @@ export class AgentQuotaExceededError extends RetryableExecutionError {
   }
 }
 
+export class AgentOverloadedError extends RetryableExecutionError {
+  constructor(message = 'Agent API is temporarily overloaded.', cause?: unknown) {
+    super(message, 'UNKNOWN', cause);
+  }
+}
+
 export class RunnerProcessError extends RetryableExecutionError {}
 
 export class UnsupportedAgentTypeError extends TerminalExecutionError {}
@@ -80,6 +93,10 @@ export function classifyAgentError(input: {
   message: string;
   rawMessage?: unknown;
 }): TaskExecutionError {
+  if (isOverloadedErrorMessage(input.message)) {
+    return new AgentOverloadedError(input.message, input.rawMessage);
+  }
+
   if (QUOTA_MESSAGE_PATTERNS.some((pattern) => pattern.test(input.message))) {
     return new AgentQuotaExceededError(input.message, input.rawMessage);
   }
@@ -97,6 +114,10 @@ export function classifyRunnerError(error: unknown): TaskExecutionError {
     if (error.name === 'AbortError' || error.message.includes('aborted')) {
       return new InterruptedExecutionError(error.message, error);
     }
+
+    if (isOverloadedErrorMessage(error.message)) {
+      return new AgentOverloadedError(error.message, error);
+    }
   }
 
   return new RunnerProcessError(
@@ -104,6 +125,10 @@ export function classifyRunnerError(error: unknown): TaskExecutionError {
     'UNKNOWN',
     error,
   );
+}
+
+export function isOverloadedErrorMessage(message: string): boolean {
+  return OVERLOADED_MESSAGE_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 function normalizeExecutionErrorMessage(message: string): string {


### PR DESCRIPTION
## Summary
- Classify Claude `529 overloaded_error` failures as retryable overload errors instead of generic unknown runner failures.
- Resume the current Claude session once when an overload happens after a session id has been captured.
- Preserve the existing persisted execution error-code contract by storing overloads as `UNKNOWN` while exposing a dedicated worker error class.

## Validation
- `npm run build:dev`
- `npm -w apps/worker run build`
- `npm run dev:1` booted successfully until the expected timeout; backend reached `Application is running on: http://localhost:2003` with the known AppInitRunner prompt block error.

## Technical Debt
- There is no worker unit test harness yet, so this is validated through TypeScript and full build/dev boot rather than a focused unit test.