### PR TITLE
Harden worker auth reconnects

### DIFF
--- a/apps/worker/src/auth/worker-auth.ts
+++ b/apps/worker/src/auth/worker-auth.ts
@@ -64,7 +64,20 @@ export class WorkerAuth {
 
   async getCredentials(): Promise<WorkerCredentials> {
     await this.ensureAuthenticated();
-    return this.ensureFreshCredentials();
+    try {
+      return await this.ensureFreshCredentials();
+    } catch (error) {
+      if (!isAuthFailure(error)) {
+        throw error;
+      }
+
+      console.warn(
+        '[worker] Stored worker credentials were rejected. Re-authorizing.',
+      );
+      this.credentials = null;
+      const bootstrap = await this.ensureAuthenticated();
+      return bootstrap.credentials;
+    }
   }
 
   async getAccessToken(): Promise<string> {
@@ -73,7 +86,21 @@ export class WorkerAuth {
   }
 
   async refreshAccessToken(): Promise<string> {
-    const credentials = await this.ensureFreshCredentials(true);
+    let credentials: WorkerCredentials;
+    try {
+      credentials = await this.ensureFreshCredentials(true);
+    } catch (error) {
+      if (!isAuthFailure(error)) {
+        throw error;
+      }
+
+      console.warn(
+        '[worker] Worker refresh token was rejected. Re-authorizing.',
+      );
+      this.credentials = null;
+      credentials = (await this.ensureAuthenticated()).credentials;
+    }
+
     return credentials.accessToken;
   }
 
@@ -308,6 +335,15 @@ function normalizeBaseUrl(serverUrl: string): string {
 }
 
 function isAuthFailure(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const status = (error as { status?: unknown }).status;
+  if (status === 401 || status === 403) {
+    return true;
+  }
+
   return (
     error instanceof Error &&
     (error.message.startsWith('HTTP 401:') ||

--- a/apps/worker/src/execution-activity-gateway-client.ts
+++ b/apps/worker/src/execution-activity-gateway-client.ts
@@ -13,6 +13,7 @@ import { WORKER_VERSION } from './version.js';
 const DEFAULT_TOKEN_REFRESH_SKEW_MS = 60_000;
 const ACK_TIMEOUT_MS = 5_000;
 const WORKER_HEARTBEAT_INTERVAL_MS = 30_000;
+const RECONNECT_RETRY_DELAY_MS = 5_000;
 
 type ActivityAck = {
   ok: boolean;
@@ -38,6 +39,7 @@ export class ExecutionActivityGatewayClient {
   private started = false;
   private reconnectAttempts = 0;
   private tokenRefreshTimer?: ReturnType<typeof setTimeout>;
+  private reconnectRetryTimer?: ReturnType<typeof setTimeout>;
   private workerHeartbeatTimer?: ReturnType<typeof setInterval>;
   private reconnectPromise: Promise<void> | null = null;
   private resolveInitialConnect?: () => void;
@@ -65,6 +67,7 @@ export class ExecutionActivityGatewayClient {
   async stop(): Promise<void> {
     this.started = false;
     this.clearTokenRefreshTimer();
+    this.clearReconnectRetryTimer();
     this.clearWorkerHeartbeatTimer();
     this.clearInitialConnectHandlers();
 
@@ -173,6 +176,8 @@ export class ExecutionActivityGatewayClient {
       console.log(`[execution-activity] connecting to ${url}`);
     }
 
+    this.clearReconnectRetryTimer();
+
     this.socket = io(url, {
       transports,
       auth: { token: credentials.accessToken, workerVersion: WORKER_VERSION },
@@ -213,7 +218,9 @@ export class ExecutionActivityGatewayClient {
       }
 
       if (reason === 'io server disconnect') {
-        void this.reconnectWithFreshToken();
+        void this.reconnectWithFreshToken().catch((error) => {
+          this.handleReconnectError(error);
+        });
       }
     });
 
@@ -248,7 +255,9 @@ export class ExecutionActivityGatewayClient {
       }
 
       if (isAuthError(err)) {
-        void this.reconnectWithFreshToken(true);
+        void this.reconnectWithFreshToken(true).catch((error) => {
+          this.handleReconnectError(error);
+        });
       }
     });
   }
@@ -270,12 +279,16 @@ export class ExecutionActivityGatewayClient {
 
     const delayMs = expiresAtMs - Date.now() - refreshSkewMs;
     if (delayMs <= 0) {
-      void this.reconnectWithFreshToken(true);
+      void this.reconnectWithFreshToken(true).catch((error) => {
+        this.handleReconnectError(error);
+      });
       return;
     }
 
     this.tokenRefreshTimer = setTimeout(() => {
-      void this.reconnectWithFreshToken(true);
+      void this.reconnectWithFreshToken(true).catch((error) => {
+        this.handleReconnectError(error);
+      });
     }, delayMs);
   }
 
@@ -285,6 +298,14 @@ export class ExecutionActivityGatewayClient {
     }
     clearTimeout(this.tokenRefreshTimer);
     this.tokenRefreshTimer = undefined;
+  }
+
+  private clearReconnectRetryTimer(): void {
+    if (!this.reconnectRetryTimer) {
+      return;
+    }
+    clearTimeout(this.reconnectRetryTimer);
+    this.reconnectRetryTimer = undefined;
   }
 
   private startWorkerHeartbeatTimer(): void {
@@ -334,6 +355,22 @@ export class ExecutionActivityGatewayClient {
     })();
 
     return this.reconnectPromise;
+  }
+
+  private handleReconnectError(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[execution-activity] reconnect failed: ${message}`);
+
+    if (!this.started || this.reconnectRetryTimer) {
+      return;
+    }
+
+    this.reconnectRetryTimer = setTimeout(() => {
+      this.reconnectRetryTimer = undefined;
+      void this.reconnectWithFreshToken().catch((retryError) => {
+        this.handleReconnectError(retryError);
+      });
+    }, RECONNECT_RETRY_DELAY_MS);
   }
 }
 

--- a/apps/worker/src/worker-app.ts
+++ b/apps/worker/src/worker-app.ts
@@ -205,9 +205,13 @@ function isRetryableStartupError(error: unknown): boolean {
     'code' in cause &&
     typeof cause.code === 'string'
   ) {
-    return ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND'].includes(
-      cause.code,
-    );
+    return [
+      'ECONNREFUSED',
+      'ECONNRESET',
+      'ETIMEDOUT',
+      'ENOTFOUND',
+      'UND_ERR_CONNECT_TIMEOUT',
+    ].includes(cause.code);
   }
 
   return false;


### PR DESCRIPTION
## Summary
- Recover from rejected stored worker credentials by re-authorizing instead of crashing.
- Treat v2 client ApiError 401/403 status codes as auth failures.
- Catch background execution gateway refresh/reconnect failures and schedule retries so transient fetch failures do not terminate the worker.
- Include undici connect timeout errors in startup retry classification.

## Validation
- npm run build:dev
- npm run dev:5 (started successfully on http://localhost:2016; terminated after validation timeout)

## Notes
- npm run dev:1 and npm run dev:2 both reached Nest startup but failed because their backend ports were already in use.