### PR TITLE
Add project selector to tasks views

### DIFF
--- a/apps/ui/src/app/shells/DesktopShell.css
+++ b/apps/ui/src/app/shells/DesktopShell.css
@@ -22,6 +22,19 @@
   color: var(--text);
 }
 
+.desktop-shell__title-row {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.desktop-shell__title-accessory {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
 .desktop-shell__actions {
   display: flex;
   align-items: center;

--- a/apps/ui/src/app/shells/DesktopShell.tsx
+++ b/apps/ui/src/app/shells/DesktopShell.tsx
@@ -3,16 +3,22 @@ import "./DesktopShell.css";
 
 export interface DesktopShellProps {
   sectionTitle?: string;
+  titleAccessory?: ReactNode;
   headerActions?: ReactNode;
   children: ReactNode;
 }
 
-export function DesktopShell({ sectionTitle, headerActions, children }: DesktopShellProps): React.JSX.Element {
+export function DesktopShell({ sectionTitle, titleAccessory, headerActions, children }: DesktopShellProps): React.JSX.Element {
   return (
     <div className="desktop-shell">
       {sectionTitle && (
         <div className="desktop-shell__header">
-          <h1 className="desktop-shell__title">{sectionTitle}</h1>
+          <div className="desktop-shell__title-row">
+            <h1 className="desktop-shell__title">{sectionTitle}</h1>
+            {titleAccessory ? (
+              <div className="desktop-shell__title-accessory">{titleAccessory}</div>
+            ) : null}
+          </div>
           {headerActions ? (
             <div className="desktop-shell__actions">{headerActions}</div>
           ) : null}

--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -1173,6 +1173,7 @@ export function TaskDetailPage() {
   const { d: taskId } = useParams<{ d: string }>();
   const {
     tasks,
+    detailTasks,
     getTaskById,
     isLoading,
     hasLoadedOnce,
@@ -1187,8 +1188,19 @@ export function TaskDetailPage() {
 
   const [isFetchingTask, setIsFetchingTask] = useState(false);
 
-  // Derive task from the live tasks array so WebSocket updates are reflected automatically.
-  const task = taskId ? tasks.find(t => t.id === taskId) : undefined;
+  const allCachedTasks = useMemo(() => {
+    const taskById = new Map<string, Task>();
+    for (const task of tasks) {
+      taskById.set(task.id, task);
+    }
+    for (const task of detailTasks) {
+      taskById.set(task.id, task);
+    }
+    return Array.from(taskById.values());
+  }, [tasks, detailTasks]);
+
+  // Derive task from all cached tasks so direct detail hydration does not affect board state.
+  const task = taskId ? allCachedTasks.find(t => t.id === taskId) : undefined;
 
   // On mount (or taskId change), ensure the task is in the cache.
   // getTaskById fetches from the API and adds it to the tasks array if missing.
@@ -1211,7 +1223,7 @@ export function TaskDetailPage() {
     if (!task || !task.dependsOnIds || task.dependsOnIds.length === 0) return;
 
     const missingDependencyIds = task.dependsOnIds.filter(
-      depId => !tasks.some(t => t.id === depId)
+      depId => !allCachedTasks.some(t => t.id === depId)
     );
 
     if (missingDependencyIds.length === 0) return;
@@ -1225,7 +1237,7 @@ export function TaskDetailPage() {
         })
       )
     );
-  }, [task, tasks, getTaskById]);
+  }, [task, allCachedTasks, getTaskById]);
 
   const isLoadingTask = !task && (!hasLoadedOnce || isLoading || isFetchingTask);
 
@@ -1239,7 +1251,7 @@ export function TaskDetailPage() {
     addTag: ({ taskId, tag }) => TasksService.TasksController_addTagToTask({ id: taskId, body: { name: tag.name } }),
     removeTag: ({ taskId, tagId }) => TasksService.TasksController_removeTagFromTask({ id: taskId, tagId }),
     addDependency: async ({ taskId, dependencyTaskId }) => {
-      const currentTask = tasks.find(t => t.id === taskId);
+      const currentTask = allCachedTasks.find(t => t.id === taskId);
       if (!currentTask) return;
       const updatedDependsOnIds = [...(currentTask.dependsOnIds || []), dependencyTaskId];
       await TasksService.TasksController_updateTask({
@@ -1256,7 +1268,7 @@ export function TaskDetailPage() {
       }
     },
     removeDependency: async ({ taskId, dependencyTaskId }) => {
-      const currentTask = tasks.find(t => t.id === taskId);
+      const currentTask = allCachedTasks.find(t => t.id === taskId);
       if (!currentTask) return;
       const updatedDependsOnIds = (currentTask.dependsOnIds || []).filter(id => id !== dependencyTaskId);
       await TasksService.TasksController_updateTask({
@@ -1274,7 +1286,7 @@ export function TaskDetailPage() {
       isLoadingTask={isLoadingTask}
       activityByTaskId={activityByTaskId}
       handlers={handlers}
-      allTasks={tasks}
+      allTasks={allCachedTasks}
     />
   );
 }

--- a/apps/ui/src/features/tasks/TasksLayout.css
+++ b/apps/ui/src/features/tasks/TasksLayout.css
@@ -4,6 +4,158 @@
   gap: var(--space-2);
 }
 
+.tasks-layout__project-selector {
+  position: relative;
+  display: inline-block;
+  min-width: 0;
+}
+
+.tasks-layout__project-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  width: 100%;
+  min-width: 9rem;
+  max-width: 13rem;
+  min-height: 30px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-3);
+  background: var(--card-bg);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-1);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+}
+
+.tasks-layout__project-trigger:hover {
+  border-color: var(--border);
+  background: var(--surface);
+}
+
+.tasks-layout__project-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.tasks-layout__project-trigger:disabled {
+  cursor: default;
+  color: var(--text-muted);
+}
+
+.tasks-layout__project-selector-icon {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.tasks-layout__project-selector-chevron {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--text-muted);
+  transition: transform 120ms ease;
+}
+
+.tasks-layout__project-selector-chevron--open {
+  transform: rotate(180deg);
+}
+
+.tasks-layout__project-trigger-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tasks-layout__project-menu {
+  position: absolute;
+  top: calc(100% + var(--space-1));
+  left: 0;
+  z-index: 20;
+  width: min(18rem, 80vw);
+  padding: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+  background: var(--card-bg);
+  box-shadow: var(--shadow-2);
+}
+
+.tasks-layout__project-search {
+  width: 100%;
+  height: 32px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-2);
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-1);
+  outline: none;
+}
+
+.tasks-layout__project-search:focus {
+  border-color: var(--accent);
+}
+
+.tasks-layout__project-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  max-height: 16rem;
+  margin-top: var(--space-2);
+  overflow: auto;
+}
+
+.tasks-layout__project-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  min-height: 32px;
+  padding: 0 var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--r-2);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-1);
+  text-align: left;
+  cursor: pointer;
+}
+
+.tasks-layout__project-option:hover,
+.tasks-layout__project-option:focus-visible {
+  border-color: var(--border);
+  background: var(--surface);
+  outline: none;
+}
+
+.tasks-layout__project-option--selected {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.tasks-layout__project-option-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tasks-layout__project-option-tag,
+.tasks-layout__project-empty {
+  color: var(--text-muted);
+  font-size: var(--fs-1);
+}
+
+.tasks-layout__project-option-tag {
+  flex: 0 0 auto;
+}
+
+.tasks-layout__project-empty {
+  padding: var(--space-2);
+}
+
 .tasks-layout__view-toggle {
   display: inline-flex;
   align-items: center;
@@ -41,6 +193,25 @@
 }
 
 .tasks-layout__mobile-view-toggle {
+  width: 100%;
+}
+
+.tasks-layout__mobile-top-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.tasks-layout__mobile-top-actions .tasks-layout__project-selector {
+  width: 100%;
+}
+
+.tasks-layout__mobile-top-actions .tasks-layout__project-trigger {
+  max-width: none;
+}
+
+.tasks-layout__mobile-top-actions .tasks-layout__project-menu {
   width: 100%;
 }
 

--- a/apps/ui/src/features/tasks/TasksLayout.tsx
+++ b/apps/ui/src/features/tasks/TasksLayout.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { CalendarDays, GitBranch, LayoutDashboard } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { CalendarDays, ChevronDown, FolderKanban, GitBranch, LayoutDashboard } from "lucide-react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useIsDesktop } from "../../app/hooks/useIsDesktop";
 import { DesktopShell } from "../../app/shells/DesktopShell";
@@ -14,7 +14,14 @@ import "./TasksLayout.css";
 
 export function TasksLayout(): React.JSX.Element {
   const isDesktop = useIsDesktop();
-  const { sectionTitle, shippedCelebrationTrigger } = useTasksCtx();
+  const {
+    sectionTitle,
+    shippedCelebrationTrigger,
+    projects,
+    projectsLoaded,
+    selectedProjectId,
+    setSelectedProjectId,
+  } = useTasksCtx();
   const navigate = useNavigate();
   const location = useLocation();
   const [activeScheduleCount, setActiveScheduleCount] = useState<number | null>(null);
@@ -26,12 +33,21 @@ export function TasksLayout(): React.JSX.Element {
     "/tasks/done",
   ].includes(location.pathname);
   const showViewToggle = isBoardView || isDependencyView;
+  const showProjectSelector = isBoardView || isDependencyView;
   const viewToggle = (
     <TaskViewToggle
       isBoardView={isBoardView}
       isDependencyView={isDependencyView}
       onBoardClick={() => navigate('/tasks/not-started')}
       onDependenciesClick={() => navigate('/tasks/dependencies')}
+    />
+  );
+  const projectSelector = (
+    <ProjectSelector
+      projects={projects}
+      projectsLoaded={projectsLoaded}
+      selectedProjectId={selectedProjectId}
+      onChange={setSelectedProjectId}
     />
   );
 
@@ -63,6 +79,7 @@ export function TasksLayout(): React.JSX.Element {
       {isDesktop ?
         <DesktopShell
           sectionTitle={sectionTitle}
+          titleAccessory={showProjectSelector ? projectSelector : undefined}
           headerActions={(
             <div className="tasks-layout__header-actions">
               {showViewToggle ? viewToggle : null}
@@ -88,12 +105,144 @@ export function TasksLayout(): React.JSX.Element {
           appTitle="Tasks"
           sectionTitle={sectionTitle}
           navItems={TASKS_STATUS_NAV}
-          topActions={showViewToggle ? <div className="tasks-layout__mobile-view-toggle">{viewToggle}</div> : undefined}
+          topActions={showProjectSelector || showViewToggle ? (
+            <div className="tasks-layout__mobile-top-actions">
+              {showProjectSelector ? projectSelector : null}
+              {showViewToggle ? <div className="tasks-layout__mobile-view-toggle">{viewToggle}</div> : null}
+            </div>
+          ) : undefined}
         >
           <Outlet />
         </IosShell>}
     </div>
   )
+}
+
+function ProjectSelector({
+  projects,
+  projectsLoaded,
+  selectedProjectId,
+  onChange,
+}: {
+  projects: Array<{ id: string; slug: string; tagName: string }>;
+  projectsLoaded: boolean;
+  selectedProjectId: string | null;
+  onChange: (projectId: string | null) => void;
+}): React.JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredProjects = useMemo(() => {
+    if (!normalizedQuery) {
+      return projects;
+    }
+    return projects.filter((project) =>
+      project.slug.toLowerCase().includes(normalizedQuery) ||
+      project.tagName.toLowerCase().includes(normalizedQuery)
+    );
+  }, [normalizedQuery, projects]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    window.setTimeout(() => searchInputRef.current?.focus(), 0);
+
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [isOpen]);
+
+  const selectProject = (projectId: string | null) => {
+    onChange(projectId);
+    setQuery("");
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="tasks-layout__project-selector" ref={rootRef}>
+      <button
+        className="tasks-layout__project-trigger"
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-label="Task project"
+        disabled={!projectsLoaded}
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        <FolderKanban className="tasks-layout__project-selector-icon" size={15} strokeWidth={1.75} absoluteStrokeWidth />
+        <span className="tasks-layout__project-trigger-label">
+          {selectedProject?.slug ?? "All projects"}
+        </span>
+        <ChevronDown
+          className={`tasks-layout__project-selector-chevron${isOpen ? " tasks-layout__project-selector-chevron--open" : ""}`}
+          size={14}
+          strokeWidth={1.75}
+          absoluteStrokeWidth
+        />
+      </button>
+
+      {isOpen ? (
+        <div className="tasks-layout__project-menu">
+          <input
+            ref={searchInputRef}
+            className="tasks-layout__project-search"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search projects"
+            aria-label="Search projects"
+          />
+          <div className="tasks-layout__project-options" role="listbox" aria-label="Task project">
+            <button
+              className={`tasks-layout__project-option${selectedProjectId === null ? " tasks-layout__project-option--selected" : ""}`}
+              type="button"
+              role="option"
+              aria-selected={selectedProjectId === null}
+              onClick={() => selectProject(null)}
+            >
+              All projects
+            </button>
+            {filteredProjects.length === 0 ? (
+              <div className="tasks-layout__project-empty">No matching projects</div>
+            ) : (
+              filteredProjects.map((project) => (
+                <button
+                  key={project.id}
+                  className={`tasks-layout__project-option${selectedProjectId === project.id ? " tasks-layout__project-option--selected" : ""}`}
+                  type="button"
+                  role="option"
+                  aria-selected={selectedProjectId === project.id}
+                  onClick={() => selectProject(project.id)}
+                >
+                  <span className="tasks-layout__project-option-name">{project.slug}</span>
+                  <span className="tasks-layout__project-option-tag">{project.tagName}</span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 function TaskViewToggle({

--- a/apps/ui/src/features/tasks/TasksProvider.tsx
+++ b/apps/ui/src/features/tasks/TasksProvider.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useMemo, useRef, useState 
 import { useTasks } from "./useTasks"; // your abstraction hook
 import type { Task } from "./types";
 import { TaskStatus } from "./const";
-import { CommentResponseDto, CreateTaskDto, TaskResponseDto, InputRequestResponseDto } from "@taico/client/v2";
+import { CommentResponseDto, CreateTaskDto, TaskResponseDto, InputRequestResponseDto, ProjectResponseDto } from "@taico/client/v2";
 import { TaskActivityWireEvent } from "@taico/events";
 
 // Animation state tracked per status (for column-based animations)
@@ -52,6 +52,12 @@ export type TasksContextValue = {
   globalExitingTasks: Task[];
   activityByTaskId: Record<string, TaskActivityWireEvent>;
   shippedCelebrationTrigger: number;
+  projects: ProjectResponseDto[];
+  projectsLoaded: boolean;
+  selectedProjectId: string | null;
+  selectedProject: ProjectResponseDto | null;
+  selectedProjectTag: string | null;
+  setSelectedProjectId: (projectId: string | null) => void;
 };
 
 const TasksContext = createContext<TasksContextValue | null>(null);
@@ -70,7 +76,27 @@ type ActiveAnimation = {
 
 export function TasksProvider({ children }: { children: React.ReactNode }) {
   // IMPORTANT: this is where the one websocket connection should be created
-  const { tasks, getTaskById, isLoading, hasLoadedOnce, error, isConnected, createTask, deleteTask, addComment, assignTask, assignTaskToMe, answerInputRequest, activityByTaskId } = useTasks();
+  const {
+    tasks,
+    getTaskById,
+    isLoading,
+    hasLoadedOnce,
+    error,
+    isConnected,
+    createTask,
+    deleteTask,
+    addComment,
+    assignTask,
+    assignTaskToMe,
+    answerInputRequest,
+    activityByTaskId,
+    projects,
+    projectsLoaded,
+    selectedProjectId,
+    selectedProject,
+    selectedProjectTag,
+    setSelectedProjectId,
+  } = useTasks();
   const [sectionTitle, setSectionTitle] = useState("");
   const [shippedCelebrationTrigger, setShippedCelebrationTrigger] = useState(0);
 
@@ -241,6 +267,12 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
       globalExitingTasks,
       activityByTaskId,
       shippedCelebrationTrigger,
+      projects,
+      projectsLoaded,
+      selectedProjectId,
+      selectedProject,
+      selectedProjectTag,
+      setSelectedProjectId,
     };
   }, [
     tasks,
@@ -262,6 +294,12 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
     globalExitingTasks,
     activityByTaskId,
     shippedCelebrationTrigger,
+    projects,
+    projectsLoaded,
+    selectedProjectId,
+    selectedProject,
+    selectedProjectTag,
+    setSelectedProjectId,
   ]);
 
   return <TasksContext.Provider value={value}>{children}</TasksContext.Provider>;

--- a/apps/ui/src/features/tasks/TasksProvider.tsx
+++ b/apps/ui/src/features/tasks/TasksProvider.tsx
@@ -22,6 +22,7 @@ const createEmptyAnimationByStatus = (): Record<TaskStatus, AnimationState> => (
 // Shape this to match what pages/layout need.
 export type TasksContextValue = {
   tasks: Task[];
+  detailTasks: Task[];
   getTaskById: (taskId: string) => Promise<Task | null>;
   createTask: (task: CreateTaskDto) => Promise<Task>;
   deleteTask: ({ taskId }: { taskId: string }) => Promise<void>;
@@ -78,6 +79,7 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
   // IMPORTANT: this is where the one websocket connection should be created
   const {
     tasks,
+    detailTasks,
     getTaskById,
     isLoading,
     hasLoadedOnce,
@@ -249,6 +251,7 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
   const value = useMemo<TasksContextValue>(() => {
     return {
       tasks,
+      detailTasks,
       getTaskById,
       createTask,
       deleteTask,
@@ -276,6 +279,7 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
     };
   }, [
     tasks,
+    detailTasks,
     getTaskById,
     createTask,
     deleteTask,

--- a/apps/ui/src/features/tasks/api.ts
+++ b/apps/ui/src/features/tasks/api.ts
@@ -10,10 +10,12 @@ const client = new ApiClient({
 export const TasksService = client.task;
 export const ActorsService = client.actors;
 export const MetaService = client.meta;
+export const ProjectsService = client.metaProjects;
 
 // Export API client for easier access to all endpoints
 export const api = {
   task: client.task,
   actor: client.actors,
   meta: client.meta,
+  projects: client.metaProjects,
 };

--- a/apps/ui/src/features/tasks/useTasks.ts
+++ b/apps/ui/src/features/tasks/useTasks.ts
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { io, Socket } from 'socket.io-client';
-import { TasksService } from './api';
+import { ProjectsService, TasksService } from './api';
 import type { Task } from './types';
 import { getUIWebSocketUrl } from '../../config/api';
 import type {
   CreateTaskDto,
   AssignTaskDto,
+  ProjectResponseDto,
 } from "@taico/client/v2"
 import {
   TaskWireEvents,
@@ -22,7 +23,19 @@ import {
 // Use centralized API configuration
 const SOCKET_URL = getUIWebSocketUrl('/tasks');
 const TASKS_PAGE_SIZE = 100;
+const SELECTED_PROJECT_STORAGE_KEY = 'tasks.selectedProjectId';
 
+function readStoredSelectedProjectId(): string | null {
+  try {
+    return localStorage.getItem(SELECTED_PROJECT_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function taskHasTag(task: Pick<Task, 'tags'>, tagName: string): boolean {
+  return task.tags.some((tag) => tag.name === tagName);
+}
 
 export const useTasks = () => {
   // UI feedback
@@ -32,6 +45,9 @@ export const useTasks = () => {
 
   // Data store
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [projects, setProjects] = useState<ProjectResponseDto[]>([]);
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
+  const [selectedProjectId, setSelectedProjectIdState] = useState<string | null>(() => readStoredSelectedProjectId());
 
   // Transport
   const [socket, setSocket] = useState<Socket | null>(null);
@@ -39,6 +55,56 @@ export const useTasks = () => {
 
   // Ephemeral UI state: last activity per task
   const [activityByTaskId, setActivityByTaskId] = useState<Record<string, TaskActivityWireEvent>>({});
+  const tasksRef = useRef<Task[]>([]);
+  const selectedProjectTagRef = useRef<string | null>(null);
+  const isProjectSelectionReadyRef = useRef(false);
+
+  const selectedProject = useMemo(() => {
+    if (!selectedProjectId) {
+      return null;
+    }
+    return projects.find((project) => project.id === selectedProjectId) ?? null;
+  }, [projects, selectedProjectId]);
+
+  const selectedProjectTag = selectedProject?.tagName ?? null;
+  const isProjectSelectionReady = !selectedProjectId || Boolean(selectedProject);
+
+  useEffect(() => {
+    tasksRef.current = tasks;
+  }, [tasks]);
+
+  useEffect(() => {
+    selectedProjectTagRef.current = selectedProjectTag;
+  }, [selectedProjectTag]);
+
+  useEffect(() => {
+    isProjectSelectionReadyRef.current = isProjectSelectionReady;
+  }, [isProjectSelectionReady]);
+
+  const setSelectedProjectId = useCallback((projectId: string | null) => {
+    setSelectedProjectIdState(projectId);
+    try {
+      if (projectId) {
+        localStorage.setItem(SELECTED_PROJECT_STORAGE_KEY, projectId);
+      } else {
+        localStorage.removeItem(SELECTED_PROJECT_STORAGE_KEY);
+      }
+    } catch (err) {
+      console.error('Failed to persist selected task project', err);
+    }
+  }, []);
+
+  const loadProjects = useCallback(async () => {
+    try {
+      const response = await ProjectsService.ProjectsController_getAllProjects();
+      setProjects(response);
+    } catch (err) {
+      console.error('Failed to load projects', err);
+      setProjects([]);
+    } finally {
+      setProjectsLoaded(true);
+    }
+  }, []);
 
   const upsertActivity = (evt: TaskActivityWireEvent) => {
     // Only store activity if it has a message to display
@@ -60,13 +126,6 @@ export const useTasks = () => {
     });
   };
 
-  // Boot
-  useEffect(() => {
-    loadTasks();
-    const cleanup = setupWebsocket();
-    return cleanup;
-  }, []);
-
   // Sort tasks by updatedAt (newest first)
   const sortTasks = (tasks: Task[]): Task[] => {
     return [...tasks].sort((a, b) => {
@@ -86,7 +145,14 @@ export const useTasks = () => {
 
   // Create task
   const createTask = async (task: CreateTaskDto) => {
-    return await TasksService.TasksController_createTask({ body: task });
+    const projectTag = selectedProjectTagRef.current;
+    const body: CreateTaskDto = projectTag
+      ? {
+        ...task,
+        tagNames: Array.from(new Set([...(task.tagNames ?? []), projectTag])),
+      }
+      : task;
+    return await TasksService.TasksController_createTask({ body });
   }
 
   // Delete tasl
@@ -124,12 +190,16 @@ export const useTasks = () => {
 
   // Load tasks
   const loadTasks = async () => {
+    if (!isProjectSelectionReadyRef.current) {
+      return;
+    }
     setIsLoading(true);
     setError(null);
     try {
       const response = await TasksService.TasksController_listTasks({
         page: 1,
         limit: TASKS_PAGE_SIZE,
+        tag: selectedProjectTagRef.current ?? undefined,
       });
       setTasks(prev => mergeTasks(prev, response.items));
     } catch (err) {
@@ -148,6 +218,11 @@ export const useTasks = () => {
     // Try to fetch from backend (it's fast enough and ensures we have the latest data)
     try {
       const task = await TasksService.TasksController_getTask({ id: taskId });
+      const selectedTag = selectedProjectTagRef.current;
+      if (selectedTag && !taskHasTag(task, selectedTag)) {
+        setTasks((prev) => prev.filter((t) => t.id !== task.id));
+        return null;
+      }
       // Add to cache for future lookups
       setTasks((prev) => {
         // Check if task already exists in cache to avoid duplicates
@@ -164,6 +239,47 @@ export const useTasks = () => {
       return null;
     }
   }, []); // No dependencies - uses functional state updates
+
+  const taskMatchesSelectedProject = (task: Task): boolean => {
+    const selectedTag = selectedProjectTagRef.current;
+    return !selectedTag || taskHasTag(task, selectedTag);
+  };
+
+  const isVisibleTaskId = (taskId: string): boolean => {
+    const selectedTag = selectedProjectTagRef.current;
+    if (!selectedTag) {
+      return true;
+    }
+    return tasksRef.current.some((task) => task.id === taskId && taskHasTag(task, selectedTag));
+  };
+
+  const upsertTaskFromEvent = (task: Task) => {
+    if (!taskMatchesSelectedProject(task)) {
+      setTasks((prev) => prev.filter((existingTask) => existingTask.id !== task.id));
+      clearActivity(task.id);
+      return;
+    }
+
+    setTasks((prev) => {
+      if (prev.some((existingTask) => existingTask.id === task.id)) {
+        return sortTasks(prev.map((existingTask) => (existingTask.id === task.id ? task : existingTask)));
+      }
+      return sortTasks([task, ...prev]);
+    });
+  };
+
+  const refreshVisibleTask = async (taskId: string, errorMessage: string) => {
+    if (!isVisibleTaskId(taskId)) {
+      return;
+    }
+
+    try {
+      const updatedTask = await TasksService.TasksController_getTask({ id: taskId });
+      upsertTaskFromEvent(updatedTask);
+    } catch (err) {
+      console.error(errorMessage, err);
+    }
+  };
 
   // Setup websocket
   const setupWebsocket = () => {
@@ -195,84 +311,55 @@ export const useTasks = () => {
     // Handle task created event
     newSocket.on(TaskWireEvents.TASK_CREATED, (event: TaskCreatedWireEvent) => {
       console.log('task.created', event);
-      setTasks((prev) => {
-        // Avoid duplicates - check if task already exists
-        if (prev.some(t => t.id === event.payload.id)) {
-          return prev;
-        }
-        // TODO: this type assertion is to hide a type mismatch!
-        return sortTasks([event.payload as Task, ...prev]);
-      });
+      upsertTaskFromEvent(event.payload as Task);
     });
 
     // Handle task updated event
     newSocket.on(TaskWireEvents.TASK_UPDATED, (event: TaskUpdatedWireEvent) => {
       console.log('task.updated', event);
-      setTasks((prev) =>
-        sortTasks(prev.map((t) => (t.id === event.payload.id ? event.payload as Task : t)))
-      );
+      upsertTaskFromEvent(event.payload as Task);
     });
 
     // Handle task deleted event
     newSocket.on(TaskWireEvents.TASK_DELETED, (event: TaskDeletedWireEvent) => {
       console.log('task.deleted', event);
+      if (!isVisibleTaskId(event.payload.taskId)) {
+        return;
+      }
       setTasks((prev) => prev.filter((t) => t.id !== event.payload.taskId));
+      clearActivity(event.payload.taskId);
     });
 
     // Handle task assigned event
     newSocket.on(TaskWireEvents.TASK_ASSIGNED, (event: TaskAssignedWireEvent) => {
       console.log('task.assigned', event);
-      setTasks((prev) =>
-        sortTasks(prev.map((t) => (t.id === event.payload.id ? event.payload as Task : t)))
-      );
+      upsertTaskFromEvent(event.payload as Task);
     });
 
     // Handle comment added event
     newSocket.on(TaskWireEvents.TASK_COMMENTED, async (event: TaskCommentedWireEvent) => {
       console.log('task.commented', event);
-      try {
-        // event.payload is CommentWirePayload with taskId
-        const updatedTask = await TasksService.TasksController_getTask({ id: event.payload.taskId });
-        setTasks((prev) => {
-          const existingTaskIndex = prev.findIndex((t) => t.id === updatedTask.id);
-          if (existingTaskIndex === -1) {
-            return sortTasks([updatedTask, ...prev]);
-          }
-          return sortTasks(prev.map((t) => (t.id === updatedTask.id ? updatedTask : t)));
-        });
-      } catch (err) {
-        console.error('Failed to refresh task after comment', err);
-      }
+      await refreshVisibleTask(event.payload.taskId, 'Failed to refresh task after comment');
     });
 
     // Handle input request answered event
     newSocket.on(TaskWireEvents.INPUT_REQUEST_ANSWERED, async (event: InputRequestAnsweredWireEvent) => {
       console.log('input.request.answered', event);
-      try {
-        const updatedTask = await TasksService.TasksController_getTask({ id: event.payload.taskId });
-        setTasks((prev) => {
-          const existingTaskIndex = prev.findIndex((t) => t.id === updatedTask.id);
-          if (existingTaskIndex === -1) {
-            return sortTasks([updatedTask, ...prev]);
-          }
-          return sortTasks(prev.map((t) => (t.id === updatedTask.id ? updatedTask : t)));
-        });
-      } catch (err) {
-        console.error('Failed to refresh task after input request answer', err);
-      }
+      await refreshVisibleTask(event.payload.taskId, 'Failed to refresh task after input request answer');
     });
 
     // Handle task status changed event
     newSocket.on(TaskWireEvents.TASK_STATUS_CHANGED, (event: TaskStatusChangedWireEvent) => {
       console.log('task.status_changed', event);
-      setTasks((prev) =>
-        sortTasks(prev.map((t) => (t.id === event.payload.id ? event.payload as Task : t)))
-      );
+      upsertTaskFromEvent(event.payload as Task);
     });
 
     // Handle task activity event (ephemeral UI feedback, not persisted)
     newSocket.on(TaskWireEvents.TASK_ACTIVITY, (evt: TaskActivityWireEvent) => {
       console.log('task.activity', evt);
+      if (!isVisibleTaskId(evt.taskId)) {
+        return;
+      }
       upsertActivity(evt);
     });
 
@@ -283,12 +370,52 @@ export const useTasks = () => {
     };
   };
 
+  useEffect(() => {
+    loadProjects();
+  }, [loadProjects]);
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === SELECTED_PROJECT_STORAGE_KEY) {
+        setSelectedProjectIdState(event.newValue);
+      }
+    };
+
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  useEffect(() => {
+    if (!projectsLoaded || !selectedProjectId || selectedProject) {
+      return;
+    }
+    setSelectedProjectId(null);
+  }, [projectsLoaded, selectedProject, selectedProjectId, setSelectedProjectId]);
+
+  useEffect(() => {
+    if (!isProjectSelectionReady) {
+      return;
+    }
+
+    setTasks([]);
+    setActivityByTaskId({});
+    loadTasks();
+    const cleanup = setupWebsocket();
+    return cleanup;
+  }, [isProjectSelectionReady, selectedProjectTag]);
+
   return {
     // UI feedback
     isLoading,
     hasLoadedOnce,
     error,
     activityByTaskId,
+    projects,
+    projectsLoaded,
+    selectedProjectId,
+    selectedProject,
+    selectedProjectTag,
+    setSelectedProjectId,
 
     // Data
     tasks,

--- a/apps/ui/src/features/tasks/useTasks.ts
+++ b/apps/ui/src/features/tasks/useTasks.ts
@@ -59,6 +59,7 @@ export const useTasks = () => {
   const tasksRef = useRef<Task[]>([]);
   const selectedProjectTagRef = useRef<string | null>(null);
   const isProjectSelectionReadyRef = useRef(false);
+  const loadTasksRequestIdRef = useRef(0);
 
   const selectedProject = useMemo(() => {
     if (!selectedProjectId) {
@@ -198,20 +199,35 @@ export const useTasks = () => {
     if (!isProjectSelectionReadyRef.current) {
       return;
     }
+    const requestId = loadTasksRequestIdRef.current + 1;
+    loadTasksRequestIdRef.current = requestId;
+    const requestedProjectTag = selectedProjectTagRef.current;
     setIsLoading(true);
     setError(null);
     try {
       const response = await TasksService.TasksController_listTasks({
         page: 1,
         limit: TASKS_PAGE_SIZE,
-        tag: selectedProjectTagRef.current ?? undefined,
+        tag: requestedProjectTag ?? undefined,
       });
-      setTasks(prev => mergeTasks(prev, response.items));
+      if (loadTasksRequestIdRef.current !== requestId || selectedProjectTagRef.current !== requestedProjectTag) {
+        return;
+      }
+
+      const visibleItems = requestedProjectTag
+        ? response.items.filter((task) => taskHasTag(task, requestedProjectTag))
+        : response.items;
+      setTasks(prev => mergeTasks(prev, visibleItems));
     } catch (err) {
+      if (loadTasksRequestIdRef.current !== requestId || selectedProjectTagRef.current !== requestedProjectTag) {
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to load tasks');
     } finally {
-      setHasLoadedOnce(true);
-      setIsLoading(false);
+      if (loadTasksRequestIdRef.current === requestId && selectedProjectTagRef.current === requestedProjectTag) {
+        setHasLoadedOnce(true);
+        setIsLoading(false);
+      }
     }
   };
 

--- a/apps/ui/src/features/tasks/useTasks.ts
+++ b/apps/ui/src/features/tasks/useTasks.ts
@@ -418,7 +418,6 @@ export const useTasks = () => {
     }
 
     setTasks([]);
-    setDetailTasks([]);
     setActivityByTaskId({});
     loadTasks();
     const cleanup = setupWebsocket();

--- a/apps/ui/src/features/tasks/useTasks.ts
+++ b/apps/ui/src/features/tasks/useTasks.ts
@@ -274,6 +274,12 @@ export const useTasks = () => {
     });
   };
 
+  const removeTaskFromCaches = (taskId: string) => {
+    setTasks((prev) => prev.filter((task) => task.id !== taskId));
+    setDetailTasks((prev) => prev.filter((task) => task.id !== taskId));
+    clearActivity(taskId);
+  };
+
   const refreshTaskFromEvent = async (taskId: string, errorMessage: string) => {
     try {
       const updatedTask = await TasksService.TasksController_getTask({ id: taskId });
@@ -325,11 +331,7 @@ export const useTasks = () => {
     // Handle task deleted event
     newSocket.on(TaskWireEvents.TASK_DELETED, (event: TaskDeletedWireEvent) => {
       console.log('task.deleted', event);
-      if (!isVisibleTaskId(event.payload.taskId)) {
-        return;
-      }
-      setTasks((prev) => prev.filter((t) => t.id !== event.payload.taskId));
-      clearActivity(event.payload.taskId);
+      removeTaskFromCaches(event.payload.taskId);
     });
 
     // Handle task assigned event

--- a/apps/ui/src/features/tasks/useTasks.ts
+++ b/apps/ui/src/features/tasks/useTasks.ts
@@ -218,11 +218,6 @@ export const useTasks = () => {
     // Try to fetch from backend (it's fast enough and ensures we have the latest data)
     try {
       const task = await TasksService.TasksController_getTask({ id: taskId });
-      const selectedTag = selectedProjectTagRef.current;
-      if (selectedTag && !taskHasTag(task, selectedTag)) {
-        setTasks((prev) => prev.filter((t) => t.id !== task.id));
-        return null;
-      }
       // Add to cache for future lookups
       setTasks((prev) => {
         // Check if task already exists in cache to avoid duplicates

--- a/apps/ui/src/features/tasks/useTasks.ts
+++ b/apps/ui/src/features/tasks/useTasks.ts
@@ -45,6 +45,7 @@ export const useTasks = () => {
 
   // Data store
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [detailTasks, setDetailTasks] = useState<Task[]>([]);
   const [projects, setProjects] = useState<ProjectResponseDto[]>([]);
   const [projectsLoaded, setProjectsLoaded] = useState(false);
   const [selectedProjectId, setSelectedProjectIdState] = useState<string | null>(() => readStoredSelectedProjectId());
@@ -143,6 +144,10 @@ export const useTasks = () => {
     ]);
   };
 
+  const cacheDetailTask = (task: Task) => {
+    setDetailTasks((prev) => mergeTasks(prev, [task]));
+  };
+
   // Create task
   const createTask = async (task: CreateTaskDto) => {
     const projectTag = selectedProjectTagRef.current;
@@ -218,8 +223,12 @@ export const useTasks = () => {
     // Try to fetch from backend (it's fast enough and ensures we have the latest data)
     try {
       const task = await TasksService.TasksController_getTask({ id: taskId });
-      // Add to cache for future lookups
+      cacheDetailTask(task);
+      // Only project-matching hydrated tasks belong in the board/list cache.
       setTasks((prev) => {
+        if (!taskMatchesSelectedProject(task)) {
+          return prev.filter(t => t.id !== task.id);
+        }
         // Check if task already exists in cache to avoid duplicates
         if (prev.some(t => t.id === task.id)) {
           // Update existing task in case it changed
@@ -233,7 +242,7 @@ export const useTasks = () => {
       console.error('Failed to fetch task by ID', err);
       return null;
     }
-  }, []); // No dependencies - uses functional state updates
+  }, []); // No dependencies - uses refs and functional state updates
 
   const taskMatchesSelectedProject = (task: Task): boolean => {
     const selectedTag = selectedProjectTagRef.current;
@@ -249,6 +258,8 @@ export const useTasks = () => {
   };
 
   const upsertTaskFromEvent = (task: Task) => {
+    cacheDetailTask(task);
+
     if (!taskMatchesSelectedProject(task)) {
       setTasks((prev) => prev.filter((existingTask) => existingTask.id !== task.id));
       clearActivity(task.id);
@@ -389,6 +400,7 @@ export const useTasks = () => {
     }
 
     setTasks([]);
+    setDetailTasks([]);
     setActivityByTaskId({});
     loadTasks();
     const cleanup = setupWebsocket();
@@ -410,6 +422,7 @@ export const useTasks = () => {
 
     // Data
     tasks,
+    detailTasks,
     getTaskById,
     createTask,
     deleteTask,

--- a/apps/ui/src/features/tasks/useTasks.ts
+++ b/apps/ui/src/features/tasks/useTasks.ts
@@ -263,11 +263,7 @@ export const useTasks = () => {
     });
   };
 
-  const refreshVisibleTask = async (taskId: string, errorMessage: string) => {
-    if (!isVisibleTaskId(taskId)) {
-      return;
-    }
-
+  const refreshTaskFromEvent = async (taskId: string, errorMessage: string) => {
     try {
       const updatedTask = await TasksService.TasksController_getTask({ id: taskId });
       upsertTaskFromEvent(updatedTask);
@@ -334,13 +330,13 @@ export const useTasks = () => {
     // Handle comment added event
     newSocket.on(TaskWireEvents.TASK_COMMENTED, async (event: TaskCommentedWireEvent) => {
       console.log('task.commented', event);
-      await refreshVisibleTask(event.payload.taskId, 'Failed to refresh task after comment');
+      await refreshTaskFromEvent(event.payload.taskId, 'Failed to refresh task after comment');
     });
 
     // Handle input request answered event
     newSocket.on(TaskWireEvents.INPUT_REQUEST_ANSWERED, async (event: InputRequestAnsweredWireEvent) => {
       console.log('input.request.answered', event);
-      await refreshVisibleTask(event.payload.taskId, 'Failed to refresh task after input request answer');
+      await refreshTaskFromEvent(event.payload.taskId, 'Failed to refresh task after input request answer');
     });
 
     // Handle task status changed event


### PR DESCRIPTION
## Summary
- add a persisted project selector to the tasks board/dependencies views
- filter task listing and realtime task state by selected project tag
- default new tasks to the selected project tag
- use a custom searchable project dropdown and keep it off task detail routes

## Verification
- npm -w apps/ui run build
- Browser Use smoke test on /tasks/not-started and task detail route