### PR TITLE
Add Gemini 2.5 Pro defaults

### DIFF
--- a/apps/backend/src/agents/agent-template.catalog.ts
+++ b/apps/backend/src/agents/agent-template.catalog.ts
@@ -8,7 +8,7 @@ import {
   ANTHROPIC_CLAUDE,
   CODEX,
   COPILOT_CLAUDE,
-  GEMINI_FLASH,
+  GEMINI_PRO,
   GPT_5_4,
 } from 'src/app-init/models/models';
 import { AgentType } from './enums';
@@ -100,9 +100,9 @@ export const AGENT_TEMPLATE_HARNESSES: AgentTemplateHarnessDto[] = [
     modelOptions: [
       defaultModelOption,
       modelOption({
-        label: 'Gemini 2.5 Flash',
-        providerId: GEMINI_FLASH.providerId,
-        modelId: GEMINI_FLASH.modelId,
+        label: 'Gemini 2.5 Pro',
+        providerId: GEMINI_PRO.providerId,
+        modelId: GEMINI_PRO.modelId,
       }),
     ],
   },
@@ -172,7 +172,7 @@ export const AGENT_TEMPLATES: AgentTemplateDto[] = [
     label: 'General helper',
     description: 'Handles general tasks and asks for clarification when needed.',
     type: AgentType.ADK,
-    modelId: GEMINI_FLASH.modelId,
+    modelId: GEMINI_PRO.modelId,
     agentDescription: 'General helper for task execution.',
     systemPrompt: ASSISTANT_PROMPT,
     statusTriggers: [TaskStatus.NOT_STARTED],

--- a/apps/backend/src/app-init/agent/gemini-assistant.agent.ts
+++ b/apps/backend/src/app-init/agent/gemini-assistant.agent.ts
@@ -3,15 +3,15 @@ import { getAgentAvatarUrlById } from 'src/agents/agent-avatar.library';
 import { AgentType } from 'src/agents/enums';
 import { TaskStatus } from 'src/tasks/enums';
 import { ASSISTANT_PROMPT } from '../prompts/prompts';
-import { GEMINI_FLASH } from '../models/models';
+import { GEMINI_PRO } from '../models/models';
 
 export const createGeminiAssistant: CreateAgentInput = {
   slug: 'gemini-assistant',
   name: 'Gemini Assistant',
   type: AgentType.ADK,
-  modelId: GEMINI_FLASH.modelId,
+  modelId: GEMINI_PRO.modelId,
   avatarUrl: getAgentAvatarUrlById('gemini'),
-  description: 'Gemini 2.5 Flash with an assistant persona, running on a ADK',
+  description: 'Gemini 2.5 Pro with an assistant persona, running on a ADK',
   systemPrompt: ASSISTANT_PROMPT,
   statusTriggers: [TaskStatus.NOT_STARTED],
   allowedTools: [],

--- a/apps/backend/src/app-init/app-init.runner.ts
+++ b/apps/backend/src/app-init/app-init.runner.ts
@@ -188,7 +188,15 @@ export class AppInitRunner implements OnApplicationBootstrap {
       this.logger.error('Error ensuring codex-dev Agent exists');
     }
     try {
-      await this.ensureGeminiAssistantExists();
+      await this.ensureAgentExists(createGeminiAssistant, (agent) => {
+        if (agent.modelId !== AppInitRunner.GEMINI_FLASH_MODEL_ID) {
+          return agent;
+        }
+
+        return this.agentsService.patchAgent(agent.actorId, {
+          modelId: createGeminiAssistant.modelId,
+        });
+      });
     } catch (error) {
       this.logger.error('Error ensuring gemini-assistant Agent exists');
     }
@@ -250,46 +258,39 @@ export class AppInitRunner implements OnApplicationBootstrap {
 
   async ensureAgentExists(
     agentConfig: CreateAgentInput,
+    patchSeed?: (agent: AgentResult) => Promise<AgentResult> | AgentResult,
   ): Promise<AgentResult | null> {
     let agent: AgentResult | null = null;
     try {
-      agent = await this.agentsService.createAgent(agentConfig);
+      agent = await this.agentsService.getAgentBySlug({
+        slug: agentConfig.slug,
+      });
     } catch (error) {
-      if (error instanceof AgentSlugConflictError) {
-        agent = await this.agentsService.getAgentBySlug({
-          slug: agentConfig.slug,
-        });
-        // TODO: rework the update method
-        // agent = await this.agentsService.updateAgent(agent.id, createClaudeDev);
-      } else {
+      if (!(error instanceof AgentNotFoundError)) {
         throw error;
       }
     }
-    return agent;
-  }
 
-  async ensureGeminiAssistantExists(): Promise<AgentResult | null> {
-    let agent: AgentResult | null = null;
-
-    try {
-      agent = await this.agentsService.getAgentBySlug({
-        slug: createGeminiAssistant.slug,
-      });
-    } catch (error) {
-      if (error instanceof AgentNotFoundError) {
-        return this.ensureAgentExists(createGeminiAssistant);
+    if (!agent) {
+      try {
+        agent = await this.agentsService.createAgent(agentConfig);
+      } catch (error) {
+        if (error instanceof AgentSlugConflictError) {
+          agent = await this.agentsService.getAgentBySlug({
+            slug: agentConfig.slug,
+          });
+          // TODO: rework the update method
+          // agent = await this.agentsService.updateAgent(agent.id, createClaudeDev);
+        } else {
+          throw error;
+        }
       }
-
-      throw error;
     }
 
-    if (agent?.modelId !== AppInitRunner.GEMINI_FLASH_MODEL_ID) {
-      return agent;
+    if (agent && patchSeed) {
+      agent = await patchSeed(agent);
     }
-
-    return this.agentsService.patchAgent(agent.actorId, {
-      modelId: createGeminiAssistant.modelId,
-    });
+    return agent;
   }
 
   async ensureMcpServerExists(

--- a/apps/backend/src/app-init/app-init.runner.ts
+++ b/apps/backend/src/app-init/app-init.runner.ts
@@ -18,7 +18,10 @@ import {
   AgentResult,
   CreateAgentInput,
 } from 'src/agents/dto/service/agents.service.types';
-import { AgentSlugConflictError } from 'src/agents/errors/agents.errors';
+import {
+  AgentNotFoundError,
+  AgentSlugConflictError,
+} from 'src/agents/errors/agents.errors';
 import { createContext, createContextScopes } from './mcp/context.mcp';
 import { getConfig } from 'src/config/env.config';
 import { devUser, devUserRole } from './user/dev.user';
@@ -49,6 +52,7 @@ import {
 
 @Injectable()
 export class AppInitRunner implements OnApplicationBootstrap {
+  private static readonly GEMINI_FLASH_MODEL_ID = 'gemini-2.5-flash';
   private logger = new Logger(AppInitRunner.name);
 
   constructor(
@@ -184,7 +188,7 @@ export class AppInitRunner implements OnApplicationBootstrap {
       this.logger.error('Error ensuring codex-dev Agent exists');
     }
     try {
-      await this.ensureAgentExists(createGeminiAssistant);
+      await this.ensureGeminiAssistantExists();
     } catch (error) {
       this.logger.error('Error ensuring gemini-assistant Agent exists');
     }
@@ -262,6 +266,30 @@ export class AppInitRunner implements OnApplicationBootstrap {
       }
     }
     return agent;
+  }
+
+  async ensureGeminiAssistantExists(): Promise<AgentResult | null> {
+    let agent: AgentResult | null = null;
+
+    try {
+      agent = await this.agentsService.getAgentBySlug({
+        slug: createGeminiAssistant.slug,
+      });
+    } catch (error) {
+      if (error instanceof AgentNotFoundError) {
+        return this.ensureAgentExists(createGeminiAssistant);
+      }
+
+      throw error;
+    }
+
+    if (agent?.modelId !== AppInitRunner.GEMINI_FLASH_MODEL_ID) {
+      return agent;
+    }
+
+    return this.agentsService.patchAgent(agent.actorId, {
+      modelId: createGeminiAssistant.modelId,
+    });
   }
 
   async ensureMcpServerExists(

--- a/apps/backend/src/app-init/app-init.runner.ts
+++ b/apps/backend/src/app-init/app-init.runner.ts
@@ -52,7 +52,6 @@ import {
 
 @Injectable()
 export class AppInitRunner implements OnApplicationBootstrap {
-  private static readonly GEMINI_FLASH_MODEL_ID = 'gemini-2.5-flash';
   private logger = new Logger(AppInitRunner.name);
 
   constructor(
@@ -188,15 +187,7 @@ export class AppInitRunner implements OnApplicationBootstrap {
       this.logger.error('Error ensuring codex-dev Agent exists');
     }
     try {
-      await this.ensureAgentExists(createGeminiAssistant, (agent) => {
-        if (agent.modelId !== AppInitRunner.GEMINI_FLASH_MODEL_ID) {
-          return agent;
-        }
-
-        return this.agentsService.patchAgent(agent.actorId, {
-          modelId: createGeminiAssistant.modelId,
-        });
-      });
+      await this.ensureAgentExists(createGeminiAssistant);
     } catch (error) {
       this.logger.error('Error ensuring gemini-assistant Agent exists');
     }
@@ -258,7 +249,6 @@ export class AppInitRunner implements OnApplicationBootstrap {
 
   async ensureAgentExists(
     agentConfig: CreateAgentInput,
-    patchSeed?: (agent: AgentResult) => Promise<AgentResult> | AgentResult,
   ): Promise<AgentResult | null> {
     let agent: AgentResult | null = null;
     try {
@@ -287,9 +277,6 @@ export class AppInitRunner implements OnApplicationBootstrap {
       }
     }
 
-    if (agent && patchSeed) {
-      agent = await patchSeed(agent);
-    }
     return agent;
   }
 

--- a/apps/backend/src/app-init/models/models.ts
+++ b/apps/backend/src/app-init/models/models.ts
@@ -30,8 +30,8 @@ export const ANTHROPIC_CLAUDE: MODEL_CONFIG = {
   name: 'claude',
 };
 // Good for ADK runner
-export const GEMINI_FLASH: MODEL_CONFIG = {
+export const GEMINI_PRO: MODEL_CONFIG = {
   providerId: '',
-  modelId: 'gemini-2.5-flash',
+  modelId: 'gemini-2.5-pro',
   name: 'gemini',
 };

--- a/apps/backend/src/threads/backends/adk.backend.ts
+++ b/apps/backend/src/threads/backends/adk.backend.ts
@@ -53,7 +53,7 @@ export class AdkBackend implements ChatBackend, OnModuleDestroy {
       });
       const runner = await this.createRunner(
         args.token,
-        args.modelId ?? 'gemini-2.5-flash',
+        args.modelId ?? 'gemini-2.5-pro',
         instructions,
       );
       const stream = runner.runAsync({
@@ -122,7 +122,7 @@ export class AdkBackend implements ChatBackend, OnModuleDestroy {
 
       const agent = new LlmAgent({
         name: 'text_generator',
-        model: modelId ?? 'gemini-2.5-flash',
+        model: modelId ?? 'gemini-2.5-pro',
         description: '',
         instruction: '',
         tools: [],
@@ -181,7 +181,7 @@ export class AdkBackend implements ChatBackend, OnModuleDestroy {
 
     const runner = await this.createRunner(
       args.token,
-      args.modelId ?? 'gemini-2.5-flash',
+      args.modelId ?? 'gemini-2.5-pro',
       args.instructions,
     );
 

--- a/apps/worker-v1/src/runners/ADKAgentRunner.ts
+++ b/apps/worker-v1/src/runners/ADKAgentRunner.ts
@@ -71,7 +71,7 @@ export class ADKAgentRunner extends BaseAgentRunner {
 
   constructor(modelConfig: AgentModelConfig = {}) {
     super();
-    this.modelId = modelConfig.modelId ?? 'gemini-2.5-flash';
+    this.modelId = modelConfig.modelId ?? 'gemini-2.5-pro';
   }
 
   protected async runInternal(

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -77,7 +77,7 @@ export class ADKAgentRunner extends BaseAgentRunner {
 
   constructor(modelConfig: AgentModelConfig = {}) {
     super();
-    this.modelId = modelConfig.modelId ?? 'gemini-2.5-flash';
+    this.modelId = modelConfig.modelId ?? 'gemini-2.5-pro';
   }
 
   override getModel() {

--- a/packages/adk-session-store/examples/basic.ts
+++ b/packages/adk-session-store/examples/basic.ts
@@ -3,7 +3,7 @@ import { SqliteSessionService } from '../src/index.js';
 
 const agent = new LlmAgent({
   name: 'assistant',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-2.5-pro',
   instruction: 'You are helpful.',
 });
 


### PR DESCRIPTION
## Summary
- Adds `gemini-2.5-pro` as the seeded Gemini model config for ADK usage.
- Switches backend ADK thread/text/task fallbacks and worker ADK runner defaults from Gemini 2.5 Flash to Pro.
- Updates Gemini assistant/template labels and the ADK session store example to use Pro.

## Validation
- `npm run build:dev`
- `npm run dev:3` (startup validated; stopped by timeout after backend reported `Application is running on: http://localhost:2010`; expected AppInitRunner prompt-block error appeared)

## Technical Debt
- None identified.