### PR TITLE
Add Dockerized worker runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ npm-debug.log
 dist
 build
 apps/backend/dist
+apps/worker/dist
 apps/ui2/dist
 apps/ui/dist
 packages/adk-session-store/dist

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,73 @@
+# Build stage
+FROM node:24-bookworm-slim AS builder
+
+WORKDIR /workdir
+
+COPY package*.json ./
+COPY apps/backend/package*.json ./apps/backend/
+COPY apps/worker/package*.json ./apps/worker/
+COPY apps/ui-v1/package*.json ./apps/ui-v1/
+COPY apps/ui/package*.json ./apps/ui/
+COPY packages/shared/package*.json ./packages/shared/
+COPY packages/client/package*.json ./packages/client/
+COPY packages/adk-session-store/package*.json ./packages/adk-session-store/
+COPY packages/errors/package*.json ./packages/errors/
+COPY packages/events/package*.json ./packages/events/
+COPY packages/openapi-sdkgen/package*.json ./packages/openapi-sdkgen/
+
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+COPY . .
+
+RUN --mount=type=cache,target=/workdir/.nx/cache npm run build:prod
+
+# Runtime stage
+FROM node:24-bookworm-slim
+
+WORKDIR /workdir
+
+ENV NODE_ENV=production \
+    TAICO_WORKER_WORKING_DIRECTORY=/home/taico/.taico/workspaces
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    gh \
+    openssh-client \
+    python-is-python3 \
+    python3 \
+    python3-pip \
+  && rm -rf /var/lib/apt/lists/* \
+  && npm install -g opencode-ai@1 @anthropic-ai/claude-code@2 @github/copilot@1 \
+  && groupadd --system --gid 10001 taico \
+  && useradd --system --uid 10001 --gid taico --home-dir /home/taico --create-home --shell /bin/bash taico \
+  && mkdir -p /home/taico/.taico/workspaces /workdir \
+  && chown -R taico:taico /home/taico /workdir
+
+COPY package*.json ./
+COPY apps/backend/package*.json ./apps/backend/
+COPY apps/worker/package*.json ./apps/worker/
+COPY packages/shared/package*.json ./packages/shared/
+COPY packages/client/package*.json ./packages/client/
+COPY packages/adk-session-store/package*.json ./packages/adk-session-store/
+COPY packages/errors/package*.json ./packages/errors/
+COPY packages/events/package*.json ./packages/events/
+
+RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
+
+COPY --from=builder /workdir/apps/worker/dist ./apps/worker/dist
+COPY --from=builder /workdir/packages/client/dist ./packages/client/dist
+COPY --from=builder /workdir/packages/shared/dist ./packages/shared/dist
+COPY --from=builder /workdir/packages/errors/dist ./packages/errors/dist
+COPY --from=builder /workdir/packages/events/dist ./packages/events/dist
+
+COPY docker/worker-entrypoint.sh /usr/local/bin/taico-worker-entrypoint
+RUN chmod +x /usr/local/bin/taico-worker-entrypoint
+
+USER taico
+
+ENTRYPOINT ["taico-worker-entrypoint"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -51,11 +51,14 @@ RUN apt-get update \
 COPY package*.json ./
 COPY apps/backend/package*.json ./apps/backend/
 COPY apps/worker/package*.json ./apps/worker/
+COPY apps/ui-v1/package*.json ./apps/ui-v1/
+COPY apps/ui/package*.json ./apps/ui/
 COPY packages/shared/package*.json ./packages/shared/
 COPY packages/client/package*.json ./packages/client/
 COPY packages/adk-session-store/package*.json ./packages/adk-session-store/
 COPY packages/errors/package*.json ./packages/errors/
 COPY packages/events/package*.json ./packages/events/
+COPY packages/openapi-sdkgen/package*.json ./packages/openapi-sdkgen/
 
 RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -37,6 +37,14 @@ Default container paths:
 
 The helper mounts common credential locations for Taico, gh, git/SSH, GitHub Copilot, OpenCode, and Claude. Review those mounts before running it on a shared machine.
 
+The helper also mounts a dedicated host-owned Docker home at `~/.taico/docker-home` by default. This gives CLIs writable cache and runtime state paths such as `/home/taico/.cache` without mounting your full host home into the container. Override it with `TAICO_DOCKER_HOME` if needed.
+
+Smoke-check the image and helper mount shape with:
+
+```bash
+npm run docker:worker:smoke
+```
+
 ## Recommended Usage
 
 For the smallest trust boundary, run the worker in Docker and mount only the credentials and directories it needs. Running locally via `npx` is still useful while developing the worker or when you need unrestricted access to your host toolchain.

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -12,9 +12,34 @@ npx @taico/worker --serverurl http://localhost:1234
 
 The helper script [`helpers/start-worker.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-worker.sh) wraps this for the common local setup.
 
+## Docker
+
+Build the worker image with:
+
+```bash
+npm run docker:worker:build
+```
+
+Start it with Docker restart supervision:
+
+```bash
+./helpers/start-worker-docker.sh
+```
+
+The container starts the worker with `--no-startup-retry`. If it cannot connect during startup, the process exits and Docker restarts it according to `--restart unless-stopped`.
+
+The image includes Node, Python, build tools, git, gh, OpenSSH, OpenCode, Claude Code, and GitHub Copilot CLIs. Provider and CLI authentication are intentionally not baked into the image; mount the host credential directories you want the worker to use.
+
+Default container paths:
+
+- worker credentials: `/home/taico/.taico/worker-credentials.json`
+- workspaces: `/home/taico/.taico/workspaces`
+
+The helper mounts common credential locations for Taico, gh, git/SSH, GitHub Copilot, OpenCode, and Claude. Review those mounts before running it on a shared machine.
+
 ## Recommended Usage
 
-The recommended way to run the worker is locally via `npx`.
+For the smallest trust boundary, run the worker in Docker and mount only the credentials and directories it needs. Running locally via `npx` is still useful while developing the worker or when you need unrestricted access to your host toolchain.
 
 That lets it use:
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -28,6 +28,7 @@ async function main(): Promise<void> {
   const workingDirectory = resolve(
     readCliOption(args, '--working-directory') ?? DEFAULT_WORKER_WORKSPACES_PATH,
   );
+  const retryStartup = !args.includes('--no-startup-retry');
 
   const version = getAppVersion();
   console.log(`🚀 Starting Taico worker v${version}...`);
@@ -36,15 +37,17 @@ async function main(): Promise<void> {
     serverUrl,
     credentialsPath,
     workingDirectory,
+    retryStartup,
   });
 }
 
 function printUsage(): void {
   console.log(`taico-worker usage:
 
-  taico-worker --serverurl <url> [--credentials-path <path>] [--working-directory <path>]
+  taico-worker --serverurl <url> [--credentials-path <path>] [--working-directory <path>] [--no-startup-retry]
     Start worker mode against an existing Taico server.
     Working directory defaults to ~/.taico/workspaces.
+    --no-startup-retry exits immediately on startup connection failure so a supervisor can restart it.
 `);
 }
 

--- a/apps/worker/src/worker-app.ts
+++ b/apps/worker/src/worker-app.ts
@@ -14,6 +14,7 @@ export type WorkerOptions = {
   serverUrl: string;
   credentialsPath?: string;
   workingDirectory: string;
+  retryStartup?: boolean;
 };
 
 type WorkerBootstrapResult = Awaited<
@@ -33,7 +34,9 @@ export async function startWorkerApp(options: WorkerOptions): Promise<void> {
 
   let bootstrap: WorkerBootstrapResult;
   try {
-    bootstrap = await ensureAuthenticatedWithRetry(auth);
+    bootstrap = options.retryStartup === false
+      ? await auth.ensureAuthenticated()
+      : await ensureAuthenticatedWithRetry(auth);
   } catch (error) {
     if (error instanceof WorkerStartupCanceledError) {
       console.log('[worker] Startup canceled.');

--- a/docker/worker-entrypoint.sh
+++ b/docker/worker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -gt 0 ]]; then
+  exec node /workdir/apps/worker/dist/index.js "$@"
+fi
+
+if [[ -z "${TAICO_SERVER_URL:-}" ]]; then
+  echo "TAICO_SERVER_URL is required" >&2
+  exit 64
+fi
+
+exec node /workdir/apps/worker/dist/index.js \
+  --serverurl "$TAICO_SERVER_URL" \
+  --credentials-path "${TAICO_WORKER_CREDENTIALS_PATH:-/home/taico/.taico/worker-credentials.json}" \
+  --working-directory "${TAICO_WORKER_WORKING_DIRECTORY}" \
+  --no-startup-retry

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -7,9 +7,9 @@ This guide covers operating a Taico instance and the recommended way to run the 
 For a typical self-hosted setup:
 
 - run the Taico server in Docker so it is stable and restarts automatically
-- run the worker directly on your machine via `npx` so it can use the local tools and provider logins you already have
+- run the worker in Docker with explicit credential mounts so it is isolated and restarts automatically
 
-The helper scripts in [`helpers/start-server.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-server.sh) and [`helpers/start-worker.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-worker.sh) reflect that setup.
+The helper scripts in [`helpers/start-server.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-server.sh) and [`helpers/start-worker-docker.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-worker-docker.sh) reflect that setup.
 
 ## Server
 
@@ -37,26 +37,29 @@ Any documentation or workflow that refers to manually creating users with a scri
 
 ## Worker
 
-Start the worker with:
+Build and start the Dockerized worker with:
 
 ```bash
-./helpers/start-worker.sh
+npm run docker:worker:build
+./helpers/start-worker-docker.sh
 ```
 
-The helper uses:
+The helper runs the container with `--restart unless-stopped` and mounts the host credential directories needed for Taico worker OAuth, provider logins, `gh`, git, GitHub Copilot, OpenCode, and Claude. Review those mounts before using it on a shared machine.
+
+For local development, you can still run:
 
 ```bash
 npx @taico/worker --serverurl http://localhost:$PORT
 ```
 
-This is the recommended path because the worker then runs on the same machine that already has your:
+That path gives the worker direct access to your:
 
 - provider authentication
 - developer toolchain
 - shells and CLIs
 - local repository access
 
-That is powerful, but it is also a risk boundary. The worker can launch agents with direct access to what the host machine can access. Only run it where you are comfortable with that.
+That is powerful, but it is also a risk boundary. The Docker path keeps that boundary explicit by requiring credential and workspace mounts.
 
 ## Worker Authentication
 
@@ -103,6 +106,5 @@ Each thread has a parent goal and a shared context block that acts as thread sta
 ## Security Notes
 
 - Running the server in Docker is recommended for durability and isolation.
-- Running the worker locally is recommended for convenience and tool access.
-- Those recommendations intentionally split trust boundaries: the server stays stable, while the worker stays close to your real tools.
-- Review what provider logins, repositories, shell access, and credentials are available on the worker host.
+- Running the worker in Docker is recommended for isolation and automatic restart.
+- Mount only the provider logins, repositories, shell access, and credentials the worker needs.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -7,9 +7,9 @@ This guide walks through the recommended user-facing path for running and using 
 For most people, the best setup is:
 
 1. Run the Taico server in Docker so it is always available and restarts with your machine.
-2. Run the worker locally via `npx` so it can use the tools, CLIs, and provider logins you already have on your machine.
+2. Run the worker in Docker so it restarts automatically and only sees explicitly mounted credentials.
 
-Helper scripts for both live in [`helpers/start-server.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-server.sh) and [`helpers/start-worker.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-worker.sh).
+Helper scripts for both live in [`helpers/start-server.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-server.sh) and [`helpers/start-worker-docker.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-worker-docker.sh).
 
 ## Start The Server
 
@@ -35,19 +35,22 @@ On first startup, Taico guides you through creating the first account inside the
 
 ## Start The Worker
 
-Use the helper script:
+Build the worker image and use the Docker helper script:
 
 ```bash
-./helpers/start-worker.sh
+npm run docker:worker:build
+./helpers/start-worker-docker.sh
 ```
 
-The recommended way to run the worker is via `npx` on your local machine. That gives the worker direct access to:
+The Docker helper mounts common host credential locations for Taico, provider CLIs, `gh`, git, GitHub Copilot, OpenCode, and Claude so restarts do not trigger new auth flows. Review those mounts and remove anything the worker does not need.
+
+For local worker development, you can still run via `npx` on your machine. That gives the worker direct access to:
 
 - your local toolchain
 - your authenticated provider CLIs and SDKs
 - repositories and developer tools already available on your machine
 
-That convenience cuts both ways. The worker is powerful, and the agents it launches can act with the capabilities available on the host. Only run it on a machine you trust for that level of access.
+That convenience cuts both ways. The worker is powerful, and the agents it launches can act with the capabilities available on the host. Prefer Docker unless you intentionally need unrestricted host access.
 
 If you plan to use Google models via ADK, set the Google environment variables in the helper script before starting it.
 
@@ -127,7 +130,7 @@ A practical flow looks like this:
 
 1. Start the server with Docker.
 2. Create your first account in-app.
-3. Start the worker locally with `npx`.
+3. Start the worker in Docker.
 4. Review the pre-populated agents and adjust them as needed.
 5. Create a task and assign it to an agent.
 6. Add a `project:slug` tag if the task should run against a repository.

--- a/helpers/smoke-worker-docker.sh
+++ b/helpers/smoke-worker-docker.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE=${IMAGE:-taico-worker:local}
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p \
+  "$tmpdir/docker-home" \
+  "$tmpdir/docker-home/.cache" \
+  "$tmpdir/docker-home/.config" \
+  "$tmpdir/docker-home/.local/share" \
+  "$tmpdir/docker-home/.local/state" \
+  "$tmpdir/taico" \
+  "$tmpdir/gh" \
+  "$tmpdir/copilot" \
+  "$tmpdir/opencode-config" \
+  "$tmpdir/opencode-share" \
+  "$tmpdir/claude" \
+  "$tmpdir/ssh"
+touch "$tmpdir/gitconfig"
+
+docker run --rm --entrypoint bash \
+  --user "$(id -u):$(id -g)" \
+  -e HOME=/home/taico \
+  -v "$tmpdir/docker-home:/home/taico" \
+  -v "$tmpdir/taico:/home/taico/.taico" \
+  -v "$tmpdir/gh:/home/taico/.config/gh" \
+  -v "$tmpdir/copilot:/home/taico/.config/github-copilot" \
+  -v "$tmpdir/gitconfig:/home/taico/.gitconfig:ro" \
+  -v "$tmpdir/ssh:/home/taico/.ssh:ro" \
+  -v "$tmpdir/opencode-config:/home/taico/.config/opencode" \
+  -v "$tmpdir/opencode-share:/home/taico/.local/share/opencode" \
+  -v "$tmpdir/claude:/home/taico/.claude" \
+  "$IMAGE" \
+  -lc 'set -euo pipefail
+    node --version
+    npm --version
+    python --version
+    git --version
+    gh --version
+    opencode --version
+    claude --version
+    copilot_bin=$(command -v copilot || command -v github-copilot)
+    "$copilot_bin" --version
+    test -w /home/taico
+    test -d /home/taico/.cache
+    test -d /home/taico/.local/state
+  '
+
+echo "Docker worker smoke check passed for $IMAGE"

--- a/helpers/start-worker-docker.sh
+++ b/helpers/start-worker-docker.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE=taico-worker:local
+PORT=1234
+CONTAINER_NAME=taico-worker
+TAICO_HOME=${TAICO_HOME:-$HOME/.taico}
+
+mkdir -p \
+  "$TAICO_HOME" \
+  "$HOME/.config/gh" \
+  "$HOME/.config/github-copilot" \
+  "$HOME/.config/opencode" \
+  "$HOME/.claude" \
+  "$HOME/.local/share/opencode" \
+  "$HOME/.ssh"
+touch "$HOME/.gitconfig"
+
+# Mount host credentials read/write so worker OAuth, provider logins, gh, and git auth survive restarts.
+# Review these mounts before using on a shared machine.
+docker run --name "$CONTAINER_NAME" --restart unless-stopped -d \
+  --user "$(id -u):$(id -g)" \
+  -e TAICO_SERVER_URL="http://host.docker.internal:$PORT" \
+  -e HOME=/home/taico \
+  -e GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT:-}" \
+  -e GOOGLE_CLOUD_LOCATION="${GOOGLE_CLOUD_LOCATION:-}" \
+  -e GOOGLE_GENAI_USE_VERTEXAI="${GOOGLE_GENAI_USE_VERTEXAI:-True}" \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$TAICO_HOME:/home/taico/.taico" \
+  -v "$HOME/.config/gh:/home/taico/.config/gh" \
+  -v "$HOME/.config/github-copilot:/home/taico/.config/github-copilot" \
+  -v "$HOME/.gitconfig:/home/taico/.gitconfig:ro" \
+  -v "$HOME/.ssh:/home/taico/.ssh:ro" \
+  -v "$HOME/.config/opencode:/home/taico/.config/opencode" \
+  -v "$HOME/.local/share/opencode:/home/taico/.local/share/opencode" \
+  -v "$HOME/.claude:/home/taico/.claude" \
+  "$IMAGE"
+
+echo "Worker started in Docker as $CONTAINER_NAME. Follow logs with: docker logs -f $CONTAINER_NAME"

--- a/helpers/start-worker-docker.sh
+++ b/helpers/start-worker-docker.sh
@@ -5,9 +5,15 @@ IMAGE=taico-worker:local
 PORT=1234
 CONTAINER_NAME=taico-worker
 TAICO_HOME=${TAICO_HOME:-$HOME/.taico}
+TAICO_DOCKER_HOME=${TAICO_DOCKER_HOME:-$TAICO_HOME/docker-home}
 
 mkdir -p \
   "$TAICO_HOME" \
+  "$TAICO_DOCKER_HOME" \
+  "$TAICO_DOCKER_HOME/.cache" \
+  "$TAICO_DOCKER_HOME/.config" \
+  "$TAICO_DOCKER_HOME/.local/share" \
+  "$TAICO_DOCKER_HOME/.local/state" \
   "$HOME/.config/gh" \
   "$HOME/.config/github-copilot" \
   "$HOME/.config/opencode" \
@@ -26,6 +32,7 @@ docker run --name "$CONTAINER_NAME" --restart unless-stopped -d \
   -e GOOGLE_CLOUD_LOCATION="${GOOGLE_CLOUD_LOCATION:-}" \
   -e GOOGLE_GENAI_USE_VERTEXAI="${GOOGLE_GENAI_USE_VERTEXAI:-True}" \
   --add-host=host.docker.internal:host-gateway \
+  -v "$TAICO_DOCKER_HOME:/home/taico" \
   -v "$TAICO_HOME:/home/taico/.taico" \
   -v "$HOME/.config/gh:/home/taico/.config/gh" \
   -v "$HOME/.config/github-copilot:/home/taico/.config/github-copilot" \

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "docker:down": "docker-compose down",
     "docker:logs": "docker-compose logs -f",
     "docker:rebuild": "docker-compose down && docker-compose build && docker-compose up -d",
+    "docker:worker:build": "docker build -f Dockerfile.worker -t taico-worker:local .",
     "build:dev": "npm run zero-to-prod",
     "build:packages": "nx run-many -t build -p @taico/shared,@taico/events,@taico/errors,@taico/adk-session-store,@taico/openapi-sdkgen,@taico/authorization-server",
     "build:prod": "nx run-many -t assemble-public,build:prod -p @taico/authorization-server,@taico/taico,@taico/worker",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "docker:logs": "docker-compose logs -f",
     "docker:rebuild": "docker-compose down && docker-compose build && docker-compose up -d",
     "docker:worker:build": "docker build -f Dockerfile.worker -t taico-worker:local .",
+    "docker:worker:smoke": "bash helpers/smoke-worker-docker.sh",
     "build:dev": "npm run zero-to-prod",
     "build:packages": "nx run-many -t build -p @taico/shared,@taico/events,@taico/errors,@taico/adk-session-store,@taico/openapi-sdkgen,@taico/authorization-server",
     "build:prod": "nx run-many -t assemble-public,build:prod -p @taico/authorization-server,@taico/taico,@taico/worker",


### PR DESCRIPTION
## Summary
- add a dedicated Dockerfile for the Taico worker runtime with Node, Python, build tools, git, gh, OpenSSH, OpenCode, Claude Code, and GitHub Copilot CLIs
- add a worker entrypoint and `--no-startup-retry` mode so Docker can restart the worker after startup connection failures
- copy all workspace package manifests into the worker runtime stage so `npm ci --omit=dev` works with npm workspaces
- add a Docker helper script that mounts explicit host credential/workspace locations and runs with the host UID/GID
- update worker/admin/getting-started docs to recommend Dockerized worker operation

## Validation
- `npm run build:dev`
- `timeout 45s npm run dev:1` (backend and both frontends started; expected AppInitRunner errors observed)
- `npm run docker:worker:build`
- `docker run --rm taico-worker:local --help`
- `docker run --rm taico-worker:local` (fails fast when TAICO_SERVER_URL is missing)
- `bash -n helpers/start-worker-docker.sh`
- `bash -n docker/worker-entrypoint.sh`

## Technical debt
- The helper mounts common credential locations, but provider-specific auth paths can vary by CLI version and may need expansion as more harnesses are added.