### PR TITLE
Add plan reviewer app-init agent

### DIFF
--- a/apps/backend/src/app-init/agent/plan-reviewer.agent.ts
+++ b/apps/backend/src/app-init/agent/plan-reviewer.agent.ts
@@ -1,0 +1,22 @@
+import { CreateAgentInput } from 'src/agents/dto/service/agents.service.types';
+import { getAgentAvatarUrlById } from 'src/agents/agent-avatar.library';
+import { AgentType } from 'src/agents/enums';
+import { TaskStatus } from 'src/tasks/enums';
+import { PLAN_REVIEWER_PROMPT } from '../prompts/prompts';
+import { GPT_5_5 } from '../models/models';
+
+export const createPlanReviewer: CreateAgentInput = {
+  slug: 'plan-reviewer',
+  name: 'Plan Reviewer',
+  type: AgentType.OPENCODE,
+  providerId: GPT_5_5.providerId,
+  modelId: GPT_5_5.modelId,
+  avatarUrl: getAgentAvatarUrlById('angus'),
+  description: 'Reviews implementation plans and sends them back for revision when needed.',
+  systemPrompt: PLAN_REVIEWER_PROMPT,
+  statusTriggers: [TaskStatus.FOR_REVIEW],
+  tagTriggers: ['plan'],
+  allowedTools: [],
+  isActive: true,
+  concurrencyLimit: 1,
+};

--- a/apps/backend/src/app-init/app-init.runner.ts
+++ b/apps/backend/src/app-init/app-init.runner.ts
@@ -36,6 +36,7 @@ import { createGeminiAssistant } from './agent/gemini-assistant.agent';
 import { createCodeReviewer } from './agent/code-reviewer.agent';
 import { createLead } from './agent/lead.agent';
 import { createPlanner } from './agent/planner.agent';
+import { createPlanReviewer } from './agent/plan-reviewer.agent';
 import { MetaService } from 'src/meta/meta.service';
 import { ContextService } from 'src/context/context.service';
 import { DEV_PROMPT, ASSISTANT_PROMPT, REVIEWER_PROMPT } from './prompts/prompts';
@@ -210,6 +211,11 @@ export class AppInitRunner implements OnApplicationBootstrap {
       await this.ensureAgentExists(createPlanner);
     } catch (error) {
       this.logger.error('Error ensuring planner Agent exists');
+    }
+    try {
+      await this.ensureAgentExists(createPlanReviewer);
+    } catch (error) {
+      this.logger.error('Error ensuring plan-reviewer Agent exists');
     }
   }
 

--- a/apps/backend/src/app-init/prompts/prompts.ts
+++ b/apps/backend/src/app-init/prompts/prompts.ts
@@ -159,6 +159,49 @@ Your plan will be consumed by a team lead that will break it down into tasks to 
 - [] upload plan as a context block
 - [] put this task in review when done and assigned it to \`plan-reviewer\``;
 
+export const PLAN_REVIEWER_PROMPT = `# Start task
+Your goal is to review a plan that another agent worked on. You'll take it from "in review" to "done if ok, or back to "not started" if it needs changes.
+You will receive a task with a full log of activity. Read it to understand what was the original intent.
+
+A task is a unit of work, a commitment.
+You are in headless mode, and the only way to communicate with the user is through the Tasks MCP server.
+
+1. Pull the task using the Tasks MCP server by ID
+2. Read the content and comments
+
+# Workflow
+
+### Preparation
+1. You'll start in a workspace that might have a repo cloned
+2. Identify the plan (should be a reference to a context block)
+3. Pull it and store it locally as a .md file so you can read it multiple times if needed
+
+### Review Process
+4. Examine if the plan matches the intended original goal of the task
+5. Review that the actual plan includes:
+- original intent clearly written
+- test strategy
+- good modular architecture
+- look for potential gotchas
+
+### Decisions
+6. If issues are found, we will send the task back to the planner to improve it. You'll need to:
+- add a \`review ❌\` tag to the task
+- add a detailed comment to the task listing the feedback (this will be actioned)
+- include specific suggestion for fixes
+- assign the task back to the original assignee (usually \`planner\`)
+- put the task back to NOT_STARTED status
+7. If the plan looks good, LFG!
+- add a \`review ✅\` tag to the task
+- move it to DONE witha. comment saying the plan is approved
+- assign the task back to the original assignee
+
+# Checklist:
+- [] fetched and reviewed the context block with a plan
+- [] added a comment to the task with either feedback or approval
+- [] moved the task to either done or not started
+- [] assigned \`review ✅ | ❌\` tag`;
+
 export const LEAD_PROMPT = `# Start task
 Your goal is simple: lead a team to achieve a goal. You'll do so by delegating work to a planner and an implementer. You'll oversee the completion of the project.
 You will pick up a task explaining the task at hand.


### PR DESCRIPTION
## Summary
- Add the plan-reviewer system prompt from context block 5017ba51-78bf-4009-9aad-729eaba5ebba
- Add the plan-reviewer app-init agent using OpenCode, gpt-5.5, and the angus avatar
- Register the agent in AppInitRunner with FOR_REVIEW + plan triggers

## Validation
- npm run build:dev
- timeout 60s npm run dev:1

## Technical debt
- None