### PR TITLE
Add taskmaster app-init agent

### DIFF
--- a/apps/backend/src/app-init/agent/taskmaster.agent.ts
+++ b/apps/backend/src/app-init/agent/taskmaster.agent.ts
@@ -1,0 +1,21 @@
+import { CreateAgentInput } from 'src/agents/dto/service/agents.service.types';
+import { getAgentAvatarUrlById } from 'src/agents/agent-avatar.library';
+import { AgentType } from 'src/agents/enums';
+import { TaskStatus } from 'src/tasks/enums';
+import { TASKMASTER_PROMPT } from '../prompts/prompts';
+import { GPT_5_5 } from '../models/models';
+
+export const createTaskmaster: CreateAgentInput = {
+  slug: 'taskmaster',
+  name: 'Taskmaster',
+  type: AgentType.OPENCODE,
+  providerId: GPT_5_5.providerId,
+  modelId: GPT_5_5.modelId,
+  avatarUrl: getAgentAvatarUrlById('bruce'),
+  description: 'Taskmaster agent for breaking plans into implementation tasks.',
+  systemPrompt: TASKMASTER_PROMPT,
+  statusTriggers: [TaskStatus.NOT_STARTED],
+  allowedTools: [],
+  isActive: true,
+  concurrencyLimit: 1,
+};

--- a/apps/backend/src/app-init/app-init.runner.ts
+++ b/apps/backend/src/app-init/app-init.runner.ts
@@ -37,6 +37,7 @@ import { createCodeReviewer } from './agent/code-reviewer.agent';
 import { createLead } from './agent/lead.agent';
 import { createPlanner } from './agent/planner.agent';
 import { createPlanReviewer } from './agent/plan-reviewer.agent';
+import { createTaskmaster } from './agent/taskmaster.agent';
 import { MetaService } from 'src/meta/meta.service';
 import { ContextService } from 'src/context/context.service';
 import { DEV_PROMPT, ASSISTANT_PROMPT, REVIEWER_PROMPT } from './prompts/prompts';
@@ -216,6 +217,11 @@ export class AppInitRunner implements OnApplicationBootstrap {
       await this.ensureAgentExists(createPlanReviewer);
     } catch (error) {
       this.logger.error('Error ensuring plan-reviewer Agent exists');
+    }
+    try {
+      await this.ensureAgentExists(createTaskmaster);
+    } catch (error) {
+      this.logger.error('Error ensuring taskmaster Agent exists');
     }
   }
 

--- a/apps/backend/src/app-init/prompts/prompts.ts
+++ b/apps/backend/src/app-init/prompts/prompts.ts
@@ -202,6 +202,48 @@ You are in headless mode, and the only way to communicate with the user is throu
 - [] moved the task to either done or not started
 - [] assigned \`review ✅ | ❌\` tag`;
 
+export const TASKMASTER_PROMPT = `# Start task
+Your goal is to read a plan for a feature / bug fix / project and create tasks to implement it. You will pick up a task and work on it, taking it all the way from "not started" to "done". A task is a unit of work, a commitment. You are in headless mode, and the only way to communicate with the user is through the Tasks MCP server.
+
+1. Pull the task using the Tasks MCP server by ID
+2. Read the content and comments
+3. Use the MCP server to add a plan tag
+
+# Workflow
+
+### Prep
+1. You'll start in a workspace that might have a repo cloned
+2. Put the task in progress
+3. Read the plan and decide if it will be implemented in a single task or if it needs to be broken up in series / parallel (graph like)
+
+### Clarify
+4.If the requirement is not clear, ask a question via the input request tool and:
+- put the task back to NOT_STARTED
+- assign it to whomever you asked the question to
+
+### Work
+5. Decide which project:xxx tag should be used:
+- list all tags using the MCP tool, focusing on the ones that start with project:
+- if this task has a project tag, use that one
+- if not, look at the task that created the plan to see if that one has a project tag
+- if no project tag is found, ensure you add a link to the repository to work on in the tasks you create (the project resolves to a repo, so if no project is found, just link the repo)
+6. Create tasks to accomplish the plan. The tasks will be handled by a developer. Developers follow a generic flow starting from main and ending with a pull request. You'll need to provide enough details in the task body for the developers to know what to do. Reference the original scope for context if using multiple tasks.
+7. Set dependencies. If you're creating multiple tasks, keep in mind that they'll need to be merged one by one. If they're independent, fine. If there's sequencing involved, add dependencies between tasks.
+8. Ensure all tasks created have the project: tag you found (if any)
+9. Assign the tasks you created to @developer. The developer will start working on them immediately, so don't assign until dependencies and tags are applied.
+10. When you make a decision, add a comment to the task to document it
+11. When you find relevant context, add it to the task as a comment (think what will be useful for someone in the future picking up this task)
+
+### Finish
+12. Add a comment to the task mentioning how you've broken up the work and referencing all sub tasks you created
+13. Move this task to "DONE"
+
+# Checklist
+- [] put this task in progress when starting to work
+- [] read plan from context
+- [] created implementation task(s)
+- [] marked this task as DONE`;
+
 export const LEAD_PROMPT = `# Start task
 Your goal is simple: lead a team to achieve a goal. You'll do so by delegating work to a planner and an implementer. You'll oversee the completion of the project.
 You will pick up a task explaining the task at hand.


### PR DESCRIPTION
## Summary
- Add a Taskmaster OpenCode app-init agent using GPT 5.5 and the Bruce avatar
- Store the Taskmaster system prompt from context block 04fc075d-6ec9-493e-9044-7ee57f953764 as TASKMASTER_PROMPT
- Register the new agent in AppInitRunner

## Validation
- npm run build:dev
- CHOKIDAR_USEPOLLING=true npm run dev:1 (UI, UI v1, and backend reached startup; backend logged taskmaster agent initialization)

## Technical debt
- None introduced. Startup still logs existing AppInitRunner errors in local dev, which the task noted as expected.