### PR TITLE
Add backend lifecycle health checks

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "paths": {
-    "/api/v1": {
+    "/": {
       "get": {
         "operationId": "AppController_getHello",
         "parameters": [],
@@ -19,6 +19,71 @@
           }
         },
         "summary": "Health check endpoint",
+        "tags": [
+          "App"
+        ]
+      }
+    },
+    "/health/live": {
+      "get": {
+        "operationId": "AppController_getLive",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The process is alive",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Liveness check endpoint",
+        "tags": [
+          "App"
+        ]
+      }
+    },
+    "/health/ready": {
+      "get": {
+        "operationId": "AppController_getReady",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The server is ready to accept traffic",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ready"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Shutdown has started and the server is not ready"
+          }
+        },
+        "summary": "Readiness check endpoint",
         "tags": [
           "App"
         ]

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "paths": {
-    "/": {
+    "/api/v1": {
       "get": {
         "operationId": "AppController_getHello",
         "parameters": [],

--- a/apps/backend/src/app.controller.spec.ts
+++ b/apps/backend/src/app.controller.spec.ts
@@ -1,22 +1,41 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ServerLifecycleService } from './server-lifecycle.service';
 
 describe('AppController', () => {
   let appController: AppController;
+  let serverLifecycle: ServerLifecycleService;
 
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      providers: [AppService],
+      providers: [AppService, ServerLifecycleService],
     }).compile();
 
     appController = app.get<AppController>(AppController);
+    serverLifecycle = app.get<ServerLifecycleService>(ServerLifecycleService);
   });
 
   describe('root', () => {
     it('should return "Hello World!"', () => {
       expect(appController.getHello()).toBe('Hello World!');
+    });
+  });
+
+  describe('health', () => {
+    it('should return live status', () => {
+      expect(appController.getLive()).toEqual({ status: 'ok' });
+    });
+
+    it('should return ready status before shutdown', () => {
+      expect(appController.getReady()).toEqual({ status: 'ready' });
+    });
+
+    it('should reject readiness after shutdown starts', () => {
+      serverLifecycle.beginShutdown('SIGTERM');
+
+      expect(() => appController.getReady()).toThrow('Server is shutting down');
     });
   });
 });

--- a/apps/backend/src/app.controller.ts
+++ b/apps/backend/src/app.controller.ts
@@ -1,10 +1,18 @@
-import { Controller, Get, Header } from '@nestjs/common';
-import { ApiOperation, ApiOkResponse, ApiProduces } from '@nestjs/swagger';
+import { Controller, Get, ServiceUnavailableException } from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiServiceUnavailableResponse,
+} from '@nestjs/swagger';
 import { AppService } from './app.service';
+import { ServerLifecycleService } from './server-lifecycle.service';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(
+    private readonly appService: AppService,
+    private readonly serverLifecycle: ServerLifecycleService,
+  ) {}
 
   @Get()
   @ApiOperation({ summary: 'Health check endpoint' })
@@ -17,5 +25,44 @@ export class AppController {
   })
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  @Get('/health/live')
+  @ApiOperation({ summary: 'Liveness check endpoint' })
+  @ApiOkResponse({
+    description: 'The process is alive',
+    schema: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', example: 'ok' },
+      },
+      required: ['status'],
+    },
+  })
+  getLive(): { status: 'ok' } {
+    return { status: 'ok' };
+  }
+
+  @Get('/health/ready')
+  @ApiOperation({ summary: 'Readiness check endpoint' })
+  @ApiOkResponse({
+    description: 'The server is ready to accept traffic',
+    schema: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', example: 'ready' },
+      },
+      required: ['status'],
+    },
+  })
+  @ApiServiceUnavailableResponse({
+    description: 'Shutdown has started and the server is not ready',
+  })
+  getReady(): { status: 'ready' } {
+    if (!this.serverLifecycle.isReady()) {
+      throw new ServiceUnavailableException('Server is shutting down');
+    }
+
+    return { status: 'ready' };
   }
 }

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -51,6 +51,7 @@ import { ExecutionsModule } from './executions/executions.module';
 import { GlobalSearchModule } from './global-search/global-search.module';
 import { WorkersModule } from './workers/workers.module';
 import { WalkthroughModule } from './walkthrough/walkthrough.module';
+import { ServerLifecycleService } from './server-lifecycle.service';
 
 @Module({
   imports: [
@@ -113,6 +114,6 @@ import { WalkthroughModule } from './walkthrough/walkthrough.module';
     WalkthroughModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, ServerLifecycleService],
 })
 export class AppModule { }

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -11,6 +11,7 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import cookieParser from 'cookie-parser';
 import { getConfig } from './config/env.config';
 import { Request, Response } from 'express';
+import { ServerLifecycleService } from './server-lifecycle.service';
 
 const logger = new Logger('Bootstrap');
 
@@ -43,6 +44,9 @@ async function bootstrap() {
     return;
   }
 
+  const lifecycle = app.get(ServerLifecycleService);
+  process.once('SIGTERM', () => lifecycle.beginShutdown('SIGTERM'));
+  process.once('SIGINT', () => lifecycle.beginShutdown('SIGINT'));
   app.enableShutdownHooks(['SIGTERM', 'SIGINT']);
   logger.log('Shutdown hooks enabled for SIGTERM and SIGINT');
 

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -43,6 +43,9 @@ async function bootstrap() {
     return;
   }
 
+  app.enableShutdownHooks(['SIGTERM', 'SIGINT']);
+  logger.log('Shutdown hooks enabled for SIGTERM and SIGINT');
+
   const document = createSwaggerDocument(app);
 
   SwaggerModule.setup('api/v1/docs', app, document);
@@ -107,11 +110,19 @@ async function createConfiguredApp(
   app.setGlobalPrefix('api/v1', {
     exclude: [
       {
+        path: '/',
+        method: RequestMethod.ALL,
+      },
+      {
         path: '/.well-known/*path',
         method: RequestMethod.ALL,
       },
       {
         path: '/launch',
+        method: RequestMethod.ALL,
+      },
+      {
+        path: '/health/*path',
         method: RequestMethod.ALL,
       },
     ],

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -114,10 +114,6 @@ async function createConfiguredApp(
   app.setGlobalPrefix('api/v1', {
     exclude: [
       {
-        path: '/',
-        method: RequestMethod.ALL,
-      },
-      {
         path: '/.well-known/*path',
         method: RequestMethod.ALL,
       },

--- a/apps/backend/src/server-lifecycle.service.spec.ts
+++ b/apps/backend/src/server-lifecycle.service.spec.ts
@@ -1,4 +1,17 @@
+import { INestApplication, Injectable, OnModuleDestroy } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 import { ServerLifecycleService } from './server-lifecycle.service';
+
+@Injectable()
+class ShutdownProbe implements OnModuleDestroy {
+  observedReadyDuringModuleDestroy: boolean | null = null;
+
+  constructor(private readonly lifecycle: ServerLifecycleService) {}
+
+  onModuleDestroy(): void {
+    this.observedReadyDuringModuleDestroy = this.lifecycle.isReady();
+  }
+}
 
 describe('ServerLifecycleService', () => {
   let service: ServerLifecycleService;
@@ -24,5 +37,25 @@ describe('ServerLifecycleService', () => {
     expect(service.beginShutdown('SIGINT')).toBe(false);
 
     expect(service.isReady()).toBe(false);
+  });
+
+  it('marks shutdown during module destroy for programmatic app close', () => {
+    service.onModuleDestroy();
+
+    expect(service.isReady()).toBe(false);
+  });
+
+  it('marks readiness false before later module destroy hooks run', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ServerLifecycleService, ShutdownProbe],
+    }).compile();
+    const app: INestApplication = module.createNestApplication();
+    await app.init();
+
+    const probe = app.get(ShutdownProbe);
+
+    await app.close();
+
+    expect(probe.observedReadyDuringModuleDestroy).toBe(false);
   });
 });

--- a/apps/backend/src/server-lifecycle.service.spec.ts
+++ b/apps/backend/src/server-lifecycle.service.spec.ts
@@ -1,0 +1,28 @@
+import { ServerLifecycleService } from './server-lifecycle.service';
+
+describe('ServerLifecycleService', () => {
+  let service: ServerLifecycleService;
+
+  beforeEach(() => {
+    service = new ServerLifecycleService();
+  });
+
+  it('is ready before shutdown starts', () => {
+    expect(service.isReady()).toBe(true);
+    expect(service.isShuttingDown()).toBe(false);
+  });
+
+  it('is not ready after shutdown starts', () => {
+    expect(service.beginShutdown('SIGTERM')).toBe(true);
+
+    expect(service.isReady()).toBe(false);
+    expect(service.isShuttingDown()).toBe(true);
+  });
+
+  it('makes repeated shutdown starts idempotent', () => {
+    expect(service.beginShutdown('SIGTERM')).toBe(true);
+    expect(service.beginShutdown('SIGINT')).toBe(false);
+
+    expect(service.isReady()).toBe(false);
+  });
+});

--- a/apps/backend/src/server-lifecycle.service.ts
+++ b/apps/backend/src/server-lifecycle.service.ts
@@ -1,0 +1,60 @@
+import {
+  BeforeApplicationShutdown,
+  Injectable,
+  Logger,
+  OnApplicationShutdown,
+} from '@nestjs/common';
+
+@Injectable()
+export class ServerLifecycleService
+  implements BeforeApplicationShutdown, OnApplicationShutdown
+{
+  private readonly logger = new Logger(ServerLifecycleService.name);
+  private shuttingDown = false;
+  private shutdownStartedAt: number | null = null;
+  private shutdownSignal: string | undefined;
+
+  isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
+
+  isReady(): boolean {
+    return !this.shuttingDown;
+  }
+
+  beginShutdown(signal?: string): boolean {
+    if (this.shuttingDown) {
+      this.logger.log(
+        `Shutdown already in progress${this.formatSignal(signal)}; ignoring duplicate request`,
+      );
+      return false;
+    }
+
+    this.shuttingDown = true;
+    this.shutdownStartedAt = Date.now();
+    this.shutdownSignal = signal;
+    this.logger.log(
+      `Shutdown started${this.formatSignal(signal)}; readiness is now false`,
+    );
+    return true;
+  }
+
+  beforeApplicationShutdown(signal?: string): void {
+    this.beginShutdown(signal);
+  }
+
+  onApplicationShutdown(signal?: string): void {
+    const elapsedMs = this.shutdownStartedAt
+      ? Date.now() - this.shutdownStartedAt
+      : 0;
+    this.logger.log(
+      `Shutdown completed${this.formatSignal(
+        signal ?? this.shutdownSignal,
+      )} after ${elapsedMs}ms`,
+    );
+  }
+
+  private formatSignal(signal?: string): string {
+    return signal ? ` for ${signal}` : '';
+  }
+}

--- a/apps/backend/src/server-lifecycle.service.ts
+++ b/apps/backend/src/server-lifecycle.service.ts
@@ -3,11 +3,12 @@ import {
   Injectable,
   Logger,
   OnApplicationShutdown,
+  OnModuleDestroy,
 } from '@nestjs/common';
 
 @Injectable()
 export class ServerLifecycleService
-  implements BeforeApplicationShutdown, OnApplicationShutdown
+  implements OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown
 {
   private readonly logger = new Logger(ServerLifecycleService.name);
   private shuttingDown = false;
@@ -37,6 +38,10 @@ export class ServerLifecycleService
       `Shutdown started${this.formatSignal(signal)}; readiness is now false`,
     );
     return true;
+  }
+
+  onModuleDestroy(): void {
+    this.beginShutdown();
   }
 
   beforeApplicationShutdown(signal?: string): void {

--- a/apps/backend/test/app.e2e-spec.ts
+++ b/apps/backend/test/app.e2e-spec.ts
@@ -1,8 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, RequestMethod } from '@nestjs/common';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { ServerLifecycleService } from './../src/server-lifecycle.service';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
@@ -13,7 +14,23 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1', {
+      exclude: [
+        {
+          path: '/',
+          method: RequestMethod.ALL,
+        },
+        {
+          path: '/health/*path',
+          method: RequestMethod.ALL,
+        },
+      ],
+    });
     await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
   });
 
   it('/ (GET)', () => {
@@ -21,5 +38,25 @@ describe('AppController (e2e)', () => {
       .get('/')
       .expect(200)
       .expect('Hello World!');
+  });
+
+  it('/health/live (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/health/live')
+      .expect(200)
+      .expect({ status: 'ok' });
+  });
+
+  it('/health/ready (GET) before shutdown', () => {
+    return request(app.getHttpServer())
+      .get('/health/ready')
+      .expect(200)
+      .expect({ status: 'ready' });
+  });
+
+  it('/health/ready (GET) after shutdown starts', () => {
+    app.get(ServerLifecycleService).beginShutdown('SIGTERM');
+
+    return request(app.getHttpServer()).get('/health/ready').expect(503);
   });
 });

--- a/apps/backend/test/app.e2e-spec.ts
+++ b/apps/backend/test/app.e2e-spec.ts
@@ -17,10 +17,6 @@ describe('AppController (e2e)', () => {
     app.setGlobalPrefix('api/v1', {
       exclude: [
         {
-          path: '/',
-          method: RequestMethod.ALL,
-        },
-        {
           path: '/health/*path',
           method: RequestMethod.ALL,
         },
@@ -33,9 +29,9 @@ describe('AppController (e2e)', () => {
     await app.close();
   });
 
-  it('/ (GET)', () => {
+  it('/api/v1 (GET)', () => {
     return request(app.getHttpServer())
-      .get('/')
+      .get('/api/v1')
       .expect(200)
       .expect('Hello World!');
   });

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "paths": {
-    "/api/v1": {
+    "/": {
       "get": {
         "operationId": "AppController_getHello",
         "parameters": [],
@@ -19,6 +19,71 @@
           }
         },
         "summary": "Health check endpoint",
+        "tags": [
+          "App"
+        ]
+      }
+    },
+    "/health/live": {
+      "get": {
+        "operationId": "AppController_getLive",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The process is alive",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Liveness check endpoint",
+        "tags": [
+          "App"
+        ]
+      }
+    },
+    "/health/ready": {
+      "get": {
+        "operationId": "AppController_getReady",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The server is ready to accept traffic",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ready"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Shutdown has started and the server is not ready"
+          }
+        },
+        "summary": "Readiness check endpoint",
         "tags": [
           "App"
         ]

--- a/packages/client/contracts/openapi.json
+++ b/packages/client/contracts/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "paths": {
-    "/": {
+    "/api/v1": {
       "get": {
         "operationId": "AppController_getHello",
         "parameters": [],

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    "/": {
+    "/api/v1": {
         parameters: {
             query?: never;
             header?: never;

--- a/packages/client/contracts/types.ts
+++ b/packages/client/contracts/types.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    "/api/v1": {
+    "/": {
         parameters: {
             query?: never;
             header?: never;
@@ -13,6 +13,40 @@ export interface paths {
         };
         /** Health check endpoint */
         get: operations["AppController_getHello"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/health/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Liveness check endpoint */
+        get: operations["AppController_getLive"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/health/ready": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Readiness check endpoint */
+        get: operations["AppController_getReady"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6212,6 +6246,59 @@ export interface operations {
                 content: {
                     "application/json": string;
                 };
+            };
+        };
+    };
+    AppController_getLive: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The process is alive */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example ok */
+                        status: string;
+                    };
+                };
+            };
+        };
+    };
+    AppController_getReady: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The server is ready to accept traffic */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example ready */
+                        status: string;
+                    };
+                };
+            };
+            /** @description Shutdown has started and the server is not ready */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/client/src/v1/client/services/AppService.ts
+++ b/packages/client/src/v1/client/services/AppService.ts
@@ -15,7 +15,7 @@ export class AppService {
     public static appControllerGetHello(config: OpenAPIConfig = OpenAPI): CancelablePromise<string> {
         return __request(config, {
             method: 'GET',
-            url: '/',
+            url: '/api/v1',
         });
     }
     /**

--- a/packages/client/src/v1/client/services/AppService.ts
+++ b/packages/client/src/v1/client/services/AppService.ts
@@ -15,7 +15,36 @@ export class AppService {
     public static appControllerGetHello(config: OpenAPIConfig = OpenAPI): CancelablePromise<string> {
         return __request(config, {
             method: 'GET',
-            url: '/api/v1',
+            url: '/',
+        });
+    }
+    /**
+     * Liveness check endpoint
+     * @returns any The process is alive
+     * @throws ApiError
+     */
+    public static appControllerGetLive(config: OpenAPIConfig = OpenAPI): CancelablePromise<{
+        status: string;
+    }> {
+        return __request(config, {
+            method: 'GET',
+            url: '/health/live',
+        });
+    }
+    /**
+     * Readiness check endpoint
+     * @returns any The server is ready to accept traffic
+     * @throws ApiError
+     */
+    public static appControllerGetReady(config: OpenAPIConfig = OpenAPI): CancelablePromise<{
+        status: string;
+    }> {
+        return __request(config, {
+            method: 'GET',
+            url: '/health/ready',
+            errors: {
+                503: `Shutdown has started and the server is not ready`,
+            },
         });
     }
 }

--- a/packages/client/src/v2/app-resource.ts
+++ b/packages/client/src/v2/app-resource.ts
@@ -7,7 +7,17 @@ export class AppResource extends BaseClient {
 
   /** Health check endpoint */
   async AppController_getHello(params?: { signal?: AbortSignal }): Promise<string> {
-    return this.request('GET', '/api/v1', { signal: params?.signal });
+    return this.request('GET', '/', { signal: params?.signal });
+  }
+
+  /** Liveness check endpoint */
+  async AppController_getLive(params?: { signal?: AbortSignal }): Promise<{ status: string }> {
+    return this.request('GET', '/health/live', { signal: params?.signal });
+  }
+
+  /** Readiness check endpoint */
+  async AppController_getReady(params?: { signal?: AbortSignal }): Promise<{ status: string }> {
+    return this.request('GET', '/health/ready', { signal: params?.signal });
   }
 
 }

--- a/packages/client/src/v2/app-resource.ts
+++ b/packages/client/src/v2/app-resource.ts
@@ -7,7 +7,7 @@ export class AppResource extends BaseClient {
 
   /** Health check endpoint */
   async AppController_getHello(params?: { signal?: AbortSignal }): Promise<string> {
-    return this.request('GET', '/', { signal: params?.signal });
+    return this.request('GET', '/api/v1', { signal: params?.signal });
   }
 
   /** Liveness check endpoint */


### PR DESCRIPTION
## Summary
- add a process-local ServerLifecycleService that tracks readiness and idempotent shutdown start/completion logs
- add root-level /health/live and /health/ready endpoints while preserving / compatibility
- enable Nest shutdown hooks for SIGTERM and SIGINT in normal server mode
- add unit and HTTP e2e coverage for lifecycle readiness and health responses
- regenerate OpenAPI and TypeScript client artifacts

## Validation
- npm run build:dev
- npm -w apps/backend run test -- app.controller.spec.ts server-lifecycle.service.spec.ts --runInBand
- npm -w apps/backend run test:should-be-e2e -- app.e2e-spec.ts
- npm -w apps/backend run build:prod && npm -w packages/client run build:prod
- timeout 35s npm run dev:2

## Notes
- npm run dev:1 was attempted first but port 2003 was already in use, so validation moved to stack 2.
- Local app/e2e startup emitted expected AppInitRunner prompt setup errors, but test assertions passed.

## Technical Debt
- No bounded HTTP/WebSocket drain tracking is added in this slice; that remains for the backend drain hardening slice.