### PR TITLE
Remove project color from creation wizard

### DIFF
--- a/apps/ui/src/features/home/SettingsProjectCreatePage.tsx
+++ b/apps/ui/src/features/home/SettingsProjectCreatePage.tsx
@@ -14,7 +14,6 @@ export function SettingsProjectCreatePage() {
   const [slug, setSlug] = useState('');
   const [description, setDescription] = useState('');
   const [repoUrl, setRepoUrl] = useState('');
-  const [color, setColor] = useState('#0969da');
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState('');
 
@@ -32,7 +31,6 @@ export function SettingsProjectCreatePage() {
         slug: slug.trim(),
         description: description.trim() || undefined,
         repoUrl: repoUrl.trim() || undefined,
-        color,
       });
 
       navigate('/settings/projects');
@@ -94,20 +92,6 @@ export function SettingsProjectCreatePage() {
                 onChange={(event) => setRepoUrl(event.target.value)}
                 className="login-input"
                 placeholder="https://github.com/username/repo"
-                disabled={isCreating}
-              />
-            </Stack>
-
-            <Stack spacing="2">
-              <label htmlFor="project-color" className="login-label">
-                <Text size="2" weight="medium">Color</Text>
-              </label>
-              <input
-                id="project-color"
-                type="color"
-                value={color}
-                onChange={(event) => setColor(event.target.value)}
-                className="settings-projects__color-input"
                 disabled={isCreating}
               />
             </Stack>

--- a/apps/ui/src/features/home/SettingsProjectsPage.css
+++ b/apps/ui/src/features/home/SettingsProjectsPage.css
@@ -1,18 +1,3 @@
-.settings-projects__color-input {
-  width: 72px;
-  height: 40px;
-  padding: var(--space-1);
-  border: 1px solid var(--border);
-  border-radius: var(--r-2);
-  background: var(--card-bg);
-  cursor: pointer;
-}
-
-.settings-projects__color-input:disabled {
-  cursor: not-allowed;
-  opacity: 0.7;
-}
-
 .settings-projects__success {
   color: var(--success);
 }


### PR DESCRIPTION
## Summary
- Remove the color picker from the settings project creation wizard.
- Stop sending a project color from that form and delete the now-unused input styles.

## Validation
- npm run build:dev
- timeout 60s npm run dev:3

## Technical Debt
- None.