### PR TITLE
Use recreate rollout for SQLite deployment

### DIFF
--- a/install/manifests/base/deployment.yaml
+++ b/install/manifests/base/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: taico
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: taico


### PR DESCRIPTION
## Summary
- configure the Taico Deployment with `strategy.type: Recreate`

## Why
A default rolling update temporarily runs old and new pods together. Both access the same single-writer SQLite database while the new pod runs startup migrations, producing `SQLITE_BUSY` failures.

## Impact
Deployments will stop the existing Taico pod before starting its replacement, eliminating concurrent SQLite access at the cost of a short maintenance window.

## Validation
- `git diff --check`
- `kustomize build install/manifests/overlays/main`