### PR TITLE
Change to PolyForm Small Business License

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,10 @@ Extensive documentation in `/docs/`:
 - `how-to-guides/realtime-events.md` - Real-time domain events, gateway wiring, room topology, and UI sync principles
 - `DEPLOYMENT.md` - Production deployment with Kubernetes and GitOps workflow
 
+## Licensing
+
+This project is licensed under the **PolyForm Small Business License 1.0.0**. Any license-related references added or modified in this codebase — including `package.json` `"license"` fields, README sections, file headers, or documentation — must use `PolyForm-Small-Business-1.0.0`. Do not introduce MIT, ISC, Apache, or any other license identifier.
+
 ## MCP Integration
 
 The project includes MCP (Model Context Protocol) support:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ Extensive documentation in `/docs/`:
 
 ## Licensing
 
-This project is licensed under the **PolyForm Small Business License 1.0.0**. Any license-related references added or modified in this codebase — including `package.json` `"license"` fields, README sections, file headers, or documentation — must use `PolyForm-Small-Business-1.0.0`. Do not introduce MIT, ISC, Apache, or any other license identifier.
+This project is licensed under **PolyForm-Small-Business-1.0.0**. Any license-related references added or modified in this codebase — including `package.json` `"license"` fields, README sections, file headers, or documentation — must use `PolyForm-Small-Business-1.0.0`. Do not introduce MIT, ISC, Apache, or any other license identifier.
 
 ## MCP Integration
 

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,35 @@
+# Commercial Licensing
+
+Taico is source-available.
+
+Taico is free to use under the PolyForm Small Business License 1.0.0 for individuals, personal projects, research, education, and qualifying small businesses.
+
+A separate commercial license is required for organisations that do not qualify under the PolyForm Small Business License 1.0.0.
+
+This includes, but is not limited to:
+
+- large companies
+- banks and financial institutions
+- consultancies
+- government agencies
+- enterprises using Taico internally or commercially
+- organisations deploying Taico for internal teams, customers, or clients
+- organisations creating private forks or derivative internal platforms based on Taico
+
+Commercial licensing may cover:
+
+- internal production use
+- enterprise deployment
+- private forks
+- managed or hosted usage
+- support
+- custom integrations
+- security review
+- commercial redistribution
+- acquisition of the project or related intellectual property
+
+If your organisation wants to use Taico and does not qualify under the PolyForm Small Business License 1.0.0, please contact:
+
+**franciscogalarza@gmail.com**
+
+Use of Taico by larger organisations without a separate commercial license is not permitted.

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -2,9 +2,9 @@
 
 Taico is source-available.
 
-Taico is free to use under the PolyForm Small Business License 1.0.0 for individuals, personal projects, research, education, and qualifying small businesses.
+Taico is free to use under PolyForm-Small-Business-1.0.0 for individuals, personal projects, research, education, and qualifying small businesses.
 
-A separate commercial license is required for organisations that do not qualify under the PolyForm Small Business License 1.0.0.
+A separate commercial license is required for organisations that do not qualify under PolyForm-Small-Business-1.0.0.
 
 This includes, but is not limited to:
 
@@ -28,7 +28,7 @@ Commercial licensing may cover:
 - commercial redistribution
 - acquisition of the project or related intellectual property
 
-If your organisation wants to use Taico and does not qualify under the PolyForm Small Business License 1.0.0, please contact:
+If your organisation wants to use Taico and does not qualify under PolyForm-Small-Business-1.0.0, please contact:
 
 **franciscogalarza@gmail.com**
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,83 @@
-MIT License
+# PolyForm Small Business License 1.0.0
 
-Copyright (c) 2025 Francisco Galarza
+Required Notice: Copyright © 2026 Francisco Galarza
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+<https://polyformproject.org/licenses/small-business/1.0.0>
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+## Acceptance
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.
+
+However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.
+
+Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.
+
+For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## Small Business
+
+Use of the software for the benefit of your company is use for a permitted purpose if your company has fewer than 100 total individuals working as employees and independent contractors, and less than 1,000,000 USD (2019) total revenue in the prior tax year.
+
+Adjust this revenue threshold for inflation according to the United States Bureau of Labor Statistics' consumer price index for all urban consumers, U.S. city average, for all items, not seasonally adjusted, with 1982–1984=100 reference base.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.
+
+These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately.
+
+If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.
+
+Otherwise, all your licenses end immediately.
+
+## No Liability
+
+**As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.**
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Taico
 
-Taico is a task execution platform where humans and AI agents collaborate on work. It is built around tasks, threads, context, tools, and executions.
+Taico is a task execution platform where humans and AI agents collaborate on work.
+
+It is built around tasks, threads, context, tools, and executions. The goal is to make AI-assisted work visible, attributable, reviewable, and easier to coordinate.
 
 ## Core Concepts
 
@@ -10,8 +12,9 @@ Taico is a task execution platform where humans and AI agents collaborate on wor
 - **Threads**: Coordination when work branches into related tasks, with shared thread state reconciled from task updates.
 - **Context**: Addressable text blocks that can be attached and reused.
 - **Tools**: MCP servers agents can call through Taico's auth model.
+- **Actors**: Humans, agents, and workers. Every action in Taico is attributable to an actor.
 
-Every action is attributable to an actor. See [`docs/PRIMITIVES.md`](/Users/franciscogalarza/github/ai-monorepo/docs/PRIMITIVES.md) for the domain model.
+See [`docs/PRIMITIVES.md`](docs/PRIMITIVES.md) for the domain model.
 
 ## Supported Runtimes
 
@@ -24,16 +27,19 @@ Taico supports:
 
 ## Recommended Startup Path
 
-### 1. One-liner launcher
-This will start a Taico server in a local container in your machine.
+### 1. Start the server
+
+This starts a Taico server in a local container on your machine.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/galarzafrancisco/ai-monorepo/refs/heads/main/helpers/start-server.sh | bash
 ```
+
 The server script is meant to be long-lived and restart with your machine.
 
 ### 2. Open the app
-Open [http://localhost:9999](http://localhost:9999), create your first account and follow the onboarding flow.
+
+Open [http://localhost:9999](http://localhost:9999), create your first account, and follow the onboarding flow.
 
 ## Development
 
@@ -44,11 +50,11 @@ npm run dev:[1-5]
 
 ## Guides
 
-- [Getting Started](/Users/franciscogalarza/github/ai-monorepo/docs/GETTING_STARTED.md): recommended user-facing setup and first workflow
-- [Admin Guide](/Users/franciscogalarza/github/ai-monorepo/docs/ADMIN_GUIDE.md): running the server and worker safely
-- [Developer Guide](/Users/franciscogalarza/github/ai-monorepo/docs/DEVELOPER_GUIDE.md): local development and architecture
-- [Worker README](/Users/franciscogalarza/github/ai-monorepo/apps/worker/README.md): worker runtime details
-- [Deployment Guide](/Users/franciscogalarza/github/ai-monorepo/docs/DEPLOYMENT.md): Kubernetes and GitOps deployment
+- [Getting Started](docs/GETTING_STARTED.md): recommended user-facing setup and first workflow
+- [Admin Guide](docs/ADMIN_GUIDE.md): running the server and worker safely
+- [Developer Guide](docs/DEVELOPER_GUIDE.md): local development and architecture
+- [Worker README](apps/worker/README.md): worker runtime details
+- [Deployment Guide](docs/DEPLOYMENT.md): Kubernetes and GitOps deployment
 
 ## Architecture At A Glance
 
@@ -56,10 +62,11 @@ npm run dev:[1-5]
 apps/
 ├── backend/          # NestJS API server
 ├── llm-benchmarker/  # LLM benchmark and evaluation tooling
-├── ui/              # Active React frontend
-├── ui-v1/           # Deprecated frontend, compile-only
+├── ui/               # Active React frontend
+├── ui-v1/            # Deprecated frontend, compile-only
 ├── worker/           # Current worker runtime
 └── worker-v1/        # Legacy worker runtime
+
 packages/
 ├── adk-session-store/  # SQLite-backed Google ADK session store
 ├── client/             # Generated TypeScript API client
@@ -69,4 +76,16 @@ packages/
 └── shared/             # Shared contracts and generated artifacts
 ```
 
-At runtime, the backend owns tasks, threads, auth, and execution lifecycle. Workers connect to it, claim work, and execute agents in isolated workspaces. `ui` is the active product UI, `worker` is the current runtime, and `worker-v1`/`ui-v1` are legacy surfaces kept for compatibility and migration.
+At runtime, the backend owns tasks, threads, auth, and execution lifecycle. Workers connect to the backend, claim work, and execute agents in isolated workspaces.
+
+`ui` is the active product UI, `worker` is the current runtime, and `worker-v1` / `ui-v1` are legacy surfaces kept for compatibility and migration.
+
+## License
+
+Taico is source-available.
+
+Taico is licensed under the [PolyForm Small Business License 1.0.0](LICENSE.md).
+
+It is free to use for individuals, personal projects, research, education, and qualifying small businesses.
+
+Use by larger organisations requires a separate commercial license. See [COMMERCIAL.md](COMMERCIAL.md).

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ At runtime, the backend owns tasks, threads, auth, and execution lifecycle. Work
 
 Taico is source-available.
 
-Taico is licensed under the [PolyForm Small Business License 1.0.0](LICENSE).
+Taico is licensed under [PolyForm-Small-Business-1.0.0](LICENSE).
 
 It is free to use for individuals, personal projects, research, education, and qualifying small businesses.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ At runtime, the backend owns tasks, threads, auth, and execution lifecycle. Work
 
 Taico is source-available.
 
-Taico is licensed under the [PolyForm Small Business License 1.0.0](LICENSE.md).
+Taico is licensed under the [PolyForm Small Business License 1.0.0](LICENSE).
 
 It is free to use for individuals, personal projects, research, education, and qualifying small businesses.
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -2,7 +2,7 @@
   "name": "@taico/taico",
   "version": "0.2.18",
   "private": false,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
   "bin": {

--- a/apps/llm-benchmarker/package.json
+++ b/apps/llm-benchmarker/package.json
@@ -2,7 +2,7 @@
   "name": "llm-benchmarker",
   "version": "0.1.0",
   "private": true,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "bin": {
     "llm-bench": "./dist/index.js"

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -188,4 +188,4 @@ No CSS-in-JS, no UI framework dependencies - just modern CSS and React.
 
 ## License
 
-[Your license here]
+PolyForm Small Business License 1.0.0. See [LICENSE](../../LICENSE) for details.

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -188,4 +188,4 @@ No CSS-in-JS, no UI framework dependencies - just modern CSS and React.
 
 ## License
 
-PolyForm Small Business License 1.0.0. See [LICENSE](../../LICENSE) for details.
+PolyForm-Small-Business-1.0.0. See [LICENSE](../../LICENSE) for details.

--- a/apps/worker-v1/package.json
+++ b/apps/worker-v1/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.18",
   "type": "module",
   "private": false,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.18",
   "type": "module",
   "private": false,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "taico",
       "version": "0.0.0",
-      "license": "ISC",
+      "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -42,7 +42,7 @@
     "apps/backend": {
       "name": "@taico/taico",
       "version": "0.2.18",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",
         "@google/adk": "^0.2.5",
@@ -326,7 +326,7 @@
     },
     "apps/llm-benchmarker": {
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "cli-table3": "^0.6.5",
         "commander": "^12.1.0",
@@ -507,7 +507,7 @@
     "apps/worker": {
       "name": "@taico/worker",
       "version": "0.2.18",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",
         "@github/copilot-sdk": "^0.2.0",
@@ -531,7 +531,7 @@
     "apps/worker-v1": {
       "name": "@taico/worker-v1",
       "version": "0.2.18",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.76",
         "@github/copilot-sdk": "^0.2.0",
@@ -20324,7 +20324,7 @@
     "packages/adk-session-store": {
       "name": "@taico/adk-session-store",
       "version": "0.2.18",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@google/adk": "^0.2.5",
         "sqlite3": "^5.1.7"
@@ -20336,7 +20336,7 @@
     "packages/client": {
       "name": "@taico/client",
       "version": "0.2.18",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "devDependencies": {
         "@redocly/openapi-core": "^1.34.10",
         "openapi-typescript": "^7.10.1",
@@ -20347,7 +20347,7 @@
     "packages/errors": {
       "name": "@taico/errors",
       "version": "0.2.18",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "devDependencies": {
         "typescript": "^5.6.3"
       }
@@ -20355,7 +20355,7 @@
     "packages/events": {
       "name": "@taico/events",
       "version": "0.2.18",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "devDependencies": {
         "typescript": "^5.6.3"
       }
@@ -20363,7 +20363,7 @@
     "packages/openapi-sdkgen": {
       "name": "@taico/openapi-sdkgen",
       "version": "0.2.18",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "bin": {
         "openapi-sdkgen": "dist/cli.js"
       },
@@ -20399,7 +20399,7 @@
     "packages/shared": {
       "name": "@taico/shared",
       "version": "0.2.18",
-      "license": "MIT",
+      "license": "PolyForm-Small-Business-1.0.0",
       "devDependencies": {
         "typescript": "^5.7.3"
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "url": "git+https://github.com/galarzafrancisco/ai-monorepo.git"
   },
   "author": "Francisco Galarza",
-  "license": "ISC",
+  "license": "PolyForm-Small-Business-1.0.0",
   "bugs": {
     "url": "https://github.com/galarzafrancisco/ai-monorepo/issues"
   },

--- a/packages/adk-session-store/package.json
+++ b/packages/adk-session-store/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.18",
   "type": "module",
   "private": false,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.18",
   "type": "module",
   "private": false,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "files": [

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.18",
   "type": "module",
   "private": false,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.18",
   "type": "module",
   "private": false,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/openapi-sdkgen/package.json
+++ b/packages/openapi-sdkgen/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.18",
   "type": "module",
   "private": false,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.18",
   "type": "module",
   "private": false,
-  "license": "MIT",
+  "license": "PolyForm-Small-Business-1.0.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary
- Replace first-party MIT/ISC license references with `PolyForm-Small-Business-1.0.0`.
- Add the PolyForm Small Business license text and commercial licensing notes.
- Fix the README license link and update first-party package-lock license metadata from reviewer feedback on PR 951.

## Validation
- `npm run build:dev`
- `npm run dev:3` started successfully on `http://localhost:2010`; stack 1 and 2 startup attempts reached Nest startup but failed to bind because ports `2003` and `2006` were already in use.

## Technical Debt
- Existing AppInitRunner prompt context block startup error still appears during dev startup, as expected by the task instructions.