### PR TITLE
Add MCP task tag creation support

### DIFF
--- a/apps/backend/src/tasks/tasks.mcp.gateway.spec.ts
+++ b/apps/backend/src/tasks/tasks.mcp.gateway.spec.ts
@@ -1,0 +1,115 @@
+import { TasksScopes } from './tasks.scopes';
+import { TasksMcpGateway } from './tasks.mcp.gateway';
+
+jest.mock('./tasks.service', () => ({
+  TasksService: jest.fn(),
+}));
+
+jest.mock('src/meta/meta.service', () => ({
+  MetaService: jest.fn(),
+}));
+
+jest.mock('src/identity-provider/actor.service', () => ({
+  ActorService: jest.fn(),
+}));
+
+jest.mock('src/threads/threads.service', () => ({
+  ThreadsService: jest.fn(),
+}));
+
+jest.mock('src/config/env.config', () => ({
+  getConfig: () => ({ appVersion: 'test' }),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: jest.fn().mockImplementation(() => ({
+    tools: {},
+    registerTool(this: any, name: string, config: unknown, handler: unknown) {
+      this.tools[name] = { config, handler };
+    },
+    connect: jest.fn(),
+  })),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: jest.fn().mockImplementation(() => ({
+    close: jest.fn(),
+    handleRequest: jest.fn(),
+  })),
+}));
+
+describe('TasksMcpGateway', () => {
+  const user = { actorId: 'actor-1' } as any;
+  const authContext = { scopes: [TasksScopes.WRITE.id] } as any;
+
+  it('exposes and forwards tagNames when creating a task', async () => {
+    const tasksService = {
+      createTask: jest.fn().mockResolvedValue({ id: 'task-1' }),
+      createTaskInThread: jest.fn(),
+    };
+    const gateway = new TasksMcpGateway(
+      tasksService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const server = (gateway as any).buildServer(user, authContext);
+    const createTaskTool = server.tools.create_task;
+
+    expect(createTaskTool.config.inputSchema.tagNames).toBeDefined();
+
+    await createTaskTool.handler({
+      name: 'Task with tags',
+      description: 'Created through MCP',
+      assigneeActorId: 'actor-2',
+      dependsOnIds: ['dependency-1'],
+      tagNames: ['code', 'project:taico'],
+    });
+
+    expect(tasksService.createTask).toHaveBeenCalledWith({
+      name: 'Task with tags',
+      description: 'Created through MCP',
+      assigneeActorId: 'actor-2',
+      createdByActorId: 'actor-1',
+      dependsOnIds: ['dependency-1'],
+      tagNames: ['code', 'project:taico'],
+    });
+  });
+
+  it('forwards tagNames when creating a task in a thread context', async () => {
+    const tasksService = {
+      createTask: jest.fn(),
+      createTaskInThread: jest.fn().mockResolvedValue({ id: 'task-1' }),
+    };
+    const gateway = new TasksMcpGateway(
+      tasksService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const server = (gateway as any).buildServer(
+      user,
+      authContext,
+      'execution-1',
+    );
+
+    await server.tools.create_task.handler({
+      name: 'Task with tags',
+      description: 'Created through MCP',
+      tagNames: ['code'],
+    });
+
+    expect(tasksService.createTaskInThread).toHaveBeenCalledWith({
+      name: 'Task with tags',
+      description: 'Created through MCP',
+      assigneeActorId: undefined,
+      createdByActorId: 'actor-1',
+      dependsOnIds: undefined,
+      tagNames: ['code'],
+      executionId: 'execution-1',
+      runId: undefined,
+    });
+  });
+});

--- a/apps/backend/src/tasks/tasks.mcp.gateway.ts
+++ b/apps/backend/src/tasks/tasks.mcp.gateway.ts
@@ -302,12 +302,13 @@ export class TasksMcpGateway {
         'create_task',
         {
           title: 'Create a new task',
-          description: 'Create task with name and description',
+          description: 'Create task with name, description, assignee, dependencies, and tags',
           inputSchema: {
             name: z.string(),
             description: z.string(),
             assigneeActorId: z.string().optional(),
             dependsOnIds: z.array(z.string()).optional(),
+            tagNames: z.array(z.string()).optional(),
           },
         },
         async ({
@@ -315,6 +316,7 @@ export class TasksMcpGateway {
           description,
           assigneeActorId,
           dependsOnIds,
+          tagNames,
         }) => {
           let task;
           if (executionId || runId) {
@@ -324,6 +326,7 @@ export class TasksMcpGateway {
               assigneeActorId,
               createdByActorId: user.actorId,
               dependsOnIds,
+              tagNames,
               executionId,
               runId,
             });
@@ -334,6 +337,7 @@ export class TasksMcpGateway {
               assigneeActorId,
               createdByActorId: user.actorId,
               dependsOnIds,
+              tagNames,
             });
           }
 


### PR DESCRIPTION
## Summary
- Expose optional `tagNames` on the Tasks MCP `create_task` tool.
- Forward `tagNames` through both standard task creation and execution/thread-context task creation.
- Add focused gateway tests to cover both MCP task creation paths.

## Validation
- `npm run build:dev`
- `npm -w apps/backend test -- tasks.mcp.gateway.spec.ts --runInBand`
- `npm run dev:3` started successfully on `http://localhost:2010` before bounded timeout stopped it.

## Notes
- `npm run dev:1` and `npm run dev:2` reached app initialization but their configured backend ports were already in use.
- No known technical debt added.