### PR TITLE
Pass Claude model config to SDK query

### DIFF
--- a/apps/worker/src/runners/ClaudeAgentRunner.ts
+++ b/apps/worker/src/runners/ClaudeAgentRunner.ts
@@ -95,6 +95,7 @@ export class ClaudeAgentRunner extends BaseAgentRunner {
             cwd: ctx.cwd,
             persistSession: true,
             settingSources: ['user', 'project', 'local'],
+            ...(this.model ? { model: this.model.modelId } : {}),
             ...(ctx.options ?? {}),
             ...(latestSessionId ? { resume: latestSessionId } : {}),
             mcpServers,


### PR DESCRIPTION
## Summary
- Pass configured Claude model IDs through to the Claude Agent SDK query options.
- Preserve default SDK model behavior when no model is configured.

## Validation
- npm run build:dev
- timeout 75s npm run dev:5

## Notes
- `dev:1` and `dev:2` were occupied (`EADDRINUSE`); `dev:5` started successfully.
- Existing AppInitRunner prompt context block error appeared during startup, as expected by the task checklist.