### PR TITLE
Fix OpenCode runner heartbeats

### DIFF
--- a/apps/worker/src/runners/BaseAgentRunner.ts
+++ b/apps/worker/src/runners/BaseAgentRunner.ts
@@ -13,6 +13,8 @@ export abstract class BaseAgentRunner implements AgentRunner {
     onHeartbeat: () => undefined,
   };
 
+  protected readonly usePeriodicHeartbeat: boolean = true;
+
   abstract readonly kind: string;
 
   getModel(): Model | null {
@@ -30,13 +32,20 @@ export abstract class BaseAgentRunner implements AgentRunner {
     const events: string[] = [];
     let sessionId: string | null = null;
     let result = '';
-    const heartbeatTimer = setInterval(() => {
-      void Promise.resolve(cb.onHeartbeat()).catch((error) => {
+    const emitHeartbeat = async () => {
+      try {
+        await cb.onHeartbeat();
+      } catch (error) {
         console.warn(
           `[agent-runner:${this.kind}] heartbeat callback failed: ${error instanceof Error ? error.message : String(error)}`,
         );
-      });
-    }, BaseAgentRunner.HEARTBEAT_INTERVAL_MS);
+      }
+    };
+    const heartbeatTimer = this.usePeriodicHeartbeat
+      ? setInterval(() => {
+          void emitHeartbeat();
+        }, BaseAgentRunner.HEARTBEAT_INTERVAL_MS)
+      : undefined;
 
     const emit = async (msg: string) => {
       events.push(msg);
@@ -72,12 +81,15 @@ export abstract class BaseAgentRunner implements AgentRunner {
         onError,
         onToolCall,
         onTokenUsage,
+        emitHeartbeat,
       );
     } catch (err: any) {
       await emit(`❌ Agent error: ${err?.message ?? String(err)}`);
       throw err;
     } finally {
-      clearInterval(heartbeatTimer);
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+      }
     }
 
     return { sessionId, events, result };
@@ -94,5 +106,6 @@ export abstract class BaseAgentRunner implements AgentRunner {
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
     onToolCall?: (toolName: string) => void | Promise<void>,
     onTokenUsage?: (usage: TokenUsage) => void | Promise<void>,
+    onHeartbeat?: () => void | Promise<void>,
   ): Promise<string>;
 }

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -359,6 +359,17 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
   ): Promise<string> {
     const formatter = new OpencodeAsyncMessageFormatter(ctx.agentSlug);
     this.runtimeMcpServers = ctx.mcpServers;
+    let heartbeatInFlight = false;
+    const emitHarnessHeartbeat = () => {
+      if (!onHeartbeat || heartbeatInFlight) {
+        return;
+      }
+
+      heartbeatInFlight = true;
+      void Promise.resolve(onHeartbeat()).finally(() => {
+        heartbeatInFlight = false;
+      });
+    };
 
     let removeAbortListener: (() => void) | undefined;
     this.interruptRequested = false;
@@ -450,7 +461,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
 
       console.log("--------- STARTING EVENT LOOP ---------");
       for await (const event of events.stream) {
-        await onHeartbeat?.();
+        emitHarnessHeartbeat();
 
         if (this.interruptRequested && await this.wasAbortApplied()) {
           throw new InterruptedExecutionError('OpenCode agent execution was interrupted');

--- a/apps/worker/src/runners/OpenCodeAgentRunner.ts
+++ b/apps/worker/src/runners/OpenCodeAgentRunner.ts
@@ -66,6 +66,7 @@ function stopProcessTree(proc: ChildProcessWithoutNullStreams): void {
 
 export class OpencodeAgentRunner extends BaseAgentRunner {
   readonly kind: string;
+  protected override readonly usePeriodicHeartbeat = false;
 
   // Mutex for process.chdir: serializes all instances so only one
   // changes the working directory at a time.
@@ -354,6 +355,7 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
     onError?: (error: { message: string; rawMessage?: any }) => void | Promise<void>,
     onToolCall?: (toolName: string) => void | Promise<void>,
     onTokenUsage?: (usage: TokenUsage) => void | Promise<void>,
+    onHeartbeat?: () => void | Promise<void>,
   ): Promise<string> {
     const formatter = new OpencodeAsyncMessageFormatter(ctx.agentSlug);
     this.runtimeMcpServers = ctx.mcpServers;
@@ -448,6 +450,8 @@ export class OpencodeAgentRunner extends BaseAgentRunner {
 
       console.log("--------- STARTING EVENT LOOP ---------");
       for await (const event of events.stream) {
+        await onHeartbeat?.();
+
         if (this.interruptRequested && await this.wasAbortApplied()) {
           throw new InterruptedExecutionError('OpenCode agent execution was interrupted');
         }


### PR DESCRIPTION
## Summary
- Disable the inherited timer-based execution heartbeat for the OpenCode runner.
- Emit execution heartbeats from every OpenCode harness SSE event so stalled harnesses stop masking as active.
- Keep heartbeat callback failures non-fatal through the shared runner wrapper.

## Validation
- npm run build:dev
- npm run dev:3 (started backend at http://localhost:2010; stopped by validation timeout after startup)

## Technical Debt
- None identified.