### PR TITLE
Add project import and export

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -249,6 +249,84 @@
         ]
       }
     },
+    "/api/v1/meta/projects/export": {
+      "get": {
+        "operationId": "ProjectsController_exportProjects",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Projects JSON downloaded successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Export all projects as JSON",
+        "tags": [
+          "Meta - Projects"
+        ]
+      }
+    },
+    "/api/v1/meta/projects/import": {
+      "post": {
+        "operationId": "ProjectsController_importProjects",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "JSON file exported from projects"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Projects imported successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportProjectsResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No JSON file uploaded or invalid file type"
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Import projects from JSON",
+        "tags": [
+          "Meta - Projects"
+        ]
+      }
+    },
     "/api/v1/meta/projects/search": {
       "get": {
         "operationId": "ProjectsController_searchProjects",
@@ -7500,6 +7578,18 @@
           "slug",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "ImportProjectsResponseDto": {
+        "type": "object",
+        "properties": {
+          "importedCount": {
+            "type": "number",
+            "example": 3
+          }
+        },
+        "required": [
+          "importedCount"
         ]
       },
       "PatchProjectDto": {

--- a/apps/backend/src/meta/dto/import-projects-response.dto.ts
+++ b/apps/backend/src/meta/dto/import-projects-response.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ImportProjectsResponseDto {
+  @ApiProperty({ example: 3 })
+  importedCount!: number;
+}

--- a/apps/backend/src/meta/dto/service/projects.service.types.ts
+++ b/apps/backend/src/meta/dto/service/projects.service.types.ts
@@ -26,6 +26,19 @@ export type ProjectResult = {
   updatedAt: Date;
 };
 
+export type ExportedProject = {
+  slug: string;
+  description?: string;
+  repoUrl?: string;
+  color?: string;
+};
+
+export type ProjectsExportPayload = {
+  version: 1;
+  exportedAt: string;
+  projects: ExportedProject[];
+};
+
 export type SearchProjectsInput = {
   query: string;
   limit?: number;

--- a/apps/backend/src/meta/projects.controller.ts
+++ b/apps/backend/src/meta/projects.controller.ts
@@ -11,6 +11,11 @@ import {
   HttpStatus,
   UseGuards,
   NotFoundException,
+  BadRequestException,
+  Res,
+  StreamableFile,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -22,11 +27,17 @@ import {
   ApiNotFoundResponse,
   ApiCookieAuth,
   ApiQuery,
+  ApiProduces,
+  ApiConsumes,
+  ApiBody,
 } from '@nestjs/swagger';
+import type { Response } from 'express';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { ProjectsService } from './projects.service';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { PatchProjectDto } from './dto/patch-project.dto';
 import { ProjectResponseDto } from './dto/project-response.dto';
+import { ImportProjectsResponseDto } from './dto/import-projects-response.dto';
 import { ProjectResult } from './dto/service/projects.service.types';
 import { AccessTokenGuard } from '../auth/guards/guards/access-token.guard';
 import { ScopesGuard } from '../auth/guards/guards/scopes.guard';
@@ -70,6 +81,79 @@ export class ProjectsController {
   async getAllProjects(): Promise<ProjectResponseDto[]> {
     const result = await this.projectsService.getAllProjects();
     return result.map((project) => this.mapProjectResultToResponse(project));
+  }
+
+  @Get('export')
+  @ApiOperation({ summary: 'Export all projects as JSON' })
+  @ApiProduces('application/json')
+  @ApiOkResponse({
+    description: 'Projects JSON downloaded successfully',
+    schema: {
+      type: 'string',
+      format: 'binary',
+    },
+  })
+  async exportProjects(
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<StreamableFile> {
+    const file = await this.projectsService.exportProjectsAsJson();
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const fileName = `projects-${timestamp}.json`;
+
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+    res.setHeader('Content-Length', file.byteLength.toString());
+
+    return new StreamableFile(file);
+  }
+
+  @Post('import')
+  @RequireScopes(MetaScopes.WRITE.id)
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: 'Import projects from JSON' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'JSON file exported from projects',
+        },
+      },
+    },
+  })
+  @ApiCreatedResponse({
+    type: ImportProjectsResponseDto,
+    description: 'Projects imported successfully',
+  })
+  @ApiBadRequestResponse({
+    description: 'No JSON file uploaded or invalid file type',
+  })
+  async importProjects(
+    @UploadedFile()
+    file:
+      | {
+          buffer: Buffer;
+          originalname: string;
+          mimetype: string;
+        }
+      | undefined,
+  ): Promise<ImportProjectsResponseDto> {
+    if (!file) {
+      throw new BadRequestException('A JSON file is required');
+    }
+
+    const lowerName = file.originalname.toLowerCase();
+    const isJsonMime =
+      file.mimetype === 'application/json' || file.mimetype === 'text/json';
+    if (!lowerName.endsWith('.json') && !isJsonMime) {
+      throw new BadRequestException('Only .json files are supported');
+    }
+
+    return this.projectsService.importProjectsFromJson(file.buffer);
   }
 
   @Get('search')

--- a/apps/backend/src/meta/projects.service.spec.ts
+++ b/apps/backend/src/meta/projects.service.spec.ts
@@ -1,0 +1,113 @@
+import { BadRequestException } from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+
+describe('ProjectsService import/export', () => {
+  const createdAt = new Date('2026-01-01T00:00:00Z');
+  const updatedAt = new Date('2026-01-02T00:00:00Z');
+
+  function createService() {
+    const projectRepository = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn((project) => project),
+      save: jest.fn(async (project) => ({
+        id: `${project.slug}-id`,
+        createdAt,
+        updatedAt,
+        ...project,
+      })),
+      softDelete: jest.fn(),
+    };
+    const metaService = {
+      findOrCreateTagEntity: jest.fn(async (name: string, color?: string) => ({
+        id: `${name}-tag-id`,
+        name,
+        color,
+      })),
+      deleteTag: jest.fn(),
+    };
+    const searchService = {
+      search: jest.fn(),
+    };
+
+    const service = new ProjectsService(
+      projectRepository as any,
+      metaService as any,
+      searchService as any,
+    );
+
+    return { service, projectRepository, metaService };
+  }
+
+  it('exports projects as JSON without database identifiers', async () => {
+    const { service, projectRepository } = createService();
+    projectRepository.find.mockResolvedValue([
+      {
+        id: 'project-1',
+        tagId: 'tag-1',
+        tag: { name: 'project:taico', color: '#98D8C8' },
+        slug: 'taico',
+        description: 'AI task management',
+        repoUrl: 'https://github.com/example/taico',
+        createdAt,
+        updatedAt,
+      },
+    ]);
+
+    const file = await service.exportProjectsAsJson();
+    const payload = JSON.parse(file.toString('utf8'));
+
+    expect(payload).toMatchObject({
+      version: 1,
+      projects: [
+        {
+          slug: 'taico',
+          description: 'AI task management',
+          repoUrl: 'https://github.com/example/taico',
+          color: '#98D8C8',
+        },
+      ],
+    });
+    expect(payload.projects[0]).not.toHaveProperty('id');
+    expect(payload.projects[0]).not.toHaveProperty('tagId');
+  });
+
+  it('imports projects using the normal create project flow', async () => {
+    const { service, projectRepository, metaService } = createService();
+    projectRepository.findOne.mockResolvedValue(null);
+    const file = Buffer.from(
+      JSON.stringify({
+        version: 1,
+        projects: [
+          {
+            slug: 'taico',
+            description: 'AI task management',
+            color: '#98D8C8',
+          },
+          { slug: 'worker', repoUrl: 'git@github.com:example/worker.git' },
+        ],
+      }),
+    );
+
+    const result = await service.importProjectsFromJson(file);
+
+    expect(result).toEqual({ importedCount: 2 });
+    expect(metaService.findOrCreateTagEntity).toHaveBeenCalledWith(
+      'project:taico',
+      '#98D8C8',
+    );
+    expect(metaService.findOrCreateTagEntity).toHaveBeenCalledWith(
+      'project:worker',
+      undefined,
+    );
+    expect(projectRepository.save).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects invalid project import JSON', async () => {
+    const { service } = createService();
+
+    await expect(
+      service.importProjectsFromJson(Buffer.from('{')),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/apps/backend/src/meta/projects.service.ts
+++ b/apps/backend/src/meta/projects.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ProjectEntity } from './project.entity';
@@ -9,6 +14,8 @@ import {
   UpdateProjectInput,
   ProjectResult,
   SearchProjectsInput,
+  ExportedProject,
+  ProjectsExportPayload,
 } from './dto/service/projects.service.types';
 
 @Injectable()
@@ -156,6 +163,53 @@ export class ProjectsService {
     return searchResults.map((result) => result.item);
   }
 
+  async exportProjectsAsJson(): Promise<Buffer> {
+    this.logger.log({ message: 'Exporting projects to JSON' });
+
+    const projects = await this.getAllProjects();
+    const payload: ProjectsExportPayload = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      projects: projects.map((project) => ({
+        slug: project.slug,
+        description: project.description,
+        repoUrl: project.repoUrl,
+        color: project.tagColor,
+      })),
+    };
+
+    return Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  }
+
+  async importProjectsFromJson(
+    fileBuffer: Buffer,
+  ): Promise<{ importedCount: number }> {
+    this.logger.log({ message: 'Importing projects from JSON' });
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(fileBuffer.toString('utf8'));
+    } catch {
+      throw new BadRequestException('Invalid projects JSON file');
+    }
+
+    const rawProjects = this.extractProjectsFromImportPayload(parsed);
+    let importedCount = 0;
+
+    for (const rawProject of rawProjects) {
+      const project = this.normalizeImportedProject(rawProject);
+      await this.createProject(project);
+      importedCount += 1;
+    }
+
+    this.logger.log({
+      message: 'Imported projects from JSON',
+      importedCount,
+    });
+
+    return { importedCount };
+  }
+
   /**
    * Update project (partial update)
    */
@@ -240,5 +294,60 @@ export class ProjectsService {
       createdAt: project.createdAt,
       updatedAt: project.updatedAt,
     };
+  }
+
+  private extractProjectsFromImportPayload(payload: unknown): unknown[] {
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+
+    if (
+      payload &&
+      typeof payload === 'object' &&
+      Array.isArray((payload as { projects?: unknown }).projects)
+    ) {
+      return (payload as { projects: unknown[] }).projects;
+    }
+
+    throw new BadRequestException(
+      'Projects JSON must contain a projects array',
+    );
+  }
+
+  private normalizeImportedProject(project: unknown): ExportedProject {
+    if (!project || typeof project !== 'object') {
+      throw new BadRequestException('Each imported project must be an object');
+    }
+
+    const rawProject = project as Record<string, unknown>;
+    if (typeof rawProject.slug !== 'string' || rawProject.slug.trim() === '') {
+      throw new BadRequestException(
+        'Each imported project must include a slug',
+      );
+    }
+
+    return {
+      slug: rawProject.slug.trim(),
+      description: this.optionalString(rawProject.description, 'description'),
+      repoUrl: this.optionalString(rawProject.repoUrl, 'repoUrl'),
+      color: this.optionalString(rawProject.color, 'color'),
+    };
+  }
+
+  private optionalString(
+    value: unknown,
+    fieldName: string,
+  ): string | undefined {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+
+    if (typeof value !== 'string') {
+      throw new BadRequestException(
+        `Imported project ${fieldName} must be a string`,
+      );
+    }
+
+    return value;
   }
 }

--- a/apps/ui/src/features/home/SettingsDataPage.tsx
+++ b/apps/ui/src/features/home/SettingsDataPage.tsx
@@ -1,53 +1,74 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Button, Card, Row, Stack, Text } from '../../ui/primitives';
-import { ErrorText } from '../../ui/primitives/ErrorText';
-import { BFF_BASE_URL } from '../../config/api';
-import { useHomeCtx } from './HomeProvider';
-import './SettingsPage.css';
-import './SettingsDataPage.css';
+import { useEffect, useMemo, useState } from "react";
+import { Button, Card, Row, Stack, Text } from "../../ui/primitives";
+import { ErrorText } from "../../ui/primitives/ErrorText";
+import { BFF_BASE_URL } from "../../config/api";
+import { useHomeCtx } from "./HomeProvider";
+import "./SettingsPage.css";
+import "./SettingsDataPage.css";
 
 type ImportResponse = {
   importedCount?: number;
 };
+
+type DataSet = "blocks" | "projects";
 
 export function SettingsDataPage() {
   const { setSectionTitle } = useHomeCtx();
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [error, setError] = useState('');
-  const [success, setSuccess] = useState('');
+  const [selectedProjectFile, setSelectedProjectFile] = useState<File | null>(
+    null,
+  );
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
 
   useEffect(() => {
-    setSectionTitle('Import / Export');
+    setSectionTitle("Import / Export");
   }, [setSectionTitle]);
 
-  const exportUrl = useMemo(() => `${BFF_BASE_URL}/api/v1/context/blocks/export`, []);
-  const importUrl = useMemo(() => `${BFF_BASE_URL}/api/v1/context/blocks/import`, []);
+  const exportUrl = useMemo(
+    () => `${BFF_BASE_URL}/api/v1/context/blocks/export`,
+    [],
+  );
+  const importUrl = useMemo(
+    () => `${BFF_BASE_URL}/api/v1/context/blocks/import`,
+    [],
+  );
+  const projectsExportUrl = useMemo(
+    () => `${BFF_BASE_URL}/api/v1/meta/projects/export`,
+    [],
+  );
+  const projectsImportUrl = useMemo(
+    () => `${BFF_BASE_URL}/api/v1/meta/projects/import`,
+    [],
+  );
 
-  const handleExportBlocks = async () => {
+  const handleExport = async (url: string, dataSet: DataSet) => {
     setIsExporting(true);
-    setError('');
-    setSuccess('');
+    setError("");
+    setSuccess("");
 
     try {
-      const response = await fetch(exportUrl, {
-        method: 'GET',
-        credentials: 'include',
+      const response = await fetch(url, {
+        method: "GET",
+        credentials: "include",
       });
 
       if (!response.ok) {
-        throw new Error('Failed to export blocks');
+        throw new Error(`Failed to export ${dataSet}`);
       }
 
       const blob = await response.blob();
       const headerFileName = response.headers
-        .get('content-disposition')
+        .get("content-disposition")
         ?.match(/filename="?([^";]+)"?/)?.[1];
-      const fileName = headerFileName || 'context-blocks.zip';
+      const fileName =
+        headerFileName ||
+        (dataSet === "blocks" ? "context-blocks.zip" : "projects.json");
 
       const objectUrl = window.URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
+      const anchor = document.createElement("a");
       anchor.href = objectUrl;
       anchor.download = fileName;
       document.body.appendChild(anchor);
@@ -55,45 +76,64 @@ export function SettingsDataPage() {
       anchor.remove();
       window.URL.revokeObjectURL(objectUrl);
 
-      setSuccess('Blocks export downloaded successfully.');
+      setSuccess(
+        `${dataSet === "blocks" ? "Blocks" : "Projects"} export downloaded successfully.`,
+      );
     } catch {
-      setError('Failed to export blocks. Please try again.');
+      setError(`Failed to export ${dataSet}. Please try again.`);
     } finally {
       setIsExporting(false);
     }
   };
 
-  const handleImportBlocks = async () => {
-    if (!selectedFile) {
-      setError('Please choose a .zip file first.');
-      setSuccess('');
+  const handleImport = async (
+    url: string,
+    file: File | null,
+    dataSet: DataSet,
+  ) => {
+    if (!file) {
+      setError(
+        `Please choose a ${dataSet === "blocks" ? ".zip" : ".json"} file first.`,
+      );
+      setSuccess("");
       return;
     }
 
     setIsImporting(true);
-    setError('');
-    setSuccess('');
+    setError("");
+    setSuccess("");
 
     try {
       const formData = new FormData();
-      formData.append('file', selectedFile);
+      formData.append("file", file);
 
-      const response = await fetch(importUrl, {
-        method: 'POST',
-        credentials: 'include',
+      const response = await fetch(url, {
+        method: "POST",
+        credentials: "include",
         body: formData,
       });
 
-      const payload = (await response.json().catch(() => ({}))) as ImportResponse;
+      const payload = (await response
+        .json()
+        .catch(() => ({}))) as ImportResponse;
       if (!response.ok) {
-        throw new Error('Failed to import blocks');
+        throw new Error(`Failed to import ${dataSet}`);
       }
 
       const importedCount = payload.importedCount ?? 0;
-      setSuccess(`Import complete. ${importedCount} block${importedCount === 1 ? '' : 's'} created.`);
-      setSelectedFile(null);
+      const noun = dataSet === "blocks" ? "block" : "project";
+      setSuccess(
+        `Import complete. ${importedCount} ${noun}${importedCount === 1 ? "" : "s"} imported.`,
+      );
+      if (dataSet === "blocks") {
+        setSelectedFile(null);
+      } else {
+        setSelectedProjectFile(null);
+      }
     } catch {
-      setError('Failed to import blocks. Verify the archive format and try again.');
+      setError(
+        `Failed to import ${dataSet}. Verify the file format and try again.`,
+      );
     } finally {
       setIsImporting(false);
     }
@@ -102,7 +142,7 @@ export function SettingsDataPage() {
   return (
     <Stack spacing="6" className="settings-subpage">
       <Text tone="muted" className="settings-subpage__intro">
-        Import and export workspace data. Blocks are available now; task support can be added in this section later.
+        Import and export workspace data for backup or migration.
       </Text>
 
       {error ? (
@@ -120,17 +160,21 @@ export function SettingsDataPage() {
       <Card padding="5" className="settings-panel-card">
         <Stack spacing="4">
           <Stack spacing="1">
-            <Text size="4" weight="semibold">Export Blocks</Text>
-            <Text tone="muted">Download all context blocks as a nested markdown zip archive.</Text>
+            <Text size="4" weight="semibold">
+              Export Blocks
+            </Text>
+            <Text tone="muted">
+              Download all context blocks as a nested markdown zip archive.
+            </Text>
           </Stack>
           <Row justify="end">
             <Button
               variant="primary"
               size="sm"
-              onClick={handleExportBlocks}
+              onClick={() => handleExport(exportUrl, "blocks")}
               disabled={isExporting}
             >
-              {isExporting ? 'Exporting...' : 'Export Blocks'}
+              {isExporting ? "Exporting..." : "Export Blocks"}
             </Button>
           </Row>
         </Stack>
@@ -139,32 +183,112 @@ export function SettingsDataPage() {
       <Card padding="5" className="settings-panel-card">
         <Stack spacing="4">
           <Stack spacing="1">
-            <Text size="4" weight="semibold">Import Blocks</Text>
-            <Text tone="muted">Upload a blocks archive to create context blocks in this workspace.</Text>
+            <Text size="4" weight="semibold">
+              Import Blocks
+            </Text>
+            <Text tone="muted">
+              Upload a blocks archive to create context blocks in this
+              workspace.
+            </Text>
           </Stack>
 
-          <label htmlFor="blocks-import-file" className="settings-data__file-label">
+          <label
+            htmlFor="blocks-import-file"
+            className="settings-data__file-label"
+          >
             Select archive (.zip)
           </label>
           <input
             id="blocks-import-file"
             type="file"
             accept=".zip,application/zip"
-            onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+            onChange={(event) =>
+              setSelectedFile(event.target.files?.[0] ?? null)
+            }
             className="settings-data__file-input"
           />
           <Text size="1" tone="muted">
-            {selectedFile ? `Selected: ${selectedFile.name}` : 'No file selected'}
+            {selectedFile
+              ? `Selected: ${selectedFile.name}`
+              : "No file selected"}
           </Text>
 
           <Row justify="end">
             <Button
               variant="secondary"
               size="sm"
-              onClick={handleImportBlocks}
+              onClick={() => handleImport(importUrl, selectedFile, "blocks")}
               disabled={isImporting}
             >
-              {isImporting ? 'Importing...' : 'Import Blocks'}
+              {isImporting ? "Importing..." : "Import Blocks"}
+            </Button>
+          </Row>
+        </Stack>
+      </Card>
+
+      <Card padding="5" className="settings-panel-card">
+        <Stack spacing="4">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">
+              Export Projects
+            </Text>
+            <Text tone="muted">Download all projects as a JSON file.</Text>
+          </Stack>
+          <Row justify="end">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => handleExport(projectsExportUrl, "projects")}
+              disabled={isExporting}
+            >
+              {isExporting ? "Exporting..." : "Export Projects"}
+            </Button>
+          </Row>
+        </Stack>
+      </Card>
+
+      <Card padding="5" className="settings-panel-card">
+        <Stack spacing="4">
+          <Stack spacing="1">
+            <Text size="4" weight="semibold">
+              Import Projects
+            </Text>
+            <Text tone="muted">
+              Upload a projects JSON file to create or update projects.
+            </Text>
+          </Stack>
+
+          <label
+            htmlFor="projects-import-file"
+            className="settings-data__file-label"
+          >
+            Select projects file (.json)
+          </label>
+          <input
+            id="projects-import-file"
+            type="file"
+            accept=".json,application/json"
+            onChange={(event) =>
+              setSelectedProjectFile(event.target.files?.[0] ?? null)
+            }
+            className="settings-data__file-input"
+          />
+          <Text size="1" tone="muted">
+            {selectedProjectFile
+              ? `Selected: ${selectedProjectFile.name}`
+              : "No file selected"}
+          </Text>
+
+          <Row justify="end">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() =>
+                handleImport(projectsImportUrl, selectedProjectFile, "projects")
+              }
+              disabled={isImporting}
+            >
+              {isImporting ? "Importing..." : "Import Projects"}
             </Button>
           </Row>
         </Stack>

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -249,6 +249,84 @@
         ]
       }
     },
+    "/api/v1/meta/projects/export": {
+      "get": {
+        "operationId": "ProjectsController_exportProjects",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Projects JSON downloaded successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Export all projects as JSON",
+        "tags": [
+          "Meta - Projects"
+        ]
+      }
+    },
+    "/api/v1/meta/projects/import": {
+      "post": {
+        "operationId": "ProjectsController_importProjects",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "JSON file exported from projects"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Projects imported successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportProjectsResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No JSON file uploaded or invalid file type"
+          }
+        },
+        "security": [
+          {
+            "JWT-Cookie": []
+          }
+        ],
+        "summary": "Import projects from JSON",
+        "tags": [
+          "Meta - Projects"
+        ]
+      }
+    },
     "/api/v1/meta/projects/search": {
       "get": {
         "operationId": "ProjectsController_searchProjects",
@@ -7500,6 +7578,18 @@
           "slug",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "ImportProjectsResponseDto": {
+        "type": "object",
+        "properties": {
+          "importedCount": {
+            "type": "number",
+            "example": 3
+          }
+        },
+        "required": [
+          "importedCount"
         ]
       },
       "PatchProjectDto": {

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -108,6 +108,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/meta/projects/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Export all projects as JSON */
+        get: operations["ProjectsController_exportProjects"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/meta/projects/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Import projects from JSON */
+        post: operations["ProjectsController_importProjects"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/meta/projects/search": {
         parameters: {
             query?: never;
@@ -2316,6 +2350,10 @@ export interface components {
              * @example 2024-01-01T00:00:00.000Z
              */
             updatedAt: string;
+        };
+        ImportProjectsResponseDto: {
+            /** @example 3 */
+            importedCount: number;
         };
         PatchProjectDto: {
             /**
@@ -6376,6 +6414,63 @@ export interface operations {
                 };
             };
             /** @description Invalid input data */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ProjectsController_exportProjects: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Projects JSON downloaded successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+    ProjectsController_importProjects: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description JSON file exported from projects
+                     */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Projects imported successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportProjectsResponseDto"];
+                };
+            };
+            /** @description No JSON file uploaded or invalid file type */
             400: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/client/src/v1/client/index.ts
+++ b/packages/client/src/v1/client/index.ts
@@ -80,6 +80,7 @@ export type { FlowServerDto } from './models/FlowServerDto.js';
 export { GetConsentMetadataResponseDto } from './models/GetConsentMetadataResponseDto.js';
 export { GlobalSearchResultDto } from './models/GlobalSearchResultDto.js';
 export type { ImportBlocksResponseDto } from './models/ImportBlocksResponseDto.js';
+export type { ImportProjectsResponseDto } from './models/ImportProjectsResponseDto.js';
 export type { InputRequestResponseDto } from './models/InputRequestResponseDto.js';
 export { IntrospectTokenRequestDto } from './models/IntrospectTokenRequestDto.js';
 export { IntrospectTokenResponseDto } from './models/IntrospectTokenResponseDto.js';

--- a/packages/client/src/v1/client/models/ImportProjectsResponseDto.ts
+++ b/packages/client/src/v1/client/models/ImportProjectsResponseDto.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ImportProjectsResponseDto = {
+    importedCount: number;
+};
+

--- a/packages/client/src/v1/client/services/MetaProjectsService.ts
+++ b/packages/client/src/v1/client/services/MetaProjectsService.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { CreateProjectDto } from '../models/CreateProjectDto.js';
+import type { ImportProjectsResponseDto } from '../models/ImportProjectsResponseDto.js';
 import type { PatchProjectDto } from '../models/PatchProjectDto.js';
 import type { ProjectResponseDto } from '../models/ProjectResponseDto.js';
 import type { CancelablePromise } from '../core/CancelablePromise.js';
@@ -39,6 +40,42 @@ export class MetaProjectsService {
         return __request(config, {
             method: 'GET',
             url: '/api/v1/meta/projects',
+        });
+    }
+    /**
+     * Export all projects as JSON
+     * @returns binary Projects JSON downloaded successfully
+     * @throws ApiError
+     */
+    public static projectsControllerExportProjects(config: OpenAPIConfig = OpenAPI): CancelablePromise<Blob> {
+        return __request(config, {
+            method: 'GET',
+            url: '/api/v1/meta/projects/export',
+        });
+    }
+    /**
+     * Import projects from JSON
+     * @param formData
+     * @returns ImportProjectsResponseDto Projects imported successfully
+     * @throws ApiError
+     */
+    public static projectsControllerImportProjects(
+        formData: {
+            /**
+             * JSON file exported from projects
+             */
+            file: Blob;
+        },
+        config: OpenAPIConfig = OpenAPI,
+    ): CancelablePromise<ImportProjectsResponseDto> {
+        return __request(config, {
+            method: 'POST',
+            url: '/api/v1/meta/projects/import',
+            formData: formData,
+            mediaType: 'multipart/form-data',
+            errors: {
+                400: `No JSON file uploaded or invalid file type`,
+            },
         });
     }
     /**

--- a/packages/client/src/v2/meta---projects-resource.ts
+++ b/packages/client/src/v2/meta---projects-resource.ts
@@ -1,5 +1,5 @@
 import { BaseClient, ClientConfig } from './base-client.js';
-import type { CreateProjectDto, PatchProjectDto, ProjectResponseDto } from './types.js';
+import type { CreateProjectDto, ImportProjectsResponseDto, PatchProjectDto, ProjectResponseDto } from './types.js';
 
 export class MetaProjectsResource extends BaseClient {
   constructor(config: ClientConfig) {
@@ -14,6 +14,16 @@ export class MetaProjectsResource extends BaseClient {
   /** Get all projects */
   async ProjectsController_getAllProjects(params?: { signal?: AbortSignal }): Promise<ProjectResponseDto[]> {
     return this.request('GET', '/api/v1/meta/projects', { signal: params?.signal });
+  }
+
+  /** Export all projects as JSON */
+  async ProjectsController_exportProjects(params?: { signal?: AbortSignal }): Promise<Blob> {
+    return this.request('GET', '/api/v1/meta/projects/export', { signal: params?.signal });
+  }
+
+  /** Import projects from JSON */
+  async ProjectsController_importProjects(params: { body: FormData; signal?: AbortSignal }): Promise<ImportProjectsResponseDto> {
+    return this.request('POST', '/api/v1/meta/projects/import', { body: params.body, bodyType: 'form-data', signal: params?.signal });
   }
 
   /** Search projects by name and description */

--- a/packages/client/src/v2/types.ts
+++ b/packages/client/src/v2/types.ts
@@ -37,6 +37,10 @@ export interface ProjectResponseDto {
   updatedAt: string;
 }
 
+export interface ImportProjectsResponseDto {
+  importedCount: number;
+}
+
 export interface PatchProjectDto {
   description?: string;
   repoUrl?: string;


### PR DESCRIPTION
## Summary
- Add backend JSON export/import endpoints for projects
- Import projects through the existing project creation path so tags stay consistent
- Add Settings > Import / Export controls for project JSON files
- Regenerate OpenAPI/client artifacts

## Validation
- npm run build:dev
- npm -w apps/backend run test -- projects.service.spec.ts --runInBand
- timeout 30s npm run dev:1

## Technical debt
- None noted.