### PR TITLE
Interrupt workers for stale executions

### DIFF
--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -14,6 +14,9 @@ module.exports = {
   collectCoverageFrom: ['apps/backend/src/**/*.(t|j)s'],
   coverageDirectory: '<rootDir>/apps/backend/coverage',
   testEnvironment: 'node',
+  moduleNameMapper: {
+    '^src/(.*)$': '<rootDir>/apps/backend/src/$1',
+  },
   transformIgnorePatterns: [
     'node_modules/(?!(@modelcontextprotocol|.*\\.mjs$))',
   ],

--- a/apps/backend/src/executions/staleness/stale-active-task-execution-pruner.service.spec.ts
+++ b/apps/backend/src/executions/staleness/stale-active-task-execution-pruner.service.spec.ts
@@ -1,0 +1,104 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DataSource, EntityManager } from 'typeorm';
+import { ActiveTaskExecutionEntity } from '../active/active-task-execution.entity';
+import { ExecutionInterruptEvent } from '../events/execution-interrupt.event';
+import { TaskExecutionHistoryStatus } from '../history/task-execution-history-status.enum';
+import { TaskStatus } from '../../tasks/enums';
+import { StaleActiveTaskExecutionPrunerService } from './stale-active-task-execution-pruner.service';
+
+describe('StaleActiveTaskExecutionPrunerService', () => {
+  let dataSource: DataSource;
+  let eventEmitter: EventEmitter2;
+  let emit: jest.Mock;
+  let service: StaleActiveTaskExecutionPrunerService;
+
+  beforeEach(() => {
+    dataSource = {
+      transaction: jest.fn(),
+    } as unknown as DataSource;
+    emit = jest.fn();
+    eventEmitter = {
+      emit,
+    } as unknown as EventEmitter2;
+    service = new StaleActiveTaskExecutionPrunerService(
+      dataSource,
+      eventEmitter,
+    );
+  });
+
+  it('emits an interrupt request after pruning a stale execution', async () => {
+    const execution = {
+      id: 'execution-1',
+      taskId: 'task-1',
+      claimedAt: new Date('2026-04-30T10:00:00.000Z'),
+      taskStatusBeforeClaim: TaskStatus.IN_PROGRESS,
+      taskTagsBeforeClaim: [],
+      taskAssigneeActorIdBeforeClaim: 'actor-1',
+      agentActorId: 'agent-1',
+      workerClientId: 'worker-1',
+      lastHeartbeatAt: null,
+      runnerSessionId: null,
+      toolCallCount: 0,
+      stats: null,
+      rowVersion: 1,
+      createdAt: new Date('2026-04-30T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-30T10:00:00.000Z'),
+      deletedAt: null,
+    } as ActiveTaskExecutionEntity;
+    const task = {
+      id: 'task-1',
+      tags: [],
+    };
+    const manager = {
+      findOne: jest.fn()
+        .mockResolvedValueOnce(execution)
+        .mockResolvedValueOnce(task),
+      save: jest.fn(),
+      delete: jest.fn(),
+      create: jest.fn((_, value) => value),
+    } as unknown as jest.Mocked<EntityManager>;
+
+    (dataSource.transaction as jest.Mock).mockImplementation(
+      async (callback: (manager: EntityManager) => Promise<unknown>) =>
+        callback(manager),
+    );
+
+    await expect(service.pruneExecutionById(execution.id)).resolves.toBe(true);
+
+    expect(manager.delete).toHaveBeenCalledWith(ActiveTaskExecutionEntity, {
+      id: execution.id,
+    });
+    expect(manager.save).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        taskId: execution.taskId,
+        status: TaskExecutionHistoryStatus.STALE,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      ExecutionInterruptEvent.INTERNAL,
+      expect.objectContaining({
+        actor: { id: 'system' },
+        payload: {
+          executionId: execution.id,
+          workerClientId: execution.workerClientId,
+        },
+      }),
+    );
+  });
+
+  it('does not emit an interrupt request when no execution is pruned', async () => {
+    const manager = {
+      findOne: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<EntityManager>;
+
+    (dataSource.transaction as jest.Mock).mockImplementation(
+      async (callback: (manager: EntityManager) => Promise<unknown>) =>
+        callback(manager),
+    );
+
+    await expect(service.pruneExecutionById('missing-execution')).resolves.toBe(false);
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/executions/staleness/stale-active-task-execution-pruner.service.ts
+++ b/apps/backend/src/executions/staleness/stale-active-task-execution-pruner.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DataSource, EntityManager, In } from 'typeorm';
 import {
   ActiveTaskExecutionEntity,
@@ -8,10 +9,16 @@ import { TagEntity } from '../../meta/tag.entity';
 import { TaskEntity } from '../../tasks/task.entity';
 import { TaskExecutionHistoryEntity } from '../history/task-execution-history.entity';
 import { TaskExecutionHistoryStatus } from '../history/task-execution-history-status.enum';
+import { ExecutionInterruptEvent } from '../events/execution-interrupt.event';
+
+const STALE_EXECUTION_INTERRUPT_ACTOR_ID = 'system';
 
 @Injectable()
 export class StaleActiveTaskExecutionPrunerService {
-  constructor(private readonly dataSource: DataSource) {}
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
 
   async pruneExecutions(executions: ActiveTaskExecutionEntity[]): Promise<number> {
     let prunedCount = 0;
@@ -25,13 +32,13 @@ export class StaleActiveTaskExecutionPrunerService {
   }
 
   async pruneExecutionById(executionId: string): Promise<boolean> {
-    return this.dataSource.transaction(async (manager) => {
+    const prunedExecution = await this.dataSource.transaction(async (manager) => {
       const activeExecution = await manager.findOne(ActiveTaskExecutionEntity, {
         where: { id: executionId },
       });
 
       if (!activeExecution) {
-        return false;
+        return null;
       }
 
       const task = await manager.findOne(TaskEntity, {
@@ -41,7 +48,7 @@ export class StaleActiveTaskExecutionPrunerService {
 
       if (!task) {
         await manager.delete(ActiveTaskExecutionEntity, { id: activeExecution.id });
-        return true;
+        return activeExecution;
       }
 
       task.status = activeExecution.taskStatusBeforeClaim;
@@ -66,8 +73,25 @@ export class StaleActiveTaskExecutionPrunerService {
         }),
       );
 
-      return true;
+      return activeExecution;
     });
+
+    if (!prunedExecution) {
+      return false;
+    }
+
+    this.eventEmitter.emit(
+      ExecutionInterruptEvent.INTERNAL,
+      new ExecutionInterruptEvent(
+        { id: STALE_EXECUTION_INTERRUPT_ACTOR_ID },
+        {
+          executionId: prunedExecution.id,
+          workerClientId: prunedExecution.workerClientId,
+        },
+      ),
+    );
+
+    return true;
   }
 
   private async resolveSnapshotTags(


### PR DESCRIPTION
## Summary
- Emit the existing execution interrupt event after stale active executions are pruned so connected workers are asked to stop leftover processes.
- Add focused coverage for stale pruning interrupt behavior.
- Map the backend Jest `src/*` alias so specs can resolve existing absolute backend imports.

## Validation
- `npm -w apps/backend run test -- --runInBand stale-active-task-execution-pruner.service.spec.ts`
- `npm run build:dev`
- `timeout 25s npm run dev:3`

## Notes
- `dev:1` and `dev:2` reached Nest startup but their backend ports were already in use; `dev:3` started successfully on `http://localhost:2010`.
- No technical debt introduced.