### PR TITLE
Fix project selector search font size

### DIFF
--- a/apps/ui/src/features/tasks/TasksLayout.css
+++ b/apps/ui/src/features/tasks/TasksLayout.css
@@ -89,7 +89,7 @@
   background: var(--surface);
   color: var(--text);
   font: inherit;
-  font-size: var(--fs-1);
+  font-size: var(--fs-input-mobile-safe);
   outline: none;
 }
 


### PR DESCRIPTION
## Summary
- Updated the task project selector search input to use the mobile-safe input font token.
- Prevents iOS focus auto-zoom caused by the previous 12px search input font size.

## Validation
- npm run build:dev
- npm run dev:5 (started successfully at http://localhost:2016; dev:1/dev:2 reached startup but their backend ports were already in use)

## Technical Debt
- None.