### PR TITLE
Add auto-prune task tag behavior

### DIFF
--- a/apps/backend/src/meta/meta.service.spec.ts
+++ b/apps/backend/src/meta/meta.service.spec.ts
@@ -49,6 +49,25 @@ describe('MetaService system tags', () => {
     expect(tagRepository.save).toHaveBeenCalled();
   });
 
+  it('canonicalizes an existing case-variant auto-prune system tag on module init', async () => {
+    const { service, tagRepository } = createService();
+    const tag = {
+      id: 'tag-1',
+      name: 'Auto-Prune',
+      color: '#FF0000',
+    };
+    tagRepository.findOne.mockResolvedValue(tag);
+
+    await service.onModuleInit();
+
+    expect(tagRepository.create).not.toHaveBeenCalled();
+    expect(tagRepository.save).toHaveBeenCalledWith({
+      ...tag,
+      name: AUTO_PRUNE_TAG_NAME,
+      color: '#8E7CC3',
+    });
+  });
+
   it('does not delete the auto-prune system tag directly', async () => {
     const { service, tagRepository } = createService();
     tagRepository.findOne.mockResolvedValue({
@@ -61,11 +80,37 @@ describe('MetaService system tags', () => {
     expect(tagRepository.delete).not.toHaveBeenCalled();
   });
 
+  it('does not delete a case-variant auto-prune system tag directly', async () => {
+    const { service, tagRepository } = createService();
+    tagRepository.findOne.mockResolvedValue({
+      id: 'tag-1',
+      name: 'Auto-Prune',
+    });
+
+    await service.deleteTag('tag-1');
+
+    expect(tagRepository.delete).not.toHaveBeenCalled();
+  });
+
   it('does not delete the auto-prune system tag as an orphan', async () => {
     const { service, tagRepository } = createService();
     tagRepository.findOne.mockResolvedValue({
       id: 'tag-1',
       name: AUTO_PRUNE_TAG_NAME,
+      tasks: [],
+      blocks: [],
+    });
+
+    await service.cleanupOrphanedTag('tag-1');
+
+    expect(tagRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('does not delete a case-variant auto-prune system tag as an orphan', async () => {
+    const { service, tagRepository } = createService();
+    tagRepository.findOne.mockResolvedValue({
+      id: 'tag-1',
+      name: 'Auto-Prune',
       tasks: [],
       blocks: [],
     });

--- a/apps/backend/src/meta/meta.service.spec.ts
+++ b/apps/backend/src/meta/meta.service.spec.ts
@@ -1,0 +1,77 @@
+import { MetaService } from './meta.service';
+import { AUTO_PRUNE_TAG_NAME } from './system-tags';
+
+describe('MetaService system tags', () => {
+  function createService() {
+    const tagRepository = {
+      create: jest.fn((tag) => tag),
+      save: jest.fn(async (tag) => ({
+        id: 'tag-1',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+        ...tag,
+      })),
+      findOne: jest.fn(),
+      delete: jest.fn(async () => ({ affected: 1 })),
+    };
+    const tagUsageRepository = {
+      find: jest.fn(),
+      query: jest.fn(),
+    };
+    const projectRepository = {
+      findOne: jest.fn(),
+      create: jest.fn((project) => project),
+      save: jest.fn(async (project) => project),
+    };
+
+    const service = new MetaService(
+      tagRepository as any,
+      tagUsageRepository as any,
+      projectRepository as any,
+    );
+
+    return {
+      service,
+      tagRepository,
+    };
+  }
+
+  it('creates the auto-prune system tag on module init', async () => {
+    const { service, tagRepository } = createService();
+    tagRepository.findOne.mockResolvedValue(null);
+
+    await service.onModuleInit();
+
+    expect(tagRepository.create).toHaveBeenCalledWith({
+      name: AUTO_PRUNE_TAG_NAME,
+      color: '#8E7CC3',
+    });
+    expect(tagRepository.save).toHaveBeenCalled();
+  });
+
+  it('does not delete the auto-prune system tag directly', async () => {
+    const { service, tagRepository } = createService();
+    tagRepository.findOne.mockResolvedValue({
+      id: 'tag-1',
+      name: AUTO_PRUNE_TAG_NAME,
+    });
+
+    await service.deleteTag('tag-1');
+
+    expect(tagRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('does not delete the auto-prune system tag as an orphan', async () => {
+    const { service, tagRepository } = createService();
+    tagRepository.findOne.mockResolvedValue({
+      id: 'tag-1',
+      name: AUTO_PRUNE_TAG_NAME,
+      tasks: [],
+      blocks: [],
+    });
+
+    await service.cleanupOrphanedTag('tag-1');
+
+    expect(tagRepository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/meta/meta.service.ts
+++ b/apps/backend/src/meta/meta.service.ts
@@ -56,7 +56,15 @@ export class MetaService implements OnModuleInit {
 
   private async ensureSystemTags(): Promise<void> {
     for (const systemTag of SYSTEM_TAGS) {
-      await this.findOrCreateTagEntity(systemTag.name, systemTag.color);
+      const tag = await this.findOrCreateTagEntity(
+        systemTag.name,
+        systemTag.color,
+      );
+      if (tag.name !== systemTag.name || tag.color !== systemTag.color) {
+        tag.name = systemTag.name;
+        tag.color = systemTag.color;
+        await this.tagRepository.save(tag);
+      }
     }
   }
 

--- a/apps/backend/src/meta/meta.service.ts
+++ b/apps/backend/src/meta/meta.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, forwardRef, Inject } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
@@ -8,6 +8,7 @@ import { TagEntity } from './tag.entity';
 import { TagUsageEntity } from './tag-usage.entity';
 import { ProjectEntity } from './project.entity';
 import { CreateTagInput, TagResult, VersionResult } from './dto/service/meta.service.types';
+import { SYSTEM_TAGS, isSystemTagName } from './system-tags';
 
 /**
  * Predefined color palette for tags
@@ -37,7 +38,7 @@ export const TAG_COLOR_PALETTE = [
 ] as const;
 
 @Injectable()
-export class MetaService {
+export class MetaService implements OnModuleInit {
   private readonly logger = new Logger(MetaService.name);
 
   constructor(
@@ -48,6 +49,16 @@ export class MetaService {
     @InjectRepository(ProjectEntity)
     private readonly projectRepository: Repository<ProjectEntity>,
   ) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.ensureSystemTags();
+  }
+
+  private async ensureSystemTags(): Promise<void> {
+    for (const systemTag of SYSTEM_TAGS) {
+      await this.findOrCreateTagEntity(systemTag.name, systemTag.color);
+    }
+  }
 
   /**
    * Returns a random color from the predefined palette
@@ -213,6 +224,25 @@ export class MetaService {
       message: 'Deleting tag',
       tagId,
     });
+
+    const tag = await this.tagRepository.findOne({ where: { id: tagId } });
+
+    if (!tag) {
+      this.logger.warn({
+        message: 'Tag not found for deletion',
+        tagId,
+      });
+      return;
+    }
+
+    if (isSystemTagName(tag.name)) {
+      this.logger.warn({
+        message: 'System tag cannot be deleted',
+        tagId,
+        tagName: tag.name,
+      });
+      return;
+    }
 
     const result = await this.tagRepository.delete(tagId);
 
@@ -386,6 +416,15 @@ export class MetaService {
       this.logger.warn({
         message: 'Tag not found for cleanup check',
         tagId,
+      });
+      return;
+    }
+
+    if (isSystemTagName(tagWithRelations.name)) {
+      this.logger.log({
+        message: 'System tag kept during orphan cleanup',
+        tagId,
+        tagName: tagWithRelations.name,
       });
       return;
     }

--- a/apps/backend/src/meta/system-tags.ts
+++ b/apps/backend/src/meta/system-tags.ts
@@ -1,0 +1,16 @@
+export const SYSTEM_TAGS = [
+  {
+    name: 'auto-prune',
+    color: '#8E7CC3',
+  },
+] as const;
+
+export const AUTO_PRUNE_TAG_NAME = SYSTEM_TAGS[0].name;
+
+const SYSTEM_TAG_NAMES: ReadonlySet<string> = new Set(
+  SYSTEM_TAGS.map((tag) => tag.name),
+);
+
+export function isSystemTagName(name: string): boolean {
+  return SYSTEM_TAG_NAMES.has(name);
+}

--- a/apps/backend/src/meta/system-tags.ts
+++ b/apps/backend/src/meta/system-tags.ts
@@ -7,10 +7,14 @@ export const SYSTEM_TAGS = [
 
 export const AUTO_PRUNE_TAG_NAME = SYSTEM_TAGS[0].name;
 
+function normalizeSystemTagName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
 const SYSTEM_TAG_NAMES: ReadonlySet<string> = new Set(
-  SYSTEM_TAGS.map((tag) => tag.name),
+  SYSTEM_TAGS.map((tag) => normalizeSystemTagName(tag.name)),
 );
 
 export function isSystemTagName(name: string): boolean {
-  return SYSTEM_TAG_NAMES.has(name);
+  return SYSTEM_TAG_NAMES.has(normalizeSystemTagName(name));
 }

--- a/apps/backend/src/tasks/tasks.service.auto-prune.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.auto-prune.spec.ts
@@ -133,10 +133,39 @@ describe('TasksService auto-prune', () => {
     );
   });
 
-  it('keeps an auto-prune tagged task when it is a thread parent', async () => {
-    const { service, taskRepository, eventEmitter, threadsService } = createService({
-      threadsWithParent: [{ id: 'thread-1' }],
+  it('soft-deletes a case-variant auto-prune tagged task after completion', async () => {
+    const { service, taskRepository, threadsService } = createService();
+    const task = createTask({
+      tags: [{ id: 'tag-1', name: 'Auto-Prune' }],
     });
+    const completedTask = createTask({
+      status: TaskStatus.DONE,
+      comments: [{ id: 'comment-1' }],
+      tags: [{ id: 'tag-1', name: 'Auto-Prune' }],
+    });
+
+    taskRepository.findOne
+      .mockResolvedValueOnce(task)
+      .mockResolvedValueOnce(completedTask)
+      .mockResolvedValueOnce(completedTask);
+
+    await service.changeStatus(
+      task.id,
+      { status: TaskStatus.DONE, comment: 'Finished' },
+      actor.id,
+    );
+
+    expect(threadsService.findThreadsByParentTaskId).toHaveBeenCalledWith(
+      task.id,
+    );
+    expect(taskRepository.softRemove).toHaveBeenCalledWith(completedTask);
+  });
+
+  it('keeps an auto-prune tagged task when it is a thread parent', async () => {
+    const { service, taskRepository, eventEmitter, threadsService } =
+      createService({
+        threadsWithParent: [{ id: 'thread-1' }],
+      });
     const task = createTask();
     const completedTask = createTask({
       status: TaskStatus.DONE,

--- a/apps/backend/src/tasks/tasks.service.auto-prune.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.auto-prune.spec.ts
@@ -1,0 +1,170 @@
+jest.mock('@taico/errors', () => ({
+  ErrorCodes: {
+    TASK_NOT_FOUND: 'TASK_NOT_FOUND',
+    TASK_NOT_ASSIGNED: 'TASK_NOT_ASSIGNED',
+    INVALID_STATUS_TRANSITION: 'INVALID_STATUS_TRANSITION',
+    COMMENT_REQUIRED: 'COMMENT_REQUIRED',
+    AGENT_NOT_FOUND: 'AGENT_NOT_FOUND',
+    TASK_IS_THREAD_PARENT: 'TASK_IS_THREAD_PARENT',
+    INPUT_REQUEST_SELF_ASSIGNMENT: 'INPUT_REQUEST_SELF_ASSIGNMENT',
+  },
+}));
+
+jest.mock('../threads/threads.service', () => ({
+  ThreadsService: jest.fn(),
+}));
+
+import { TasksService } from './tasks.service';
+import { TaskStatus } from './enums';
+import {
+  TaskDeletedEvent,
+  TaskStatusChangedEvent,
+} from './events/tasks.events';
+
+describe('TasksService auto-prune', () => {
+  const actor = {
+    id: 'actor-1',
+    type: 'agent',
+    slug: 'agent-1',
+    displayName: 'Agent 1',
+    avatarUrl: null,
+    introduction: null,
+  } as any;
+
+  function createTask(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'task-1',
+      name: 'Task 1',
+      description: 'Description',
+      status: TaskStatus.IN_PROGRESS,
+      assigneeActorId: actor.id,
+      assigneeActor: actor,
+      createdByActorId: actor.id,
+      createdByActor: actor,
+      sessionId: null,
+      comments: [],
+      artefacts: [],
+      inputRequests: [],
+      tags: [{ id: 'tag-1', name: 'auto-prune' }],
+      dependsOn: [],
+      rowVersion: 1,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+      deletedAt: null,
+      ...overrides,
+    } as any;
+  }
+
+  function createService(options: { threadsWithParent?: unknown[] } = {}) {
+    const taskRepository = {
+      findOne: jest.fn(),
+      save: jest.fn(async (task) => task),
+      softRemove: jest.fn(async (task) => ({ ...task, deletedAt: new Date() })),
+    };
+    const commentRepository = {
+      create: jest.fn((comment) => comment),
+      save: jest.fn(async (comment) => comment),
+    };
+    const eventEmitter = {
+      emit: jest.fn(),
+    };
+    const threadsService = {
+      findThreadsByParentTaskId: jest
+        .fn()
+        .mockResolvedValue(options.threadsWithParent ?? []),
+    };
+
+    const service = new TasksService(
+      taskRepository as any,
+      commentRepository as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      eventEmitter as any,
+      {} as any,
+      {} as any,
+      threadsService as any,
+      {} as any,
+    );
+
+    return {
+      service,
+      taskRepository,
+      commentRepository,
+      eventEmitter,
+      threadsService,
+    };
+  }
+
+  it('soft-deletes an auto-prune tagged task after completion', async () => {
+    const { service, taskRepository, eventEmitter, threadsService } =
+      createService();
+    const task = createTask();
+    const completedTask = createTask({
+      status: TaskStatus.DONE,
+      comments: [{ id: 'comment-1' }],
+    });
+
+    taskRepository.findOne
+      .mockResolvedValueOnce(task)
+      .mockResolvedValueOnce(completedTask)
+      .mockResolvedValueOnce(completedTask);
+
+    const result = await service.changeStatus(
+      task.id,
+      { status: TaskStatus.DONE, comment: 'Finished' },
+      actor.id,
+    );
+
+    expect(result.status).toBe(TaskStatus.DONE);
+    expect(threadsService.findThreadsByParentTaskId).toHaveBeenCalledWith(
+      task.id,
+    );
+    expect(taskRepository.softRemove).toHaveBeenCalledWith(completedTask);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      TaskStatusChangedEvent.INTERNAL,
+      expect.any(TaskStatusChangedEvent),
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      TaskDeletedEvent.INTERNAL,
+      expect.any(TaskDeletedEvent),
+    );
+  });
+
+  it('keeps an auto-prune tagged task when it is a thread parent', async () => {
+    const { service, taskRepository, eventEmitter, threadsService } = createService({
+      threadsWithParent: [{ id: 'thread-1' }],
+    });
+    const task = createTask();
+    const completedTask = createTask({
+      status: TaskStatus.DONE,
+      comments: [{ id: 'comment-1' }],
+    });
+
+    taskRepository.findOne
+      .mockResolvedValueOnce(task)
+      .mockResolvedValueOnce(completedTask);
+
+    const result = await service.changeStatus(
+      task.id,
+      { status: TaskStatus.DONE, comment: 'Finished' },
+      actor.id,
+    );
+
+    expect(result.status).toBe(TaskStatus.DONE);
+    expect(threadsService.findThreadsByParentTaskId).toHaveBeenCalledWith(
+      task.id,
+    );
+    expect(taskRepository.softRemove).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      TaskStatusChangedEvent.INTERNAL,
+      expect.any(TaskStatusChangedEvent),
+    );
+    expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+      TaskDeletedEvent.INTERNAL,
+      expect.any(TaskDeletedEvent),
+    );
+  });
+});

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -49,6 +49,7 @@ import {
   InputRequestAnsweredEvent,
 } from './events/tasks.events';
 import { MetaService } from '../meta/meta.service';
+import { AUTO_PRUNE_TAG_NAME } from '../meta/system-tags';
 import { TagEntity } from '../meta/tag.entity';
 import { ActorService } from 'src/identity-provider/actor.service';
 import { SearchService } from '../search/search.service';
@@ -56,8 +57,6 @@ import { AgentRunsService } from '../agent-runs/agent-runs.service';
 import { ThreadsService } from '../threads/threads.service';
 import { ParentTaskThreadAlreadyExistsError } from '../threads/errors/threads.errors';
 import { ActiveExecutionContextResolverService } from '../executions/active/active-execution-context-resolver.service';
-
-const AUTO_PRUNE_TAG_NAME = 'auto-prune';
 
 @Injectable()
 export class TasksService {

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -49,7 +49,7 @@ import {
   InputRequestAnsweredEvent,
 } from './events/tasks.events';
 import { MetaService } from '../meta/meta.service';
-import { AUTO_PRUNE_TAG_NAME } from '../meta/system-tags';
+import { isSystemTagName } from '../meta/system-tags';
 import { TagEntity } from '../meta/tag.entity';
 import { ActorService } from 'src/identity-provider/actor.service';
 import { SearchService } from '../search/search.service';
@@ -824,8 +824,8 @@ export class TasksService {
 
   private shouldAutoPrune(task: TaskEntity): boolean {
     return (
-      task.status === TaskStatus.DONE
-      && (task.tags || []).some((tag) => tag.name === AUTO_PRUNE_TAG_NAME)
+      task.status === TaskStatus.DONE &&
+      (task.tags || []).some((tag) => isSystemTagName(tag.name))
     );
   }
 

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -57,6 +57,8 @@ import { ThreadsService } from '../threads/threads.service';
 import { ParentTaskThreadAlreadyExistsError } from '../threads/errors/threads.errors';
 import { ActiveExecutionContextResolverService } from '../executions/active/active-execution-context-resolver.service';
 
+const AUTO_PRUNE_TAG_NAME = 'auto-prune';
+
 @Injectable()
 export class TasksService {
   private readonly logger = new Logger(TasksService.name);
@@ -813,7 +815,53 @@ export class TasksService {
       TaskStatusChangedEvent.INTERNAL,
       new TaskStatusChangedEvent({ id: actorId }, taskWithRelations),
     );
+
+    if (this.shouldAutoPrune(taskWithRelations)) {
+      await this.autoPruneCompletedTask(taskWithRelations.id, actorId);
+    }
+
     return this.mapTaskToResult(taskWithRelations);
+  }
+
+  private shouldAutoPrune(task: TaskEntity): boolean {
+    return (
+      task.status === TaskStatus.DONE
+      && (task.tags || []).some((tag) => tag.name === AUTO_PRUNE_TAG_NAME)
+    );
+  }
+
+  private async autoPruneCompletedTask(
+    taskId: string,
+    actorId: string,
+  ): Promise<void> {
+    const threadsWithParent = await this.threadsService.findThreadsByParentTaskId(
+      taskId,
+    );
+    if (threadsWithParent.length > 0) {
+      this.logger.log({
+        message: 'Auto-prune skipped because task is a thread parent',
+        taskId,
+        threadCount: threadsWithParent.length,
+      });
+      return;
+    }
+
+    const task = await this.taskRepository.findOne({ where: { id: taskId } });
+    if (!task) {
+      return;
+    }
+
+    await this.taskRepository.softRemove(task);
+
+    this.logger.log({
+      message: 'Task auto-pruned after completion',
+      taskId,
+    });
+
+    this.eventEmitter.emit(
+      TaskDeletedEvent.INTERNAL,
+      new TaskDeletedEvent({ id: actorId }, taskId),
+    );
   }
 
   async addTagToTask(


### PR DESCRIPTION
## Summary
- Add auto-prune task tag behavior when a task transitions to DONE
- Soft-delete auto-pruned tasks and emit the existing task deleted event
- Preserve thread-parent protection by skipping auto-prune when the task owns a thread
- Define auto-prune as a meta-owned protected system tag, seed it on startup, and prevent direct delete or orphan cleanup from removing it
- Add focused service tests for prune behavior, thread-parent skip behavior, system-tag seeding, and system-tag protection paths

## Validation
- npm -w apps/backend run test -- --runInBand meta.service.spec.ts tasks.service.auto-prune.spec.ts
- npm run build:dev
- timeout 35s npm run dev:1 reached backend startup but port 2003 was already in use
- timeout 35s npm run dev:2 reached successful backend startup on http://localhost:2006; expected AppInitRunner prompt-context error appeared

## Technical debt
- None identified