### PR TITLE
Add new OpenCode GPT models

### DIFF
--- a/apps/backend/src/agents/agent-template.catalog.ts
+++ b/apps/backend/src/agents/agent-template.catalog.ts
@@ -10,6 +10,10 @@ import {
   COPILOT_CLAUDE,
   GEMINI_FLASH,
   GPT_5_4,
+  GPT_5_5,
+  GPT_5_6_LUNA,
+  GPT_5_6_SOL,
+  GPT_5_6_TERRA,
 } from 'src/app-init/models/models';
 import { AgentType } from './enums';
 import {
@@ -90,6 +94,26 @@ export const AGENT_TEMPLATE_HARNESSES: AgentTemplateHarnessDto[] = [
         label: 'GPT-5.4',
         providerId: GPT_5_4.providerId,
         modelId: GPT_5_4.modelId,
+      }),
+      modelOption({
+        label: 'GPT-5.6 Sol',
+        providerId: GPT_5_6_SOL.providerId,
+        modelId: GPT_5_6_SOL.modelId,
+      }),
+      modelOption({
+        label: 'GPT-5.6 Terra',
+        providerId: GPT_5_6_TERRA.providerId,
+        modelId: GPT_5_6_TERRA.modelId,
+      }),
+      modelOption({
+        label: 'GPT-5.6 Luna',
+        providerId: GPT_5_6_LUNA.providerId,
+        modelId: GPT_5_6_LUNA.modelId,
+      }),
+      modelOption({
+        label: 'GPT-5.5',
+        providerId: GPT_5_5.providerId,
+        modelId: GPT_5_5.modelId,
       }),
     ],
   },

--- a/apps/backend/src/app-init/models/models.ts
+++ b/apps/backend/src/app-init/models/models.ts
@@ -17,6 +17,30 @@ export const GPT_5_4: MODEL_CONFIG = {
   name: 'gpt-5.4',
 };
 
+export const GPT_5_6_SOL: MODEL_CONFIG = {
+  providerId: 'openai',
+  modelId: 'gpt-5.6-sol',
+  name: 'gpt-5.6-sol',
+};
+
+export const GPT_5_6_TERRA: MODEL_CONFIG = {
+  providerId: 'openai',
+  modelId: 'gpt-5.6-terra',
+  name: 'gpt-5.6-terra',
+};
+
+export const GPT_5_6_LUNA: MODEL_CONFIG = {
+  providerId: 'openai',
+  modelId: 'gpt-5.6-luna',
+  name: 'gpt-5.6-luna',
+};
+
+export const GPT_5_5: MODEL_CONFIG = {
+  providerId: 'openai',
+  modelId: 'gpt-5.5',
+  name: 'gpt-5.5',
+};
+
 // Good for GitHub Copilot runner
 export const COPILOT_CLAUDE: MODEL_CONFIG = {
   providerId: '',


### PR DESCRIPTION
## Summary
- Add shared model constants for gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, and gpt-5.5
- Expose the new models as selectable options for the OpenCode harness template catalog

## Validation
- npm run build:dev
- timeout 45s npm run dev:1 (backend and UIs started; existing AppInitRunner prompt context error observed during startup)

## Technical debt
- None