### PR TITLE
Remove planner plan tag trigger

### DIFF
--- a/apps/backend/src/app-init/agent/planner.agent.ts
+++ b/apps/backend/src/app-init/agent/planner.agent.ts
@@ -15,7 +15,6 @@ export const createPlanner: CreateAgentInput = {
   description: 'Planner agent for creating implementation plans.',
   systemPrompt: PLANNER_PROMPT,
   statusTriggers: [TaskStatus.NOT_STARTED],
-  tagTriggers: ['plan'],
   allowedTools: [],
   isActive: true,
   concurrencyLimit: 1,

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -45,6 +45,7 @@ import { RenameHasSeenWalkthroughToOnboardingDisplayMode1742400000000 } from './
 import { AllowInterruptedExecutionErrorCode1742500000000 } from './migrations/1742500000000-AllowInterruptedExecutionErrorCode';
 import { AddExecutionStatsTable1742600000000 } from './migrations/1742600000000-AddExecutionStatsTable';
 import { AddWorkerVersionFields1742700000000 } from './migrations/1742700000000-AddWorkerVersionFields';
+import { RemovePlannerPlanTagTrigger1742800000000 } from './migrations/1742800000000-RemovePlannerPlanTagTrigger';
 import { SecretsModule } from './secrets/secrets.module';
 import { ChatProvidersModule } from './chat-providers/chat-providers.module';
 import { ExecutionsModule } from './executions/executions.module';
@@ -88,6 +89,7 @@ import { WalkthroughModule } from './walkthrough/walkthrough.module';
         AllowInterruptedExecutionErrorCode1742500000000,
         AddExecutionStatsTable1742600000000,
         AddWorkerVersionFields1742700000000,
+        RemovePlannerPlanTagTrigger1742800000000,
       ],
     }),
     EventEmitterModule.forRoot(),

--- a/apps/backend/src/migrations/1742800000000-RemovePlannerPlanTagTrigger.ts
+++ b/apps/backend/src/migrations/1742800000000-RemovePlannerPlanTagTrigger.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemovePlannerPlanTagTrigger1742800000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE agents
+      SET tag_triggers = ''
+      WHERE actor_id IN (
+        SELECT id FROM actors WHERE slug = 'planner'
+      )
+      AND tag_triggers = 'plan'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE agents
+      SET tag_triggers = 'plan'
+      WHERE actor_id IN (
+        SELECT id FROM actors WHERE slug = 'planner'
+      )
+      AND tag_triggers = ''
+    `);
+  }
+}


### PR DESCRIPTION
## Summary
- Remove the bundled planner agent plan tag trigger so it can react to assigned not-started planning tasks without requiring the tag trigger.
- Add and register a migration that clears the existing planner tag_triggers value when it is exactly plan.

## Validation
- npm run build:dev
- npm run dev:5 reached successful backend startup on port 2016; stopped by timeout after startup. Known AppInitRunner prompt context block error appeared during startup.

## Technical Debt
- Seeded agents are currently create-only in AppInitRunner, so behavioral seed changes need one-off migrations for existing databases.