### PR TITLE
Fix absolute Markdown paths

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -48,5 +48,5 @@ npm -w apps/backend run test:e2e
 
 See the repo-level guides for broader setup and architecture:
 
-- [`docs/PRIMITIVES.md`](/Users/franciscogalarza/github/ai-monorepo/docs/PRIMITIVES.md)
-- [`docs/DEVELOPER_GUIDE.md`](/Users/franciscogalarza/github/ai-monorepo/docs/DEVELOPER_GUIDE.md)
+- [`docs/PRIMITIVES.md`](../../docs/PRIMITIVES.md)
+- [`docs/DEVELOPER_GUIDE.md`](../../docs/DEVELOPER_GUIDE.md)

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -10,7 +10,7 @@ The worker connects to an existing Taico server, claims eligible work, starts ex
 npx @taico/worker --serverurl http://localhost:1234
 ```
 
-The helper script [`helpers/start-worker.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-worker.sh) wraps this for the common local setup.
+The helper script [`helpers/start-worker.sh`](../../helpers/start-worker.sh) wraps this for the common local setup.
 
 ## Recommended Usage
 

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -9,7 +9,7 @@ For a typical self-hosted setup:
 - run the Taico server in Docker so it is stable and restarts automatically
 - run the worker directly on your machine via `npx` so it can use the local tools and provider logins you already have
 
-The helper scripts in [`helpers/start-server.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-server.sh) and [`helpers/start-worker.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-worker.sh) reflect that setup.
+The helper scripts in [`helpers/start-server.sh`](../helpers/start-server.sh) and [`helpers/start-worker.sh`](../helpers/start-worker.sh) reflect that setup.
 
 ## Server
 

--- a/docs/AGENT_RUN_DEPRECATION.md
+++ b/docs/AGENT_RUN_DEPRECATION.md
@@ -10,6 +10,6 @@ Current model:
 - workers start and update executions
 - execution identity is the runtime identity for agent work
 
-If you are working on current code, use the executions surfaces under [`apps/backend/src/executions`](/Users/franciscogalarza/github/ai-monorepo/apps/backend/src/executions) and the current worker under [`apps/worker`](/Users/franciscogalarza/github/ai-monorepo/apps/worker).
+If you are working on current code, use the executions surfaces under [`apps/backend/src/executions`](../apps/backend/src/executions) and the current worker under [`apps/worker`](../apps/worker).
 
 Any references to `agent-runs`, `run-id`, or orchestrator-era behavior should be treated as legacy migration context only.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -100,10 +100,10 @@ Key rules:
 
 See:
 
-- [Controller Responsibilities](/Users/franciscogalarza/github/ai-monorepo/docs/architecture/controller-responsibilities.md)
-- [Service Transport Independence](/Users/franciscogalarza/github/ai-monorepo/docs/architecture/service-transport-independence.md)
-- [DTO Mapping Patterns](/Users/franciscogalarza/github/ai-monorepo/docs/architecture/dto-mapping-patterns.md)
-- [Enum Management](/Users/franciscogalarza/github/ai-monorepo/docs/architecture/enum-management.md)
+- [Controller Responsibilities](architecture/controller-responsibilities.md)
+- [Service Transport Independence](architecture/service-transport-independence.md)
+- [DTO Mapping Patterns](architecture/dto-mapping-patterns.md)
+- [Enum Management](architecture/enum-management.md)
 
 ### Execution Model
 
@@ -137,11 +137,11 @@ The OpenAPI pipeline is:
 
 Socket.io gateways provide real-time behavior across the app. Workers also use realtime channels alongside execution APIs.
 
-For implementation details, see [Realtime Events](/Users/franciscogalarza/github/ai-monorepo/docs/how-to-guides/realtime-events.md).
+For implementation details, see [Realtime Events](how-to-guides/realtime-events.md).
 
 ## UI Development
 
-Read [`apps/ui/CLAUDE.md`](/Users/franciscogalarza/github/ai-monorepo/apps/ui/CLAUDE.md) before making UI changes.
+Read [`apps/ui/CLAUDE.md`](../apps/ui/CLAUDE.md) before making UI changes.
 
 ## Backend Development
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -9,7 +9,7 @@ For most people, the best setup is:
 1. Run the Taico server in Docker so it is always available and restarts with your machine.
 2. Run the worker locally via `npx` so it can use the tools, CLIs, and provider logins you already have on your machine.
 
-Helper scripts for both live in [`helpers/start-server.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-server.sh) and [`helpers/start-worker.sh`](/Users/franciscogalarza/github/ai-monorepo/helpers/start-worker.sh).
+Helper scripts for both live in [`helpers/start-server.sh`](../helpers/start-server.sh) and [`helpers/start-worker.sh`](../helpers/start-worker.sh).
 
 ## Start The Server
 

--- a/docs/best-practices/error.md
+++ b/docs/best-practices/error.md
@@ -114,7 +114,7 @@ All public HTTP APIs must emit errors as
 
 ## 🧭 Error Codes
 
-- Declared centrally in a shared package (`packages/shared/errors`).
+- Declared centrally in a shared package (`packages/errors`).
 - Exported as constants for reuse across services.
 
 ```ts
@@ -162,7 +162,7 @@ Example:
 
 ## 🧱 Schema Sharing
 
-A lightweight shared package (`packages/shared/errors`) contains:
+A lightweight shared package (`packages/errors`) contains:
 
 - `ErrorCodes` (constants)
 - `ProblemDetails` TypeScript type and runtime schema (e.g. Zod)

--- a/docs/how-to-guides/create-an-error.md
+++ b/docs/how-to-guides/create-an-error.md
@@ -8,7 +8,7 @@ This guide turns the Error Best Practices into concrete steps, files, and naming
 
 - **Domain errors live inside each module** (e.g., `product/errors/product.errors.ts`). They’re **HTTP‑agnostic** and include a stable `code` and safe `context`.
 - **Transport mapping happens at the boundary** (controller/global filter) via a service‑local **Error Catalog** → emits **`application/problem+json`** (RFC 7807 shape + our extensions).
-- **Codes + schema are shared** under `packages/shared/errors` so UI can reason on the same `code`, `status`, `retryable`, `requestId`, etc.
+- **Codes + schema are shared** under `packages/errors` so UI can reason on the same `code`, `status`, `retryable`, `requestId`, etc.
 - Modules may **re‑export their subset of codes** for convenience (so engineers rarely open the shared package).
 
 ---
@@ -43,8 +43,8 @@ This guide turns the Error Best Practices into concrete steps, files, and naming
 │  └─ ui/
 │     └─ src/errors/…                        # code -> i18n & UX mapping
 ├─ packages/
-│  └─ shared/
-│     └─ errors/
+│  └─ errors/
+│     └─ src/
 │        ├─ error-codes.ts                   # SOURCE OF TRUTH for codes
 │        ├─ problem-details.type.ts          # TS type + Zod validator
 │        └─ index.ts
@@ -57,7 +57,7 @@ This guide turns the Error Best Practices into concrete steps, files, and naming
 
 ## 2) Shared package (unchanged)
 
-### `packages/shared/errors/error-codes.ts`
+### `packages/errors/src/error-codes.ts`
 ```ts
 export const ErrorCodes = {
   PRODUCT_NOT_FOUND: 'PRODUCT_NOT_FOUND',
@@ -70,7 +70,7 @@ export const ErrorCodes = {
 export type ErrorCode = typeof ErrorCodes[keyof typeof ErrorCodes];
 ```
 
-### `packages/shared/errors/problem-details.type.ts`
+### `packages/errors/src/problem-details.type.ts`
 ```ts
 import { z } from 'zod';
 import type { ErrorCode } from './error-codes';
@@ -113,7 +113,7 @@ Owns **domain error classes** for the Product module, plus a **module‑scoped v
 ```ts
 // apps/backend/src/product/errors/product.errors.ts
 
-import { ErrorCodes } from '../../../../packages/shared/errors/error-codes';
+import { ErrorCodes } from '@taico/errors';
 
 // Optional: module-scoped re-export of just what Product uses.
 export const ProductErrorCodes = {
@@ -165,7 +165,7 @@ async getById(id: string) {
 
 ### `apps/backend/src/errors/http/error-catalog.ts`
 ```ts
-import { ErrorCodes } from '../../../../packages/shared/errors/error-codes';
+import { ErrorCodes } from '@taico/errors';
 
 export const ErrorCatalog: Record<string, {
   status: number; title: string; type: string; retryable?: boolean;
@@ -190,7 +190,7 @@ export const ErrorCatalog: Record<string, {
 
 ### `apps/backend/src/errors/http/problem-details.ts`
 ```ts
-import { ProblemDetails } from '../../../../packages/shared/errors/problem-details.type';
+import { ProblemDetails } from '@taico/errors';
 
 export const toProblem = (p: Partial<ProblemDetails>): ProblemDetails => ({
   type: p.type ?? '/catalog/internal',
@@ -295,7 +295,7 @@ export class ProblemExceptionFilter implements ExceptionFilter {
 
 ## 7) Adding a new error (with module‑local errors)
 
-1) **Register the code once** in `packages/shared/errors/error-codes.ts`.
+1) **Register the code once** in `packages/errors/src/error-codes.ts`.
    ```ts
    export const ErrorCodes = {
      ...ErrorCodes,
@@ -334,7 +334,7 @@ export class ProblemExceptionFilter implements ExceptionFilter {
 - **Module file name:** `apps/backend/src/<module>/errors/<module>.errors.ts`
 - **Domain base class:** `<Module>DomainError` (e.g., `ProductDomainError`).
 - **Class names:** `<Module><What><Error>` (e.g., `ProductNotFoundError`).
-- **Codes:** live centrally in `packages/shared/errors/error-codes.ts`; module files **re‑export** their subset (`ProductErrorCodes`) for clarity.
+- **Codes:** live centrally in `packages/errors/src/error-codes.ts`; module files **re‑export** their subset (`ProductErrorCodes`) for clarity.
 - **Transport files (global):** `apps/backend/src/errors/http/*` (shared for the service).
 - **Never** leak HTTP into domain errors; never leak secrets/PII into `detail/context`.
 

--- a/docs/reviews/domain-error-implementation.md
+++ b/docs/reviews/domain-error-implementation.md
@@ -27,13 +27,13 @@ This document analyzes the domain error implementation patterns across the Tasks
 
 The application uses a three-tiered error architecture:
 
-1. **Shared Error Codes** - Central registry in `packages/shared/errors`
+1. **Shared Error Codes** - Central registry in `packages/errors`
 2. **Module Domain Errors** - Domain-specific error classes per module
 3. **HTTP Mapping Layer** - Transport concerns handled at boundaries
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│         packages/shared/errors/error-codes.ts             │
+│         packages/errors/src/error-codes.ts                │
 │               (Single Source of Truth)                    │
 │                                                           │
 │  ErrorCodes = {                                          │
@@ -977,7 +977,7 @@ export abstract class TasksDomainError extends Error {
 - `/docs/review-guides/error.md` - Error review checklist
 
 ### Implementation Files
-- `/packages/shared/errors/error-codes.ts` - Central error registry
+- `/packages/errors/src/error-codes.ts` - Central error registry
 - `/apps/backend/src/errors/http/error-catalog.ts` - HTTP mapping
 - `/apps/backend/src/http/problem-details.filter.ts` - Global filter
 - `/apps/backend/src/errors/http/domain-to-problem.mapper.ts` - Mapper

--- a/docs/reviews/error-catalog-completeness.md
+++ b/docs/reviews/error-catalog-completeness.md
@@ -96,7 +96,7 @@ All domain errors have corresponding catalog entries. No missing mappings detect
 
 ## Error Code Definitions
 
-All error codes are centrally defined in: `/packages/shared/errors/error-codes.ts`
+All error codes are centrally defined in: `/packages/errors/src/error-codes.ts`
 
 This ensures consistency across the monorepo and prevents code duplication.
 
@@ -133,7 +133,7 @@ The error system follows the established architecture patterns:
 
 ### Code Organization
 ```
-packages/shared/errors/
+packages/errors/src/
   └── error-codes.ts          # Central error code definitions
 
 apps/backend/src/
@@ -153,7 +153,7 @@ The error catalog is complete and well-maintained. All domain errors have proper
 ### Future Additions
 When adding new domain errors:
 
-1. **Define the error code** in `/packages/shared/errors/error-codes.ts`
+1. **Define the error code** in `/packages/errors/src/error-codes.ts`
 2. **Create the domain error class** in the appropriate module's errors file
 3. **Add catalog entry** in `/apps/backend/src/errors/http/error-catalog.ts`
 4. **Update this document** to reflect the new error

--- a/docs/reviews/error-code-centralization.md
+++ b/docs/reviews/error-code-centralization.md
@@ -24,7 +24,7 @@ The codebase demonstrates **exemplary error code centralization** following RFC 
 
 ### 1. Single Source of Truth
 
-**Location**: `/packages/shared/errors/error-codes.ts`
+**Location**: `/packages/errors/src/error-codes.ts`
 
 ```typescript
 export const ErrorCodes = {
@@ -140,7 +140,7 @@ export abstract class [Module]DomainError extends Error {
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                    packages/shared/errors/                   │
+│                    packages/errors/src/                      │
 │                      error-codes.ts                          │
 │                   (SINGLE SOURCE OF TRUTH)                   │
 │                                                              │
@@ -189,7 +189,7 @@ export abstract class [Module]DomainError extends Error {
 ## Error Flow Analysis
 
 ### 1. Error Definition Flow
-1. New error code added to `/packages/shared/errors/error-codes.ts`
+1. New error code added to `/packages/errors/src/error-codes.ts`
 2. HTTP mapping added to `/apps/backend/src/errors/http/error-catalog.ts`
 3. Module re-exports relevant codes in `[module]/errors/[module].errors.ts`
 4. Module defines domain error class using the re-exported code
@@ -224,7 +224,7 @@ ErrorCodes (central)
 - Zero instances of ad-hoc error codes
 
 **Error Code References**:
-- Central definition: 1 file (`packages/shared/errors/error-codes.ts`)
+- Central definition: 1 file (`packages/errors/src/error-codes.ts`)
 - Catalog mapping: 1 file (`apps/backend/src/errors/http/error-catalog.ts`)
 - Module re-exports: 2 files (Tasks, Context)
 - Domain error classes: 2 files (Tasks, Context)
@@ -499,7 +499,7 @@ The error code centralization in this codebase is **exemplary** and represents a
 ### Internal Documentation
 - `/docs/best-practices/error.md`
 - `/docs/how-to-guides/create-an-error.md`
-- `/packages/shared/errors/error-codes.ts`
+- `/packages/errors/src/error-codes.ts`
 - `/apps/backend/src/errors/http/error-catalog.ts`
 
 ### External Standards

--- a/docs/reviews/error-http-coupling.md
+++ b/docs/reviews/error-http-coupling.md
@@ -91,7 +91,7 @@ export abstract class ContextDomainError extends Error {
 
 ### 2. Error Codes (✅ CLEAN)
 
-**File:** `/packages/shared/errors/error-codes.ts`
+**File:** `/packages/errors/src/error-codes.ts`
 
 Error codes are pure string constants with NO HTTP information:
 ```typescript

--- a/docs/reviews/error-management-review.md
+++ b/docs/reviews/error-management-review.md
@@ -32,7 +32,7 @@ Reviewed all backend services for compliance with error handling best practices:
 | Domain errors extend base `DomainError` class | ✅ PASS | All modules define module-scoped base classes: `TasksDomainError`, `ContextDomainError`, `McpRegistryDomainError`, `ClientRegistrationDomainError` |
 | Errors contain `message`, `code`, `context` | ✅ PASS | All domain error classes follow the pattern with required fields |
 | No HTTP references in domain errors | ✅ PASS | Zero HTTP status codes or transport details in any domain error classes |
-| Errors reference centralized error codes | ✅ PASS | All errors reference codes from `packages/shared/errors/error-codes.ts` |
+| Errors reference centralized error codes | ✅ PASS | All errors reference codes from `packages/errors/src/error-codes.ts` |
 
 ### ✅ Transport Layer (RFC 7807)
 
@@ -101,7 +101,7 @@ async getTask(@Param() params: TaskParamsDto): Promise<TaskResponseDto> {
 
 | Requirement | Status | Evidence |
 |------------|--------|----------|
-| Codes defined in shared package | ✅ PASS | `packages/shared/errors/error-codes.ts` |
+| Codes defined in shared package | ✅ PASS | `packages/errors/src/error-codes.ts` |
 | Module-scoped re-exports | ✅ PASS | Each module re-exports only codes it uses |
 | Stable, uppercase snake_case naming | ✅ PASS | All codes follow convention (e.g., `TASK_NOT_FOUND`) |
 | No duplicates | ✅ PASS | All 22 codes unique |
@@ -178,8 +178,8 @@ async getTask(@Param() params: TaskParamsDto): Promise<TaskResponseDto> {
 - `apps/backend/src/authorization-server/client-registration.controller.ts`
 
 ### Infrastructure
-- `packages/shared/errors/error-codes.ts`
-- `packages/shared/errors/index.ts`
+- `packages/errors/src/error-codes.ts`
+- `packages/errors/src/index.ts`
 - `apps/backend/src/errors/http/error-catalog.ts`
 - `apps/backend/src/errors/http/domain-to-problem.mapper.ts`
 - `apps/backend/src/http/problem-details.filter.ts`

--- a/docs/reviews/rfc-7807-compliance.md
+++ b/docs/reviews/rfc-7807-compliance.md
@@ -24,7 +24,7 @@ RFC 7807 defines a standard format for HTTP API error responses with the followi
 ### Core Components
 
 #### 1. Type Definition
-**Location:** `/Users/franciscogalarza/github/ai-monorepo/packages/shared/errors/problem-details.type.ts`
+**Location:** `../../packages/shared/errors/problem-details.type.ts`
 
 ```typescript
 export type ProblemDetails = {
@@ -46,7 +46,7 @@ export type ProblemDetails = {
 - Extension fields properly added without conflicting with spec
 
 #### 2. Problem Details Filter
-**Location:** `/Users/franciscogalarza/github/ai-monorepo/apps/backend/src/http/problem-details.filter.ts`
+**Location:** `../../apps/backend/src/http/problem-details.filter.ts`
 
 **Key Features:**
 - Global exception handler using `@Catch()` decorator
@@ -63,7 +63,7 @@ export type ProblemDetails = {
 - Consistent error response format
 
 #### 3. Problem Builder Function
-**Location:** `/Users/franciscogalarza/github/ai-monorepo/apps/backend/src/errors/http/problem-details.ts`
+**Location:** `../../apps/backend/src/errors/http/problem-details.ts`
 
 ```typescript
 export const toProblem = (p: Partial<ProblemDetails>): ProblemDetails => ({
@@ -287,7 +287,7 @@ The implementation is RFC 7807 compliant with all required fields properly imple
 
 - [RFC 7807: Problem Details for HTTP APIs](https://tools.ietf.org/html/rfc7807)
 - Implementation files:
-  - `/Users/franciscogalarza/github/ai-monorepo/apps/backend/src/http/problem-details.filter.ts`
-  - `/Users/franciscogalarza/github/ai-monorepo/apps/backend/src/errors/http/problem-details.ts`
-  - `/Users/franciscogalarza/github/ai-monorepo/packages/shared/errors/problem-details.type.ts`
-  - `/Users/franciscogalarza/github/ai-monorepo/apps/backend/src/errors/http/domain-to-problem.mapper.ts`
+  - `../../apps/backend/src/http/problem-details.filter.ts`
+  - `../../apps/backend/src/errors/http/problem-details.ts`
+  - `../../packages/shared/errors/problem-details.type.ts`
+  - `../../apps/backend/src/errors/http/domain-to-problem.mapper.ts`

--- a/docs/reviews/rfc-7807-compliance.md
+++ b/docs/reviews/rfc-7807-compliance.md
@@ -24,7 +24,7 @@ RFC 7807 defines a standard format for HTTP API error responses with the followi
 ### Core Components
 
 #### 1. Type Definition
-**Location:** `../../packages/shared/errors/problem-details.type.ts`
+**Location:** `../../packages/errors/src/problem-details.type.ts`
 
 ```typescript
 export type ProblemDetails = {
@@ -289,5 +289,5 @@ The implementation is RFC 7807 compliant with all required fields properly imple
 - Implementation files:
   - `../../apps/backend/src/http/problem-details.filter.ts`
   - `../../apps/backend/src/errors/http/problem-details.ts`
-  - `../../packages/shared/errors/problem-details.type.ts`
+  - `../../packages/errors/src/problem-details.type.ts`
   - `../../apps/backend/src/errors/http/domain-to-problem.mapper.ts`

--- a/docs/reviews/service-review.md
+++ b/docs/reviews/service-review.md
@@ -258,7 +258,7 @@ export class AuthFlowAlreadyCompletedError extends AuthorizationDomainError {
 
 ### Step 2: Add Error Codes to Shared Package
 
-In `packages/shared/errors/error-codes.ts`:
+In `packages/errors/src/error-codes.ts`:
 
 ```typescript
 export const ErrorCodes = {

--- a/docs/worker-migration-status.md
+++ b/docs/worker-migration-status.md
@@ -11,8 +11,8 @@ The migration from the old worker model to the current execution-centric worker 
 
 If you need the current architecture, use:
 
-- [`docs/PRIMITIVES.md`](/Users/franciscogalarza/github/ai-monorepo/docs/PRIMITIVES.md)
-- [`apps/backend/src/executions/ARCHITECTURE.md`](/Users/franciscogalarza/github/ai-monorepo/apps/backend/src/executions/ARCHITECTURE.md)
-- [`apps/worker/README.md`](/Users/franciscogalarza/github/ai-monorepo/apps/worker/README.md)
+- [`docs/PRIMITIVES.md`](PRIMITIVES.md)
+- [`apps/backend/src/executions/ARCHITECTURE.md`](../apps/backend/src/executions/ARCHITECTURE.md)
+- [`apps/worker/README.md`](../apps/worker/README.md)
 
 Do not use this file as an implementation plan for new work.

--- a/docs/worker-server-run-tracking-redesign-plan.md
+++ b/docs/worker-server-run-tracking-redesign-plan.md
@@ -8,7 +8,7 @@ That migration has been superseded by the current architecture:
 
 - executions are the runtime record
 - workers, not an orchestrator, execute agent work
-- current execution work lives under [`apps/backend/src/executions`](/Users/franciscogalarza/github/ai-monorepo/apps/backend/src/executions)
-- current worker implementation lives under [`apps/worker`](/Users/franciscogalarza/github/ai-monorepo/apps/worker)
+- current execution work lives under [`apps/backend/src/executions`](../apps/backend/src/executions)
+- current worker implementation lives under [`apps/worker`](../apps/worker)
 
-For current behavior and terminology, use [`docs/PRIMITIVES.md`](/Users/franciscogalarza/github/ai-monorepo/docs/PRIMITIVES.md) and the `executions` architecture docs instead.
+For current behavior and terminology, use [`docs/PRIMITIVES.md`](PRIMITIVES.md) and the `executions` architecture docs instead.


### PR DESCRIPTION
## Summary
- Replace leaked local absolute Markdown link targets with repo-relative links.
- Replace remaining leaked local path references in Markdown review docs with relative paths.
- Verify no Markdown files still contain the leaked local repo path or absolute local Markdown link targets.

## Validation
- npm run build:dev
- timeout 60s npm run dev:1 (reached Nest application successfully started / Application is running on http://localhost:2003; expected AppInitRunner prompt-block error appeared)

## Technical Debt
- None.