### PR TITLE
Add worker graceful shutdown coordinator

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "start": "tsx src/index.ts",
-    "test": "tsx src/test.ts",
+    "test": "node --import tsx --test test/*.test.ts",
     "build": "tsc -p tsconfig.build.json",
     "build:prod": "npm run build",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",

--- a/apps/worker/src/task-claim-worker.ts
+++ b/apps/worker/src/task-claim-worker.ts
@@ -6,31 +6,56 @@ import { isTaskClaimDeferred } from './task-claim-deferral.js';
 
 const QUEUE_POLL_INTERVAL_MS = 60_000;
 
+type PickTaskFn = typeof pickTask;
+
+export type TaskClaimWorkerOptions = {
+  signal?: AbortSignal;
+  shouldClaimTask?: () => boolean;
+  trackTaskExecution?: (taskId: string, execution: Promise<void>) => void;
+  pollIntervalMs?: number;
+  pickTaskFn?: PickTaskFn;
+};
+
 export async function runTaskClaimWorker(
   client: ApiClient,
   workingDirectory: string,
   baseUrl: string,
   activityGatewayClient: ExecutionActivityGatewayClient,
+  options: TaskClaimWorkerOptions = {},
 ): Promise<void> {
+  const pollIntervalMs = options.pollIntervalMs ?? QUEUE_POLL_INTERVAL_MS;
   console.log(
-    `[worker] Polling executions queue every ${QUEUE_POLL_INTERVAL_MS / 1000}s.`,
+    `[worker] Polling executions queue every ${pollIntervalMs / 1000}s.`,
   );
 
-  while (true) {
+  while (!options.signal?.aborted) {
     try {
       await processNextQueuedTask(
         client,
         workingDirectory,
         baseUrl,
         activityGatewayClient,
+        options,
       );
     } catch (error) {
+      if (isAbortError(error)) {
+        break;
+      }
       const message = error instanceof Error ? error.message : String(error);
       console.error(`[worker] Queue poll failed: ${message}`);
     }
 
-    await sleep(QUEUE_POLL_INTERVAL_MS);
+    try {
+      await sleep(pollIntervalMs, undefined, { signal: options.signal });
+    } catch (error) {
+      if (isAbortError(error)) {
+        break;
+      }
+      throw error;
+    }
   }
+
+  console.log('[worker] Task claim worker stopped.');
 }
 
 export async function attemptClaimTask(
@@ -39,8 +64,14 @@ export async function attemptClaimTask(
   workingDirectory: string,
   baseUrl: string,
   activityGatewayClient: ExecutionActivityGatewayClient,
+  options: TaskClaimWorkerOptions = {},
 ): Promise<void> {
   console.log(`[worker] Received queue notification for task ${taskId}, attempting to claim...`);
+
+  if (!canClaimTask(options)) {
+    console.log(`[worker] Skipping task ${taskId}; worker is shutting down.`);
+    return;
+  }
 
   if (isTaskClaimDeferred(taskId)) {
     console.log(`[worker] Skipping task ${taskId}; recently unclaimed by this worker.`);
@@ -48,13 +79,15 @@ export async function attemptClaimTask(
   }
 
   try {
-    await pickTask({
+    const taskExecution = (options.pickTaskFn ?? pickTask)({
       client,
       taskId,
       baseDir: workingDirectory,
       baseUrl,
       activityGatewayClient,
     });
+    options.trackTaskExecution?.(taskId, taskExecution);
+    await taskExecution;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.log(`[worker] Failed to claim task ${taskId}: ${message}`);
@@ -66,9 +99,18 @@ async function processNextQueuedTask(
   workingDirectory: string,
   baseUrl: string,
   activityGatewayClient: ExecutionActivityGatewayClient,
+  options: TaskClaimWorkerOptions,
 ): Promise<void> {
+  if (!canClaimTask(options)) {
+    return;
+  }
+
   const queueResponse = await client.executions.TaskExecutionQueueController_listQueue({ limit: 25 });
   console.log(`[worker] Queue poll succeeded. ${queueResponse.total} task(s) ready.`);
+
+  if (!canClaimTask(options)) {
+    return;
+  }
 
   const nextTask = queueResponse.items.find(
     (item) => !isTaskClaimDeferred(item.taskId),
@@ -77,7 +119,11 @@ async function processNextQueuedTask(
     return;
   }
 
-  void pickTask({
+  if (!canClaimTask(options)) {
+    return;
+  }
+
+  const taskExecution = (options.pickTaskFn ?? pickTask)({
     client,
     taskId: nextTask.taskId,
     baseDir: workingDirectory,
@@ -90,4 +136,14 @@ async function processNextQueuedTask(
         `[worker] Task processing failed for ${nextTask.taskId}: ${message}`,
       );
     });
+
+  options.trackTaskExecution?.(nextTask.taskId, taskExecution);
+}
+
+function canClaimTask(options: TaskClaimWorkerOptions): boolean {
+  return !options.signal?.aborted && (options.shouldClaimTask?.() ?? true);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }

--- a/apps/worker/src/worker-app.ts
+++ b/apps/worker/src/worker-app.ts
@@ -103,7 +103,21 @@ export async function startWorkerApp(options: WorkerOptions): Promise<void> {
   });
 
   try {
-    await activityGatewayClient.start();
+    const gatewayStart = activityGatewayClient.start();
+    const startupResult = await Promise.race([
+      gatewayStart.then(() => 'started' as const),
+      shutdownCoordinator.waitForShutdownStart().then(() => 'shutdown' as const),
+    ]);
+
+    if (startupResult === 'shutdown') {
+      void gatewayStart.catch((error) => {
+        console.warn(
+          `[worker] Activity gateway startup failed after shutdown started: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+      await shutdownCoordinator.shutdown(activityGatewayClient, client);
+      return;
+    }
 
     if (shutdownCoordinator.isShuttingDown()) {
       await shutdownCoordinator.shutdown(activityGatewayClient, client);

--- a/apps/worker/src/worker-app.ts
+++ b/apps/worker/src/worker-app.ts
@@ -9,11 +9,14 @@ export const activeExecutionAbortControllers = new Map<string, AbortController>(
 export const activeExecutionInterruptHandlers = new Map<string, () => void | Promise<void>>();
 
 const STARTUP_RETRY_DELAY_MS = 2_000;
+const DEFAULT_WORKER_SHUTDOWN_GRACE_MS = 60_000;
+const WORKER_SHUTDOWN_MESSAGE = 'Worker shutdown interrupted active execution.';
 
 export type WorkerOptions = {
   serverUrl: string;
   credentialsPath?: string;
   workingDirectory: string;
+  shutdownGraceMs?: number;
 };
 
 type WorkerBootstrapResult = Awaited<
@@ -21,6 +24,15 @@ type WorkerBootstrapResult = Awaited<
 >;
 
 export async function startWorkerApp(options: WorkerOptions): Promise<void> {
+  const startupAbortController = new AbortController();
+  const shutdownCoordinator = new WorkerShutdownCoordinator({
+    graceMs: options.shutdownGraceMs ?? readShutdownGraceMs(),
+  });
+  const removeSignalHandlers = installSignalHandlers((signal) => {
+    startupAbortController.abort();
+    shutdownCoordinator.beginShutdown(signal);
+  });
+
   const auth = new WorkerAuth({
     serverUrl: options.serverUrl,
     credentialsPath: options.credentialsPath,
@@ -33,13 +45,19 @@ export async function startWorkerApp(options: WorkerOptions): Promise<void> {
 
   let bootstrap: WorkerBootstrapResult;
   try {
-    bootstrap = await ensureAuthenticatedWithRetry(auth);
+    bootstrap = await ensureAuthenticatedWithRetry(auth, startupAbortController.signal);
   } catch (error) {
+    removeSignalHandlers();
     if (error instanceof WorkerStartupCanceledError) {
       console.log('[worker] Startup canceled.');
       return;
     }
     throw error;
+  }
+
+  if (shutdownCoordinator.isShuttingDown()) {
+    removeSignalHandlers();
+    return;
   }
 
   if (bootstrap.didBootstrap) {
@@ -64,6 +82,7 @@ export async function startWorkerApp(options: WorkerOptions): Promise<void> {
         options.workingDirectory,
         auth.serverUrl,
         activityGatewayClient,
+        shutdownCoordinator.getTaskClaimOptions(),
       );
     },
     onExecutionInterruptRequest: (event) => {
@@ -83,25 +102,51 @@ export async function startWorkerApp(options: WorkerOptions): Promise<void> {
     },
   });
 
-  await activityGatewayClient.start();
+  try {
+    await activityGatewayClient.start();
 
-  console.log('[worker] Connectivity check succeeded.');
+    if (shutdownCoordinator.isShuttingDown()) {
+      await shutdownCoordinator.shutdown(activityGatewayClient, client);
+      return;
+    }
 
-  await runTaskClaimWorker(
-    client,
-    options.workingDirectory,
-    auth.serverUrl,
-    activityGatewayClient,
-  );
+    console.log('[worker] Connectivity check succeeded.');
+
+    const taskClaimWorker = runTaskClaimWorker(
+      client,
+      options.workingDirectory,
+      auth.serverUrl,
+      activityGatewayClient,
+      shutdownCoordinator.getTaskClaimOptions(),
+    );
+
+    await Promise.race([
+      taskClaimWorker,
+      shutdownCoordinator.waitForShutdownStart(),
+    ]);
+
+    if (shutdownCoordinator.isShuttingDown()) {
+      await shutdownCoordinator.shutdown(activityGatewayClient, client);
+      await taskClaimWorker;
+    } else {
+      await taskClaimWorker;
+    }
+  } finally {
+    removeSignalHandlers();
+  }
 }
 
-async function ensureAuthenticatedWithRetry(auth: WorkerAuth): Promise<{
+async function ensureAuthenticatedWithRetry(auth: WorkerAuth, signal?: AbortSignal): Promise<{
   credentials: Awaited<ReturnType<WorkerAuth['getCredentials']>>;
   didBootstrap: boolean;
 }> {
   let attempt = 1;
 
   while (true) {
+    if (signal?.aborted) {
+      throw new WorkerStartupCanceledError();
+    }
+
     try {
       clearRetryStatusLine();
       return await auth.ensureAuthenticated();
@@ -112,10 +157,10 @@ async function ensureAuthenticatedWithRetry(auth: WorkerAuth): Promise<{
       }
 
       renderRetryStatus(attempt);
-      const canceled = await waitForRetryOrCancel(STARTUP_RETRY_DELAY_MS);
+      const canceled = await waitForRetryOrCancel(STARTUP_RETRY_DELAY_MS, signal);
       clearRetryStatusLine();
 
-      if (canceled) {
+      if (canceled || signal?.aborted) {
         throw new WorkerStartupCanceledError();
       }
 
@@ -138,9 +183,16 @@ function clearRetryStatusLine(): void {
   process.stdout.write('\r\x1b[2K');
 }
 
-async function waitForRetryOrCancel(delayMs: number): Promise<boolean> {
+async function waitForRetryOrCancel(delayMs: number, signal?: AbortSignal): Promise<boolean> {
   if (!canCaptureEscapeKey()) {
-    await sleep(delayMs);
+    try {
+      await sleep(delayMs, undefined, { signal });
+    } catch (error) {
+      if (isAbortError(error)) {
+        return true;
+      }
+      throw error;
+    }
     return false;
   }
 
@@ -164,10 +216,16 @@ async function waitForRetryOrCancel(delayMs: number): Promise<boolean> {
       reject(error);
     };
 
+    const onAbort = () => {
+      cleanup();
+      resolve(true);
+    };
+
     const cleanup = () => {
       clearTimeout(timeout);
       stdin.off('data', onData);
       stdin.off('error', onError);
+      signal?.removeEventListener('abort', onAbort);
       if (typeof stdin.setRawMode === 'function') {
         stdin.setRawMode(false);
       }
@@ -180,6 +238,7 @@ async function waitForRetryOrCancel(delayMs: number): Promise<boolean> {
     stdin.resume();
     stdin.on('data', onData);
     stdin.on('error', onError);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 
@@ -222,4 +281,181 @@ class WorkerStartupCanceledError extends Error {
     super('Worker startup canceled by user.');
     this.name = 'WorkerStartupCanceledError';
   }
+}
+
+type WorkerSignal = 'SIGTERM' | 'SIGINT';
+
+type WorkerShutdownCoordinatorOptions = {
+  graceMs: number;
+};
+
+export class WorkerShutdownCoordinator {
+  private readonly abortController = new AbortController();
+  private readonly activeTaskExecutions = new Set<Promise<void>>();
+  private shuttingDown = false;
+  private shutdownStartedResolver!: () => void;
+  private readonly shutdownStarted = new Promise<void>((resolve) => {
+    this.shutdownStartedResolver = resolve;
+  });
+
+  constructor(private readonly options: WorkerShutdownCoordinatorOptions) {}
+
+  beginShutdown(signal: WorkerSignal | string): void {
+    if (this.shuttingDown) {
+      console.log(`[worker] Received ${signal} while shutdown is already in progress.`);
+      return;
+    }
+
+    this.shuttingDown = true;
+    console.log(`[worker] Received ${signal}; starting graceful shutdown.`);
+    this.abortController.abort();
+    this.shutdownStartedResolver();
+  }
+
+  isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
+
+  waitForShutdownStart(): Promise<void> {
+    return this.shutdownStarted;
+  }
+
+  getTaskClaimOptions() {
+    return {
+      signal: this.abortController.signal,
+      shouldClaimTask: () => !this.shuttingDown,
+      trackTaskExecution: (taskId: string, execution: Promise<void>) => {
+        this.trackTaskExecution(taskId, execution);
+      },
+    };
+  }
+
+  async shutdown(
+    activityGatewayClient: Pick<ExecutionActivityGatewayClient, 'stop'>,
+    client?: ApiClient,
+  ): Promise<void> {
+    if (!this.shuttingDown) {
+      this.beginShutdown('shutdown');
+    }
+
+    await activityGatewayClient.stop();
+    await this.drainOrCancelActiveExecutions(client);
+  }
+
+  private trackTaskExecution(taskId: string, execution: Promise<void>): void {
+    this.activeTaskExecutions.add(execution);
+    void execution.then(
+      () => this.activeTaskExecutions.delete(execution),
+      () => this.activeTaskExecutions.delete(execution),
+    );
+    console.log(`[worker] Tracking active execution for task ${taskId}.`);
+  }
+
+  private async drainOrCancelActiveExecutions(client?: ApiClient): Promise<void> {
+    if (this.activeTaskExecutions.size === 0) {
+      console.log('[worker] No active executions to drain.');
+      return;
+    }
+
+    console.log(
+      `[worker] Waiting up to ${this.options.graceMs}ms for ${this.activeTaskExecutions.size} active execution(s) to finish.`,
+    );
+
+    const completed = await waitForPromisesToSettle(
+      Array.from(this.activeTaskExecutions),
+      this.options.graceMs,
+    );
+
+    if (completed) {
+      console.log('[worker] Active executions drained cleanly.');
+      return;
+    }
+
+    const executionIds = Array.from(activeExecutionAbortControllers.keys());
+    console.warn(
+      `[worker] Shutdown grace elapsed; interrupting active execution(s): ${executionIds.join(', ') || 'unknown'}.`,
+    );
+
+    await Promise.allSettled(
+      executionIds.map(async (executionId) => {
+        activeExecutionAbortControllers.get(executionId)?.abort();
+        await Promise.resolve(activeExecutionInterruptHandlers.get(executionId)?.());
+        await this.markExecutionInterrupted(client, executionId);
+      }),
+    );
+  }
+
+  private async markExecutionInterrupted(client: ApiClient | undefined, executionId: string): Promise<void> {
+    if (!client) {
+      return;
+    }
+
+    try {
+      await client.executions.ActiveTaskExecutionController_stopTaskExecution({
+        executionId,
+        body: {
+          status: 'CANCELLED',
+          errorCode: 'INTERRUPTED',
+          errorMessage: WORKER_SHUTDOWN_MESSAGE,
+        },
+      });
+    } catch (error) {
+      console.warn(
+        `[worker] Failed to mark execution ${executionId} interrupted during shutdown; stale execution pruning remains the backstop: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}
+
+function installSignalHandlers(onSignal: (signal: WorkerSignal) => void): () => void {
+  const handleSigterm = () => onSignal('SIGTERM');
+  const handleSigint = () => onSignal('SIGINT');
+  process.once('SIGTERM', handleSigterm);
+  process.once('SIGINT', handleSigint);
+
+  return () => {
+    process.off('SIGTERM', handleSigterm);
+    process.off('SIGINT', handleSigint);
+  };
+}
+
+function readShutdownGraceMs(): number {
+  const configured = process.env.WORKER_SHUTDOWN_GRACE_MS;
+  if (!configured) {
+    return DEFAULT_WORKER_SHUTDOWN_GRACE_MS;
+  }
+
+  const parsed = Number(configured);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.warn(
+      `[worker] Ignoring invalid WORKER_SHUTDOWN_GRACE_MS=${configured}; using ${DEFAULT_WORKER_SHUTDOWN_GRACE_MS}.`,
+    );
+    return DEFAULT_WORKER_SHUTDOWN_GRACE_MS;
+  }
+
+  return parsed;
+}
+
+async function waitForPromisesToSettle(promises: Promise<void>[], timeoutMs: number): Promise<boolean> {
+  if (promises.length === 0) {
+    return true;
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.allSettled(promises).then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }

--- a/apps/worker/test/worker-shutdown.test.ts
+++ b/apps/worker/test/worker-shutdown.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { runTaskClaimWorker, attemptClaimTask } from '../src/task-claim-worker.js';
+import {
+  WorkerShutdownCoordinator,
+  activeExecutionAbortControllers,
+  activeExecutionInterruptHandlers,
+} from '../src/worker-app.js';
+
+test('runTaskClaimWorker exits when aborted during sleep', async () => {
+  const abortController = new AbortController();
+  const client = createQueueClient([]);
+  const startedAt = Date.now();
+
+  setTimeout(() => abortController.abort(), 10);
+
+  await runTaskClaimWorker(
+    client,
+    '/tmp/worker-test',
+    'http://localhost:3000',
+    createActivityGatewayClient(),
+    {
+      signal: abortController.signal,
+      pollIntervalMs: 10_000,
+    },
+  );
+
+  assert.equal(client.listQueueCalls, 1);
+  assert.ok(Date.now() - startedAt < 1_000);
+});
+
+test('queue notifications do not claim tasks after shutdown starts', async () => {
+  let pickTaskCalls = 0;
+
+  await attemptClaimTask(
+    'task-1',
+    createQueueClient([]),
+    '/tmp/worker-test',
+    'http://localhost:3000',
+    createActivityGatewayClient(),
+    {
+      shouldClaimTask: () => false,
+      pickTaskFn: async () => {
+        pickTaskCalls += 1;
+      },
+    },
+  );
+
+  assert.equal(pickTaskCalls, 0);
+});
+
+test('polling does not claim tasks after shutdown starts', async () => {
+  const abortController = new AbortController();
+  let pickTaskCalls = 0;
+
+  setTimeout(() => abortController.abort(), 10);
+
+  await runTaskClaimWorker(
+    createQueueClient(['task-1']),
+    '/tmp/worker-test',
+    'http://localhost:3000',
+    createActivityGatewayClient(),
+    {
+      signal: abortController.signal,
+      shouldClaimTask: () => false,
+      pollIntervalMs: 10_000,
+      pickTaskFn: async () => {
+        pickTaskCalls += 1;
+      },
+    },
+  );
+
+  assert.equal(pickTaskCalls, 0);
+});
+
+test('shutdown calls ExecutionActivityGatewayClient.stop', async () => {
+  const coordinator = new WorkerShutdownCoordinator({ graceMs: 10 });
+  let stopCalls = 0;
+
+  coordinator.beginShutdown('SIGTERM');
+  await coordinator.shutdown({
+    stop: async () => {
+      stopCalls += 1;
+    },
+  });
+
+  assert.equal(stopCalls, 1);
+});
+
+test('shutdown waits for active executions that complete within grace', async () => {
+  const coordinator = new WorkerShutdownCoordinator({ graceMs: 1_000 });
+  let resolveExecution!: () => void;
+  const execution = new Promise<void>((resolve) => {
+    resolveExecution = resolve;
+  });
+
+  coordinator.getTaskClaimOptions().trackTaskExecution('task-1', execution);
+  coordinator.beginShutdown('SIGTERM');
+  setTimeout(resolveExecution, 10);
+
+  await coordinator.shutdown(createActivityGatewayClient());
+
+  assert.equal(activeExecutionAbortControllers.size, 0);
+});
+
+test('shutdown interrupts active executions after grace elapses', async () => {
+  const coordinator = new WorkerShutdownCoordinator({ graceMs: 1 });
+  const executionAbortController = new AbortController();
+  let interruptCalls = 0;
+  let stoppedExecutionId: string | undefined;
+
+  activeExecutionAbortControllers.set('execution-1', executionAbortController);
+  activeExecutionInterruptHandlers.set('execution-1', () => {
+    interruptCalls += 1;
+  });
+  coordinator.getTaskClaimOptions().trackTaskExecution('task-1', new Promise(() => {}));
+  coordinator.beginShutdown('SIGTERM');
+
+  await coordinator.shutdown(createActivityGatewayClient(), {
+    executions: {
+      ActiveTaskExecutionController_stopTaskExecution: async ({ executionId }: { executionId: string }) => {
+        stoppedExecutionId = executionId;
+        return { status: 'CANCELLED' };
+      },
+    },
+  } as any);
+
+  assert.equal(executionAbortController.signal.aborted, true);
+  assert.equal(interruptCalls, 1);
+  assert.equal(stoppedExecutionId, 'execution-1');
+
+  activeExecutionAbortControllers.clear();
+  activeExecutionInterruptHandlers.clear();
+});
+
+function createQueueClient(taskIds: string[]) {
+  const client = {
+    listQueueCalls: 0,
+    executions: {
+      TaskExecutionQueueController_listQueue: async () => {
+        client.listQueueCalls += 1;
+        return {
+          total: taskIds.length,
+          items: taskIds.map((taskId) => ({ taskId })),
+        };
+      },
+    },
+  };
+
+  return client as any;
+}
+
+function createActivityGatewayClient() {
+  return {
+    stop: async () => {},
+  } as any;
+}


### PR DESCRIPTION
## Summary
- Add worker SIGTERM/SIGINT coordination with configurable WORKER_SHUTDOWN_GRACE_MS defaulting to 60000ms.
- Make task polling abortable and gate queue notifications/polling so shutdown does not claim new work.
- Stop the execution activity gateway, drain active executions, and interrupt/mark active executions cancelled after the grace deadline.
- Add worker node:test coverage for abortable polling, claim gating, gateway stop, drain, and cancel-after-grace behavior.

## Validation
- npm -w apps/worker run test
- npm -w apps/worker run build
- npm run build:dev
- npm run dev:1 (bounded startup smoke; app reached Nest application successfully started and http://localhost:2003, then timeout terminated dev servers)

## Technical debt
- None known.