### PR TITLE
Harden backend shutdown drain

### DIFF
--- a/apps/backend/src/config/env.config.ts
+++ b/apps/backend/src/config/env.config.ts
@@ -24,6 +24,7 @@ export interface AppConfig {
   // Server Configuration
   port: number;
   nodeEnv: NodeEnv;
+  httpDrainTimeoutMs: number;
 
   // Authorization Server URLs
   issuerUrl: string;
@@ -69,6 +70,7 @@ export function loadConfig(): AppConfig {
     // Server Configuration
     port: parseInt(backendPortValue, 10),
     nodeEnv: getEnv(),
+    httpDrainTimeoutMs: getHttpDrainTimeoutMs(),
 
     // Authorization Server URLs
     issuerUrl: getIssuerUrl(),
@@ -126,6 +128,7 @@ export function loadConfig(): AppConfig {
   logger.log(`  - App Version: ${config.appVersion}`);
   logger.log(`  - Port: ${config.port}`);
   logger.log(`  - Node Environment: ${config.nodeEnv}`);
+  logger.log(`  - HTTP Drain Timeout Ms: ${config.httpDrainTimeoutMs}`);
   logger.log(`  - Issuer URL: ${config.issuerUrl}`);
   logger.log(`  - Callback URL: ${config.callbackUrl}`);
   logger.log(`  - Database Path: ${config.databasePath}`);
@@ -182,6 +185,14 @@ function getBackendPort(): string {
     return process.env.PORT;
   }
   return getEnv() === 'development' ? '3000' : '2000';
+}
+
+function getHttpDrainTimeoutMs(): number {
+  const parsed = parseInt(process.env.HTTP_DRAIN_TIMEOUT_MS || '20000', 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 20000;
+  }
+  return parsed;
 }
 
 function getTypeormSchemaMode(): TypeormSchemaMode {

--- a/apps/backend/src/executions/executions-worker.gateway.spec.ts
+++ b/apps/backend/src/executions/executions-worker.gateway.spec.ts
@@ -1,0 +1,51 @@
+jest.mock('@taico/events', () => ({
+  ExecutionWireEvents: {
+    WORKER_HARNESSES_REPORT_REQUESTED: 'worker:harnesses-report-requested',
+  },
+}));
+jest.mock('../auth/guards/guards/ws-access-token-guard', () => ({
+  WsAccessTokenGuard: class {},
+}));
+jest.mock('../auth/guards/guards/ws-scopes.guard', () => ({
+  WsScopesGuard: class {},
+}));
+jest.mock('../auth/guards/validation/access-token-validation.service', () => ({
+  AccessTokenValidationService: class {},
+}));
+
+import { ExecutionsWorkerGateway } from './executions-worker.gateway';
+
+describe('ExecutionsWorkerGateway shutdown', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('emits draining, disconnects worker sockets, and clears timers', async () => {
+    const gateway = new ExecutionsWorkerGateway({} as any, {} as any, {} as any);
+    const socket = { id: 'socket-1', disconnect: jest.fn() };
+    const emit = jest.fn();
+    const timer = setTimeout(() => undefined, 60_000);
+
+    (gateway as any).server = {
+      sockets: { sockets: new Map([['socket-1', socket]]) },
+      emit,
+    };
+    (gateway as any).socketExpiryTimers.set('socket-1', timer);
+    (gateway as any).harnessReportRequestedSocketIds.add('socket-1');
+    (gateway as any).workerSocketsByClientId.set('worker-client', new Set(['socket-1']));
+
+    const shutdown = gateway.onApplicationShutdown('SIGTERM');
+    jest.advanceTimersByTime(1_000);
+    await shutdown;
+
+    expect(emit).toHaveBeenCalledWith('server:draining', { signal: 'SIGTERM' });
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+    expect((gateway as any).socketExpiryTimers.size).toBe(0);
+    expect((gateway as any).harnessReportRequestedSocketIds.size).toBe(0);
+    expect((gateway as any).workerSocketsByClientId.size).toBe(0);
+  });
+});

--- a/apps/backend/src/executions/executions-worker.gateway.ts
+++ b/apps/backend/src/executions/executions-worker.gateway.ts
@@ -1,4 +1,9 @@
 import {
+  Logger,
+  OnApplicationShutdown,
+  UseGuards,
+} from '@nestjs/common';
+import {
   ConnectedSocket,
   MessageBody,
   OnGatewayConnection,
@@ -8,8 +13,7 @@ import {
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
-import { Logger, UseGuards } from '@nestjs/common';
-import { Server, Socket } from 'socket.io';
+import { Namespace, Server, Socket } from 'socket.io';
 import * as cookie from 'cookie';
 import { OnEvent } from '@nestjs/event-emitter';
 import {
@@ -35,6 +39,8 @@ import { TaskExecutionQueuedEvent } from './queue/task-execution-queued.event';
 import { ExecutionInterruptEvent } from './events/execution-interrupt.event';
 
 const SOCKET_AUTH_EXPIRY_SKEW_MS = 1_000;
+const WORKER_SOCKET_DRAIN_EVENT = 'server:draining';
+const WORKER_SOCKET_DRAIN_DISCONNECT_DELAY_MS = 1_000;
 
 @UseGuards(WsAccessTokenGuard, WsScopesGuard)
 @RequireScopes(WorkersScopes.CONNECT.id)
@@ -45,10 +51,14 @@ const SOCKET_AUTH_EXPIRY_SKEW_MS = 1_000;
   namespace: '/executions/worker',
 })
 export class ExecutionsWorkerGateway
-  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+  implements
+    OnGatewayInit,
+    OnGatewayConnection,
+    OnGatewayDisconnect,
+    OnApplicationShutdown
 {
   @WebSocketServer()
-  server!: Server;
+  server!: Namespace | Server;
 
   private readonly logger = new Logger(ExecutionsWorkerGateway.name);
   private readonly socketExpiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -114,6 +124,37 @@ export class ExecutionsWorkerGateway
         }
       }
     }
+  }
+
+  async onApplicationShutdown(signal?: string): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    const sockets = this.getConnectedWorkerSockets();
+    if (sockets.length === 0) {
+      this.clearAllTokenExpiryDisconnects();
+      return;
+    }
+
+    this.logger.log(
+      `Draining ${sockets.length} worker WebSocket connection(s)${
+        signal ? ` for ${signal}` : ''
+      }`,
+    );
+    this.server.emit(WORKER_SOCKET_DRAIN_EVENT, { signal });
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, WORKER_SOCKET_DRAIN_DISCONNECT_DELAY_MS),
+    );
+
+    for (const client of sockets) {
+      client.disconnect(true);
+      this.clearTokenExpiryDisconnect(client.id);
+      this.harnessReportRequestedSocketIds.delete(client.id);
+    }
+    this.workerSocketsByClientId.clear();
+    this.clearAllTokenExpiryDisconnects();
   }
 
   @SubscribeMessage(ExecutionWireEvents.EXECUTION_ACTIVITY_POST)
@@ -224,6 +265,21 @@ export class ExecutionsWorkerGateway
     }
     clearTimeout(timer);
     this.socketExpiryTimers.delete(socketId);
+  }
+
+  private clearAllTokenExpiryDisconnects(): void {
+    for (const timer of this.socketExpiryTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.socketExpiryTimers.clear();
+  }
+
+  private getConnectedWorkerSockets(): Socket[] {
+    const socketContainer = this.server.sockets;
+    if (socketContainer instanceof Map) {
+      return [...socketContainer.values()];
+    }
+    return [...socketContainer.sockets.values()];
   }
 
   private async recordWorkerSeen(

--- a/apps/backend/src/http-drain.middleware.spec.ts
+++ b/apps/backend/src/http-drain.middleware.spec.ts
@@ -1,0 +1,61 @@
+import { EventEmitter } from 'events';
+import { createHttpDrainMiddleware, isHealthRequest } from './http-drain.middleware';
+import { ServerLifecycleService } from './server-lifecycle.service';
+
+describe('http drain middleware', () => {
+  let lifecycle: ServerLifecycleService;
+
+  beforeEach(() => {
+    lifecycle = new ServerLifecycleService();
+  });
+
+  it('identifies health requests', () => {
+    expect(isHealthRequest({ path: '/health/live' } as any)).toBe(true);
+    expect(isHealthRequest({ path: '/health/ready' } as any)).toBe(true);
+    expect(isHealthRequest({ path: '/api/v1/tasks' } as any)).toBe(false);
+  });
+
+  it('tracks accepted non-health requests until the response closes', () => {
+    const middleware = createHttpDrainMiddleware(lifecycle);
+    const res = new EventEmitter() as any;
+    const next = jest.fn();
+
+    middleware({ path: '/api/v1/tasks' } as any, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(lifecycle.getActiveRequestCount()).toBe(1);
+
+    res.emit('finish');
+
+    expect(lifecycle.getActiveRequestCount()).toBe(0);
+  });
+
+  it('rejects new non-health requests after shutdown starts', () => {
+    const middleware = createHttpDrainMiddleware(lifecycle);
+    const json = jest.fn();
+    const status = jest.fn(() => ({ json }));
+    const next = jest.fn();
+
+    lifecycle.beginShutdown('SIGTERM');
+    middleware({ path: '/api/v1/tasks' } as any, { status } as any, next);
+
+    expect(status).toHaveBeenCalledWith(503);
+    expect(json).toHaveBeenCalledWith({
+      statusCode: 503,
+      message: 'Server is shutting down',
+      error: 'Service Unavailable',
+    });
+    expect(next).not.toHaveBeenCalled();
+    expect(lifecycle.getActiveRequestCount()).toBe(0);
+  });
+
+  it('allows health requests after shutdown starts', () => {
+    const middleware = createHttpDrainMiddleware(lifecycle);
+    const next = jest.fn();
+
+    lifecycle.beginShutdown('SIGTERM');
+    middleware({ path: '/health/ready' } as any, {} as any, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/http-drain.middleware.ts
+++ b/apps/backend/src/http-drain.middleware.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Request, Response } from 'express';
+import { ServerLifecycleService } from './server-lifecycle.service';
+
+export function createHttpDrainMiddleware(lifecycle: ServerLifecycleService) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (isHealthRequest(req)) {
+      return next();
+    }
+
+    if (lifecycle.isShuttingDown()) {
+      return res.status(503).json({
+        statusCode: 503,
+        message: 'Server is shutting down',
+        error: 'Service Unavailable',
+      });
+    }
+
+    const release = lifecycle.trackRequest();
+    res.once('finish', release);
+    res.once('close', release);
+    return next();
+  };
+}
+
+export function isHealthRequest(req: Request): boolean {
+  return req.path === '/health/live' || req.path === '/health/ready';
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -12,6 +12,7 @@ import cookieParser from 'cookie-parser';
 import { getConfig } from './config/env.config';
 import { Request, Response } from 'express';
 import { ServerLifecycleService } from './server-lifecycle.service';
+import { createHttpDrainMiddleware } from './http-drain.middleware';
 
 const logger = new Logger('Bootstrap');
 
@@ -99,6 +100,7 @@ async function createConfiguredApp(
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   app.use(cookieParser());
+  app.use(createHttpDrainMiddleware(app.get(ServerLifecycleService)));
   app.enableCors({
     origin: true,
     credentials: true,

--- a/apps/backend/src/server-lifecycle.service.spec.ts
+++ b/apps/backend/src/server-lifecycle.service.spec.ts
@@ -58,4 +58,33 @@ describe('ServerLifecycleService', () => {
 
     expect(probe.observedReadyDuringModuleDestroy).toBe(false);
   });
+
+  it('tracks active requests until they release', () => {
+    const releaseFirst = service.trackRequest();
+    const releaseSecond = service.trackRequest();
+
+    expect(service.getActiveRequestCount()).toBe(2);
+
+    releaseFirst();
+    releaseFirst();
+    expect(service.getActiveRequestCount()).toBe(1);
+
+    releaseSecond();
+    expect(service.getActiveRequestCount()).toBe(0);
+  });
+
+  it('waits for active requests to drain', async () => {
+    const release = service.trackRequest();
+    const drained = service.waitForRequestsToDrain(100);
+
+    release();
+
+    await expect(drained).resolves.toBe(true);
+  });
+
+  it('times out when active requests do not drain', async () => {
+    service.trackRequest();
+
+    await expect(service.waitForRequestsToDrain(1)).resolves.toBe(false);
+  });
 });

--- a/apps/backend/src/server-lifecycle.service.ts
+++ b/apps/backend/src/server-lifecycle.service.ts
@@ -5,6 +5,7 @@ import {
   OnApplicationShutdown,
   OnModuleDestroy,
 } from '@nestjs/common';
+import { getConfig } from './config/env.config';
 
 @Injectable()
 export class ServerLifecycleService
@@ -14,6 +15,8 @@ export class ServerLifecycleService
   private shuttingDown = false;
   private shutdownStartedAt: number | null = null;
   private shutdownSignal: string | undefined;
+  private activeRequestCount = 0;
+  private drainWaiters: Array<() => void> = [];
 
   isShuttingDown(): boolean {
     return this.shuttingDown;
@@ -40,12 +43,62 @@ export class ServerLifecycleService
     return true;
   }
 
+  trackRequest(): () => void {
+    this.activeRequestCount += 1;
+    let released = false;
+
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.activeRequestCount -= 1;
+      if (this.activeRequestCount === 0) {
+        this.resolveDrainWaiters();
+      }
+    };
+  }
+
+  getActiveRequestCount(): number {
+    return this.activeRequestCount;
+  }
+
+  async waitForRequestsToDrain(timeoutMs: number): Promise<boolean> {
+    if (this.activeRequestCount === 0) {
+      return true;
+    }
+
+    this.logger.log(
+      `Waiting up to ${timeoutMs}ms for ${this.activeRequestCount} active HTTP request(s) to drain`,
+    );
+
+    return new Promise<boolean>((resolve) => {
+      const complete = (drained: boolean) => {
+        clearTimeout(timeout);
+        this.drainWaiters = this.drainWaiters.filter(
+          (waiter) => waiter !== onDrain,
+        );
+        if (!drained) {
+          this.logger.warn(
+            `HTTP drain timed out with ${this.activeRequestCount} active request(s) remaining`,
+          );
+        }
+        resolve(drained);
+      };
+
+      const onDrain = () => complete(true);
+      const timeout = setTimeout(() => complete(false), timeoutMs);
+      this.drainWaiters.push(onDrain);
+    });
+  }
+
   onModuleDestroy(): void {
     this.beginShutdown();
   }
 
-  beforeApplicationShutdown(signal?: string): void {
+  async beforeApplicationShutdown(signal?: string): Promise<void> {
     this.beginShutdown(signal);
+    await this.waitForRequestsToDrain(getConfig().httpDrainTimeoutMs);
   }
 
   onApplicationShutdown(signal?: string): void {
@@ -61,5 +114,13 @@ export class ServerLifecycleService
 
   private formatSignal(signal?: string): string {
     return signal ? ` for ${signal}` : '';
+  }
+
+  private resolveDrainWaiters(): void {
+    const waiters = this.drainWaiters;
+    this.drainWaiters = [];
+    for (const waiter of waiters) {
+      waiter();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add lifecycle-owned HTTP request tracking and shutdown drain waiting with configurable HTTP_DRAIN_TIMEOUT_MS defaulting to 20s
- Reject new non-health HTTP requests with 503 once shutdown starts while keeping health endpoints available
- Drain worker execution WebSockets on application shutdown by emitting a draining event, disconnecting sockets after a short delay, and clearing socket timers
- Add focused backend tests for HTTP drain tracking/rejection and worker gateway shutdown cleanup

## Validation
- npm run build:dev
- npm -w apps/backend run test -- server-lifecycle.service.spec.ts http-drain.middleware.spec.ts executions-worker.gateway.spec.ts --runInBand
- timeout 30s npm run dev:1

## Technical debt
- The worker socket draining event is currently a local string event (server:draining), not yet part of @taico/events. It can be promoted to a shared contract if clients start consuming it explicitly.