### PR TITLE
Address authorization server package feedback

### DIFF
--- a/packages/authorization-server/README.md
+++ b/packages/authorization-server/README.md
@@ -5,3 +5,25 @@ Standalone authorization server primitives for Taico-style REST, web, and MCP ap
 The package exposes a transport-neutral core, an Express adapter, MCP resource registration, JWT/JWKS handling, hosted login and consent flows, and a SQLite storage adapter.
 
 Mount the Express adapter at the app root. The adapter owns its configured `basePath` (default `/auth`) so it can expose RFC 8414 pathful issuer discovery at `/.well-known/oauth-authorization-server/auth` while serving OAuth endpoints under `/auth`.
+
+Use `auth.discovery.wellKnownUrl()` when printing or linking issuer metadata. Pathful issuers are easy to reconstruct incorrectly by hand.
+
+Browser clients need CORS enabled explicitly:
+
+```typescript
+const auth = await createAuthorizationServer({
+  issuer: 'http://localhost:3100',
+  storage,
+  identityProvider,
+  cors: { origins: ['http://localhost:5173'], credentials: true },
+});
+```
+
+The OAuth password grant is disabled by default. Hosted login screens can still authenticate with the configured identity provider, but `/token` only advertises and accepts `grant_type=password` when `grants: { password: true }` is configured. MCP resource tokens must include the MCP resource URL as `audience` or `resource` in the token request.
+
+`createPublicClient` creates an OAuth public client, meaning no `client_secret` is issued or expected. Use it for browser, CLI, and MCP clients that use PKCE.
+
+Screen modes are currently:
+
+- `default`: package-rendered HTML for quick starts and demos.
+- `hosted`: host-owned routes can call the adapter helpers while the package still owns the authorization interaction state.

--- a/packages/authorization-server/src/crypto.ts
+++ b/packages/authorization-server/src/crypto.ts
@@ -1,4 +1,4 @@
-import { exportJWK, generateKeyPair, importJWK, jwtVerify, SignJWT, type JWK, type JWTPayload } from 'jose';
+import { decodeJwt, exportJWK, generateKeyPair, importJWK, jwtVerify, SignJWT, type JWK, type JWTPayload } from 'jose';
 
 import { InvalidTokenError, InsufficientScopeError } from './errors.js';
 import type { AuthContext, AuthorizationStorage, IssueTokenInput, IssuedToken, KeyStore, ValidateTokenOptions } from './types.js';
@@ -81,7 +81,21 @@ export async function validateJwt(input: {
       errors.push(error);
     }
   }
+  const expectedAudience = input.options?.audience;
+  if (expectedAudience && errors.length > 0 && !tokenHasAudience(input.token, expectedAudience)) {
+    throw new InvalidTokenError(`Token audience does not match this protected resource. Request the token with audience/resource "${expectedAudience}".`);
+  }
   throw new InvalidTokenError(errors.length > 0 ? 'Token verification failed' : 'No signing keys available');
+}
+
+function tokenHasAudience(token: string, expectedAudience: string): boolean {
+  try {
+    const audience = decodeJwt(token).aud;
+    if (Array.isArray(audience)) return audience.includes(expectedAudience);
+    return audience === expectedAudience;
+  } catch {
+    return true;
+  }
 }
 
 export function normalizeScopes(scopes: Array<string | { id: string; description?: string }> = []): Array<{ id: string; description?: string }> {

--- a/packages/authorization-server/src/express.ts
+++ b/packages/authorization-server/src/express.ts
@@ -53,6 +53,7 @@ export function createExpressAdapter(state: AdapterState): ExpressAuthAdapter {
   const adapter: ExpressAuthAdapter = {
     routes() {
       const router = express.Router();
+      router.use(corsMiddleware(state.options));
       router.use(express.urlencoded({ extended: false }));
       router.use(express.json());
 
@@ -274,6 +275,7 @@ async function token(state: AdapterState, req: Request, res: Response): Promise<
     return;
   }
   if (grantType === 'password') {
+    if (!state.options.grants?.password) throw new AuthorizationServerError('Password grant is disabled', 'unsupported_grant_type', 400);
     const principal = await state.options.identityProvider.authenticatePassword?.({ email: req.body.email ?? req.body.username, username: req.body.username, password: req.body.password });
     if (!principal) throw new AuthorizationServerError('Invalid credentials', 'invalid_grant', 401);
     const token = await state.auth.issueToken({ subject: principal.id, principal, audience: stringBody(req.body.audience) ?? stringBody(req.body.resource), scopes: validateConfiguredScopes(state, asArray(req.body.scope)) });
@@ -337,6 +339,26 @@ function protectedResourceMetadataUrl(state: AdapterState, req: Request, audienc
   const authServerOrigin = new URL(state.authorizationServerIssuer).origin;
   if (resourceUrl.origin === authServerOrigin) return `${resourceUrl.origin}/.well-known/oauth-protected-resource${resourceUrl.pathname}`;
   return `${authServerOrigin}/.well-known/oauth-protected-resource?resource=${encodeURIComponent(resourceUrl.toString())}`;
+}
+
+function corsMiddleware(options: AuthorizationServerOptions): RequestHandler {
+  return (req, res, next) => {
+    const cors = options.cors;
+    if (!cors) return next();
+    const origin = req.header('origin');
+    const config = cors === true ? {} : cors;
+    const allowedOrigins = config.origins ?? '*';
+    const allowOrigin = allowedOrigins === '*' ? '*' : origin && allowedOrigins.includes(origin) ? origin : undefined;
+    if (allowOrigin) res.setHeader('Access-Control-Allow-Origin', allowOrigin);
+    if (config.credentials) res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Methods', (config.methods ?? ['GET', 'POST', 'OPTIONS']).join(', '));
+    res.setHeader('Access-Control-Allow-Headers', (config.headers ?? ['authorization', 'content-type']).join(', '));
+    if (req.method === 'OPTIONS') {
+      res.status(204).send();
+      return;
+    }
+    next();
+  };
 }
 
 function requestOrigin(req: Request): string {

--- a/packages/authorization-server/src/index.ts
+++ b/packages/authorization-server/src/index.ts
@@ -73,6 +73,12 @@ export async function createAuthorizationServer(options: AuthorizationServerOpti
       return input;
     },
     discovery: {
+      wellKnownUrl(): string {
+        return wellKnownAuthorizationServerMetadataUrl(authorizationServerIssuer);
+      },
+      protectedResourceMetadataUrl(resource: string): string {
+        return protectedResourceMetadataUrl(authorizationServerIssuer, resource);
+      },
       async authorizationServerMetadata(): Promise<AuthorizationServerMetadata> {
         return {
           issuer: authorizationServerIssuer,
@@ -82,7 +88,7 @@ export async function createAuthorizationServer(options: AuthorizationServerOpti
           registration_endpoint: `${authorizationServerIssuer}/clients/register`,
           introspection_endpoint: `${authorizationServerIssuer}/introspect`,
           response_types_supported: ['code'],
-          grant_types_supported: ['authorization_code', 'password'],
+          grant_types_supported: options.grants?.password ? ['authorization_code', 'password'] : ['authorization_code'],
           code_challenge_methods_supported: ['S256'],
           scopes_supported: [...configuredScopes.keys()],
         };
@@ -121,6 +127,18 @@ export function createPublicClient(input: { name?: string; redirectUris: string[
 function normalizeBasePath(path: string): string {
   const prefixed = path.startsWith('/') ? path : `/${path}`;
   return prefixed.endsWith('/') ? prefixed.slice(0, -1) : prefixed;
+}
+
+function wellKnownAuthorizationServerMetadataUrl(issuer: string): string {
+  const url = new URL(issuer);
+  return `${url.origin}/.well-known/oauth-authorization-server${url.pathname}`;
+}
+
+function protectedResourceMetadataUrl(issuer: string, resource: string): string {
+  const resourceUrl = new URL(resource);
+  const authServerOrigin = new URL(issuer).origin;
+  if (resourceUrl.origin === authServerOrigin) return `${resourceUrl.origin}/.well-known/oauth-protected-resource${resourceUrl.pathname}`;
+  return `${authServerOrigin}/.well-known/oauth-protected-resource?resource=${encodeURIComponent(resourceUrl.toString())}`;
 }
 
 function rememberScope(scopes: Map<string, ScopeDefinition>, scope: ScopeDefinition): ScopeDefinition {

--- a/packages/authorization-server/src/types.ts
+++ b/packages/authorization-server/src/types.ts
@@ -214,6 +214,17 @@ export type AuthorizationServerOptions = {
   accessTokens?: { ttlSeconds?: number; issuer?: string };
   refreshTokens?: { ttlSeconds?: number; rotate?: boolean };
   mcp?: { enabled?: boolean; dynamicClientRegistration?: { enabled?: boolean; pruneAfterDays?: number } };
+  grants?: {
+    password?: boolean;
+  };
+  cors?:
+    | boolean
+    | {
+        origins?: '*' | string[];
+        methods?: string[];
+        headers?: string[];
+        credentials?: boolean;
+      };
   screens?: {
     login?: { mode?: 'default' | 'hosted'; path?: string; allowPassword?: boolean; allowExternalProviders?: boolean };
     consent?: { mode?: 'default' | 'hosted'; path?: string; allowSwitchAccount?: boolean; rememberGrants?: boolean };
@@ -228,6 +239,8 @@ export type AuthorizationServer = {
   registerMcpServer(input: McpServerDefinition): Promise<import('./mcp.js').McpServerHandle>;
   registerDownstreamConnection(input: DownstreamConnectionDefinition): Promise<DownstreamConnectionDefinition>;
   discovery: {
+    wellKnownUrl(): string;
+    protectedResourceMetadataUrl(resource: string): string;
     authorizationServerMetadata(): Promise<AuthorizationServerMetadata>;
     protectedResourceMetadata(resource: string): Promise<ProtectedResourceMetadata>;
     jwks(): Promise<JsonWebKeySet>;

--- a/packages/authorization-server/test-app/src/scope-policy.test.ts
+++ b/packages/authorization-server/test-app/src/scope-policy.test.ts
@@ -38,10 +38,12 @@ test('authorization requests cannot escalate beyond configured client scopes', a
     const metadata = await auth.discovery.authorizationServerMetadata();
     assert.equal(metadata.issuer, `${origin}/auth`);
     assert.equal(metadata.authorization_endpoint, `${origin}/auth/authorize`);
-    assert.deepEqual(metadata.grant_types_supported, ['authorization_code', 'password']);
+    assert.deepEqual(metadata.grant_types_supported, ['authorization_code']);
+    assert.equal(auth.discovery.wellKnownUrl(), `${origin}/.well-known/oauth-authorization-server/auth`);
 
     const resourceMetadata = await auth.discovery.protectedResourceMetadata('http://localhost/resource');
     assert.deepEqual(resourceMetadata.authorization_servers, [`${origin}/auth`]);
+    assert.equal(auth.discovery.protectedResourceMetadataUrl(`${origin}/api/tasks/mcp`), `${origin}/.well-known/oauth-protected-resource/api/tasks/mcp`);
 
     const discoveredIssuer = new URL(resourceMetadata.authorization_servers[0]);
     const discoveredMetadataUrl = new URL(`/.well-known/oauth-authorization-server${discoveredIssuer.pathname}`, discoveredIssuer.origin);
@@ -74,6 +76,41 @@ test('authorization requests cannot escalate beyond configured client scopes', a
       bearer_methods_supported: ['header'],
       resource_name: 'Tasks',
     });
+
+    const wrongAudienceToken = await auth.issueToken({ subject: 'user-1', audience: `${origin}/auth`, scopes: ['mcp:use'] });
+    const wrongAudience = await fetch(new URL('/api/tasks/mcp', origin), { headers: { authorization: `Bearer ${wrongAudienceToken.accessToken}` } });
+    assert.equal(wrongAudience.status, 401);
+    assert.match((await wrongAudience.json()).error_description, /audience\/resource/);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});
+
+test('CORS and password grant are explicit opt-ins', async () => {
+  const storage = await sqliteStorage({ file: join(tmpdir(), `taico-auth-cors-${crypto.randomUUID()}.sqlite`) });
+  const app = express();
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const address = server.address();
+  assert(address && typeof address === 'object');
+  const origin = `http://127.0.0.1:${address.port}`;
+  const auth = await createAuthorizationServer({
+    issuer: origin,
+    storage,
+    identityProvider: { async authenticatePassword() { return { id: 'user-1' }; } },
+    scopes: [{ id: 'mcp:use' }],
+    grants: { password: true },
+    cors: { origins: ['https://client.example'], credentials: true },
+  });
+  app.use(auth.express().routes());
+
+  try {
+    const metadata = await auth.discovery.authorizationServerMetadata();
+    assert.deepEqual(metadata.grant_types_supported, ['authorization_code', 'password']);
+    const preflight = await fetch(new URL('/auth/token', origin), { method: 'OPTIONS', headers: { origin: 'https://client.example' } });
+    assert.equal(preflight.status, 204);
+    assert.equal(preflight.headers.get('access-control-allow-origin'), 'https://client.example');
+    assert.equal(preflight.headers.get('access-control-allow-credentials'), 'true');
   } finally {
     await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
   }


### PR DESCRIPTION
## Summary
- Make the OAuth password grant explicit opt-in for the standalone authorization server package and metadata.
- Add package-level CORS configuration for Express routes.
- Expose discovery URL helpers and improve MCP audience mismatch errors.
- Document the package feedback items and cover them in the test app.

## Validation
- npm run build:dev
- timeout 60s env UI_PORT=29131 LEGACY_UI_PORT=29132 BACKEND_PORT=29133 DATABASE_PATH=data/validation-dev.sqlite npm run dev

## Technical Debt
- Refresh tokens and token revocation remain larger follow-up gaps called out in the original feedback.