### PR TITLE
Add planner app-init agent

### DIFF
--- a/apps/backend/src/agents/agent-avatar.library.ts
+++ b/apps/backend/src/agents/agent-avatar.library.ts
@@ -45,6 +45,12 @@ export const AGENT_AVATARS: AgentAvatarDefinition[] = [
     description: 'Bundled Stacy avatar for agent profiles.',
   },
   {
+    id: 'tracy',
+    label: 'Tracy',
+    url: '/avatar/stacy.png',
+    description: 'Bundled Tracy avatar alias for planner profiles.',
+  },
+  {
     id: 'claude',
     label: 'Claude',
     url: '/avatar/claude.webp',

--- a/apps/backend/src/app-init/agent/planner.agent.ts
+++ b/apps/backend/src/app-init/agent/planner.agent.ts
@@ -1,0 +1,22 @@
+import { CreateAgentInput } from 'src/agents/dto/service/agents.service.types';
+import { getAgentAvatarUrlById } from 'src/agents/agent-avatar.library';
+import { AgentType } from 'src/agents/enums';
+import { TaskStatus } from 'src/tasks/enums';
+import { PLANNER_PROMPT } from '../prompts/prompts';
+import { GPT_5_5 } from '../models/models';
+
+export const createPlanner: CreateAgentInput = {
+  slug: 'planner',
+  name: 'Planner',
+  type: AgentType.OPENCODE,
+  providerId: GPT_5_5.providerId,
+  modelId: GPT_5_5.modelId,
+  avatarUrl: getAgentAvatarUrlById('tracy'),
+  description: 'Planner agent for creating implementation plans.',
+  systemPrompt: PLANNER_PROMPT,
+  statusTriggers: [TaskStatus.NOT_STARTED],
+  tagTriggers: ['plan'],
+  allowedTools: [],
+  isActive: true,
+  concurrencyLimit: 1,
+};

--- a/apps/backend/src/app-init/app-init.runner.ts
+++ b/apps/backend/src/app-init/app-init.runner.ts
@@ -35,6 +35,7 @@ import { createDeveloper } from './agent/developer.agent';
 import { createGeminiAssistant } from './agent/gemini-assistant.agent';
 import { createCodeReviewer } from './agent/code-reviewer.agent';
 import { createLead } from './agent/lead.agent';
+import { createPlanner } from './agent/planner.agent';
 import { MetaService } from 'src/meta/meta.service';
 import { ContextService } from 'src/context/context.service';
 import { DEV_PROMPT, ASSISTANT_PROMPT, REVIEWER_PROMPT } from './prompts/prompts';
@@ -204,6 +205,11 @@ export class AppInitRunner implements OnApplicationBootstrap {
       await this.ensureAgentExists(createLead);
     } catch (error) {
       this.logger.error('Error ensuring lead Agent exists');
+    }
+    try {
+      await this.ensureAgentExists(createPlanner);
+    } catch (error) {
+      this.logger.error('Error ensuring planner Agent exists');
     }
   }
 

--- a/apps/backend/src/app-init/prompts/prompts.ts
+++ b/apps/backend/src/app-init/prompts/prompts.ts
@@ -114,6 +114,51 @@ Your goal is to review code changes in a task that is in "for review" status. Yo
 - [] added a comment to the GitHub PR
 `;
 
+export const PLANNER_PROMPT = `# Start task
+Your goal is to create a plan for a feature / bug fix / project and save it in a context block.
+You will pick up a task and work on it, taking it all the way from "not started" to "for review". A task is a unit of work, a commitment.
+You are in headless mode, and the only way to communicate with the user is through the Tasks MCP server.
+
+1. Pull the task using the Tasks MCP server by ID
+2. Read the content and comments
+3. Use the MCP server to add a \`plan\` tag
+
+You might be triggered with a fresh task, or as a re-work after receiving feedback on a plan you've already created.
+
+# Workflow
+
+### Prep
+1. You'll start in a workspace that might have a repo cloned
+2. Put this task in progress
+
+### Clarify
+3. If the requirement is not clear, ask questions via the input request tool and:
+- put the task back to NOT_STARTED
+- assign it to whomever you asked the question to
+
+### Work
+4. Do whatever you need to understand the thing you're planning. Feel free to explore the repo and use search tools. You have he \`gh\` cli available. If there's anything you're not clear about, ask the user.
+5. You are encouraged to work on the plan in a local .md file (never commit or push anything though) so you can do edits.
+6. When you make decisions, add a comment to this task to document it
+7. When you find relevant context, add it to this task as a comment (think what would be useful for someone reading this task in the future)
+
+### Finish
+8. Upload the .md file as a context block (override the existing one if this was a re-work to incorporate feedback)
+9. Add a comment / artifact to this task with the ID of the block created and make it clear this is where the plan lives (will be read by future consumers)
+10. Mark the task as \`in review\`
+11. Assign the task to \`plan-reviewer\`
+
+# Planning guidelines
+Your plan will be consumed by a team lead that will break it down into tasks to be implemented. For your plan, please:
+- define test strategy as a foundation, not an afterthought
+- focus on modularity, interfaces and maintainability
+- explain what parts can be done in parallel and any sequencing / dependencies
+
+# Checklist
+- [] put the task in progress when starting to work
+- [] upload plan as a context block
+- [] put this task in review when done and assigned it to \`plan-reviewer\``;
+
 export const LEAD_PROMPT = `# Start task
 Your goal is simple: lead a team to achieve a goal. You'll do so by delegating work to a planner and an implementer. You'll oversee the completion of the project.
 You will pick up a task explaining the task at hand.


### PR DESCRIPTION
## Summary
- Add a seeded OpenCode planner agent using GPT 5.5
- Add the planner system prompt from the provided context block
- Register the planner in AppInitRunner startup seeding
- Add a managed Tracy avatar alias backed by the existing bundled Stacy asset because no Tracy asset exists in the repo

## Validation
- npm run build:dev
- npm run dev:1 (validated startup; stopped by timeout after backend reported successful startup)

## Technical Debt
- The repo does not include a dedicated Tracy avatar asset, so this PR uses an alias to an existing bundled avatar instead of introducing a broken asset URL.