### PR TITLE
Bind downstream token exchange to MCP grant

### DIFF
--- a/apps/backend/src/auth/core/types/access-token-claims.type.ts
+++ b/apps/backend/src/auth/core/types/access-token-claims.type.ts
@@ -59,6 +59,16 @@ export interface AccessTokenClaims {
   client_id: string;
 
   /**
+   * Authorization journey that minted this token.
+   */
+  authorization_journey_id?: string;
+
+  /**
+   * MCP authorization flow that minted this token.
+   */
+  mcp_authorization_flow_id?: string;
+
+  /**
    * Scopes granted to the client, stored as individual scope strings
    */
   scope: string[];

--- a/apps/backend/src/authorization-server/token-exchange.service.spec.ts
+++ b/apps/backend/src/authorization-server/token-exchange.service.spec.ts
@@ -1,18 +1,26 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { Repository } from 'typeorm';
-import {
-  NotFoundException,
-  ForbiddenException,
-  UnauthorizedException,
-} from '@nestjs/common';
+
+jest.mock('../mcp-registry/mcp-registry.service', () => ({
+  McpRegistryService: class McpRegistryService {},
+}));
+
+jest.mock('src/auth/crypto/token-verifier.service', () => ({
+  TokenVerifierService: class TokenVerifierService {},
+}));
+
 import { TokenExchangeService } from './token-exchange.service';
 import { McpConnectionEntity } from '../mcp-registry/entities/mcp-connection.entity';
 import { McpScopeMappingEntity } from '../mcp-registry/entities/mcp-scope-mapping.entity';
 import { ConnectionAuthorizationFlowEntity } from '../auth-journeys/entities/connection-authorization-flow.entity';
-import { JwksService } from '../auth/crypto/jwks.service';
 import { TokenExchangeRequestDto } from './dto/token-exchange-request.dto';
 import { ConnectionAuthorizationFlowStatus } from 'src/auth-journeys/enums/connection-authorization-flow-status.enum';
+import { McpRegistryService } from '../mcp-registry/mcp-registry.service';
+import { TokenVerifierService } from 'src/auth/crypto/token-verifier.service';
+import { AccessTokenClaims } from 'src/auth/core/types/access-token-claims.type';
+import { ActorType } from 'src/identity-provider/enums';
 
 describe('TokenExchangeService', () => {
   let service: TokenExchangeService;
@@ -21,33 +29,77 @@ describe('TokenExchangeService', () => {
   let connectionAuthorizationFlowRepository: jest.Mocked<
     Repository<ConnectionAuthorizationFlowEntity>
   >;
-  let jwksService: jest.Mocked<JwksService>;
+  let mcpRegistryService: jest.Mocked<McpRegistryService>;
+  let tokenVerifierService: jest.Mocked<TokenVerifierService>;
+  let queryBuilder: {
+    innerJoin: jest.Mock;
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    take: jest.Mock;
+    getMany: jest.Mock;
+  };
 
   const mockConnection: McpConnectionEntity = {
     id: 'connection-uuid',
     serverId: 'server-uuid',
     friendlyName: 'Test Connection',
     providedId: 'test-connection',
-    clientId: 'test-client-id',
-    clientSecret: 'test-client-secret',
+    clientId: 'downstream-client-id',
+    clientSecret: 'downstream-client-secret',
     authorizeUrl: 'https://example.com/authorize',
     tokenUrl: 'https://example.com/token',
     createdAt: new Date(),
     updatedAt: new Date(),
   } as McpConnectionEntity;
 
+  const mockClaims: AccessTokenClaims = {
+    iss: 'https://issuer.example.com',
+    sub: 'actor-uuid',
+    actor_id: 'actor-uuid',
+    actor_slug: 'actor',
+    actor_type: ActorType.HUMAN,
+    aud: 'test-server',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    iat: Math.floor(Date.now() / 1000),
+    jti: 'token-id',
+    client_id: 'registered-client-id',
+    authorization_journey_id: 'journey-uuid',
+    mcp_authorization_flow_id: 'mcp-flow-uuid',
+    scope: ['tasks:read'],
+    mcp_server_identifier: 'test-server',
+    resource: 'resource-uri',
+    version: '1.0.0',
+  };
+
   const mockAuthFlow: ConnectionAuthorizationFlowEntity = {
     id: 'flow-uuid',
+    authorizationJourneyId: 'journey-uuid',
     mcpConnectionId: 'connection-uuid',
     status: ConnectionAuthorizationFlowStatus.AUTHORIZED,
     accessToken: 'downstream-access-token',
     refreshToken: 'downstream-refresh-token',
-    tokenExpiresAt: new Date(Date.now() + 3600000), // 1 hour from now
+    tokenExpiresAt: new Date(Date.now() + 3600000),
     createdAt: new Date(),
     updatedAt: new Date(),
   } as ConnectionAuthorizationFlowEntity;
 
+  const request: TokenExchangeRequestDto = {
+    grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+    subject_token: 'mcp-jwt',
+    subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+    resource: 'test-connection',
+    scope: 'downstream.scope',
+  };
+
   beforeEach(async () => {
+    queryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([mockAuthFlow]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TokenExchangeService,
@@ -66,14 +118,20 @@ describe('TokenExchangeService', () => {
         {
           provide: getRepositoryToken(ConnectionAuthorizationFlowEntity),
           useValue: {
-            findOne: jest.fn(),
+            createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
             save: jest.fn(),
           },
         },
         {
-          provide: JwksService,
+          provide: McpRegistryService,
           useValue: {
-            getPublicKeys: jest.fn(),
+            resolveServerIdFromProvidedId: jest.fn(),
+          },
+        },
+        {
+          provide: TokenVerifierService,
+          useValue: {
+            verifyAndDecode: jest.fn(),
           },
         },
       ],
@@ -89,250 +147,178 @@ describe('TokenExchangeService', () => {
     connectionAuthorizationFlowRepository = module.get(
       getRepositoryToken(ConnectionAuthorizationFlowEntity),
     );
-    jwksService = module.get(JwksService);
+    mcpRegistryService = module.get(McpRegistryService);
+    tokenVerifierService = module.get(TokenVerifierService);
+
+    mcpRegistryService.resolveServerIdFromProvidedId.mockResolvedValue(
+      'server-uuid',
+    );
+    tokenVerifierService.verifyAndDecode.mockResolvedValue(mockClaims);
+    mcpConnectionRepository.findOne.mockResolvedValue(mockConnection);
+    mcpScopeMappingRepository.find.mockResolvedValue([
+      {
+        id: 'mapping-1',
+        scopeId: 'tasks:read',
+        connectionId: 'connection-uuid',
+        serverId: 'server-uuid',
+        downstreamScope: 'downstream.scope',
+      } as McpScopeMappingEntity,
+    ]);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('returns a downstream token when connection and grant bindings match', async () => {
+    const result = await service.exchangeToken(request, 'test-server');
+
+    expect(result.access_token).toBe('downstream-access-token');
+    expect(queryBuilder.getMany).toHaveBeenCalledTimes(1);
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'connectionFlow.authorizationJourneyId = :authorizationJourneyId',
+      { authorizationJourneyId: 'journey-uuid' },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'authJourney.actorId = :actorId',
+      { actorId: 'actor-uuid' },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'mcpFlow.id = :mcpAuthorizationFlowId',
+      { mcpAuthorizationFlowId: 'mcp-flow-uuid' },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'client.clientId = :clientId',
+      { clientId: 'registered-client-id' },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'mcpFlow.resource = :resource',
+      { resource: 'resource-uri' },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'server.providedId = :serverIdentifier',
+      { serverIdentifier: 'test-server' },
+    );
+    expect(queryBuilder.take).toHaveBeenCalledWith(2);
   });
 
-  describe('exchangeToken - validation', () => {
-    it('should throw NotFoundException when connection is not found', async () => {
-      const request: TokenExchangeRequestDto = {
-        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
-        subject_token: 'invalid-jwt',
-        subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
-        resource: 'non-existent-connection',
-      };
+  it.each([
+    [
+      'different actor',
+      { sub: 'other-actor' },
+      'authJourney.actorId = :actorId',
+      { actorId: 'other-actor' },
+    ],
+    [
+      'different client',
+      { client_id: 'other-client' },
+      'client.clientId = :clientId',
+      { clientId: 'other-client' },
+    ],
+    [
+      'different authorization journey',
+      { authorization_journey_id: 'other-journey' },
+      'connectionFlow.authorizationJourneyId = :authorizationJourneyId',
+      { authorizationJourneyId: 'other-journey' },
+    ],
+    [
+      'different MCP authorization flow',
+      { mcp_authorization_flow_id: 'other-flow' },
+      'mcpFlow.id = :mcpAuthorizationFlowId',
+      { mcpAuthorizationFlowId: 'other-flow' },
+    ],
+    [
+      'different resource',
+      { resource: 'other-resource' },
+      'mcpFlow.resource = :resource',
+      { resource: 'other-resource' },
+    ],
+  ])(
+    'rejects when the only downstream grant has a %s',
+    async (_label, claimPatch, predicate, params) => {
+      tokenVerifierService.verifyAndDecode.mockResolvedValue({
+        ...mockClaims,
+        ...claimPatch,
+      });
+      queryBuilder.getMany.mockResolvedValue([]);
 
-      mcpConnectionRepository.findOne.mockResolvedValue(null);
-      jwksService.getPublicKeys.mockResolvedValue([
-        {
-          kid: 'test-key',
-          kty: 'RSA',
-          alg: 'RS256',
-          use: 'sig',
-          n: 'test-n',
-          e: 'test-e',
-        },
-      ] as any);
-
-      // This will fail at JWT validation, but testing the flow
       await expect(
         service.exchangeToken(request, 'test-server'),
       ).rejects.toThrow(UnauthorizedException);
-    });
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(predicate, params);
+    },
+  );
 
-    it('should throw ForbiddenException when requested scope is not entitled', async () => {
-      // This test would require mocking the entire JWT validation flow
-      // Skipping for now as it requires complex jose library mocking
-      expect(true).toBe(true);
-    });
+  it('rejects when no bound downstream flow matches', async () => {
+    queryBuilder.getMany.mockResolvedValue([]);
+
+    await expect(service.exchangeToken(request, 'test-server')).rejects.toThrow(
+      UnauthorizedException,
+    );
   });
 
-  describe('scope resolution', () => {
-    it('should resolve downstream scopes from MCP scopes', async () => {
-      const mockMappings: McpScopeMappingEntity[] = [
-        {
-          id: 'mapping-1',
-          scopeId: 'tasks:read',
-          connectionId: 'connection-uuid',
-          serverId: 'server-uuid',
-          downstreamScope: 'https://www.googleapis.com/auth/tasks.readonly',
-        } as McpScopeMappingEntity,
-        {
-          id: 'mapping-2',
-          scopeId: 'tasks:write',
-          connectionId: 'connection-uuid',
-          serverId: 'server-uuid',
-          downstreamScope: 'https://www.googleapis.com/auth/tasks',
-        } as McpScopeMappingEntity,
-      ];
+  it('rejects ambiguous downstream grant matches', async () => {
+    queryBuilder.getMany.mockResolvedValue([mockAuthFlow, mockAuthFlow]);
 
-      mcpScopeMappingRepository.find.mockResolvedValue(mockMappings);
-
-      // Using reflection to access private method for testing
-      const resolveMethod = (service as any).resolveDownstreamScopes.bind(
-        service,
-      );
-      const result = await resolveMethod(
-        ['tasks:read', 'tasks:write'],
-        'connection-uuid',
-      );
-
-      expect(result).toEqual([
-        'https://www.googleapis.com/auth/tasks.readonly',
-        'https://www.googleapis.com/auth/tasks',
-      ]);
-    });
-
-    it('should remove duplicate downstream scopes', async () => {
-      const mockMappings: McpScopeMappingEntity[] = [
-        {
-          id: 'mapping-1',
-          scopeId: 'tasks:read',
-          connectionId: 'connection-uuid',
-          serverId: 'server-uuid',
-          downstreamScope: 'https://www.googleapis.com/auth/tasks',
-        } as McpScopeMappingEntity,
-        {
-          id: 'mapping-2',
-          scopeId: 'tasks:write',
-          connectionId: 'connection-uuid',
-          serverId: 'server-uuid',
-          downstreamScope: 'https://www.googleapis.com/auth/tasks',
-        } as McpScopeMappingEntity,
-      ];
-
-      mcpScopeMappingRepository.find.mockResolvedValue(mockMappings);
-
-      const resolveMethod = (service as any).resolveDownstreamScopes.bind(
-        service,
-      );
-      const result = await resolveMethod(
-        ['tasks:read', 'tasks:write'],
-        'connection-uuid',
-      );
-
-      expect(result).toEqual(['https://www.googleapis.com/auth/tasks']);
-      expect(result.length).toBe(1);
-    });
+    await expect(service.exchangeToken(request, 'test-server')).rejects.toThrow(
+      UnauthorizedException,
+    );
   });
 
-  describe('scope validation', () => {
-    it('should allow subset of entitled scopes', () => {
-      const validateMethod = (service as any).validateScopeEntitlement.bind(
-        service,
-      );
-      const requestedScopes = ['scope1'];
-      const entitledScopes = ['scope1', 'scope2', 'scope3'];
+  it('refreshes only after selecting the bound downstream flow', async () => {
+    const expiringAuthFlow = {
+      ...mockAuthFlow,
+      tokenExpiresAt: new Date(Date.now() + 60 * 1000),
+    } as ConnectionAuthorizationFlowEntity;
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: 'refreshed-downstream-access-token',
+        expires_in: 3600,
+      }),
+    } as Response);
+    queryBuilder.getMany.mockResolvedValue([expiringAuthFlow]);
 
-      expect(() =>
-        validateMethod(requestedScopes, entitledScopes),
-      ).not.toThrow();
-    });
+    const result = await service.exchangeToken(request, 'test-server');
 
-    it('should throw ForbiddenException for scope escalation', () => {
-      const validateMethod = (service as any).validateScopeEntitlement.bind(
-        service,
-      );
-      const requestedScopes = ['scope1', 'scope2', 'scope-not-entitled'];
-      const entitledScopes = ['scope1', 'scope2'];
+    expect(result.access_token).toBe('refreshed-downstream-access-token');
+    expect(connectionAuthorizationFlowRepository.save).toHaveBeenCalledWith(
+      expiringAuthFlow,
+    );
+    expect(expiringAuthFlow.accessToken).toBe(
+      'refreshed-downstream-access-token',
+    );
 
-      expect(() => validateMethod(requestedScopes, entitledScopes)).toThrow(
-        ForbiddenException,
-      );
-    });
-
-    it('should allow empty requested scopes', () => {
-      const validateMethod = (service as any).validateScopeEntitlement.bind(
-        service,
-      );
-      const requestedScopes: string[] = [];
-      const entitledScopes = ['scope1', 'scope2'];
-
-      expect(() =>
-        validateMethod(requestedScopes, entitledScopes),
-      ).not.toThrow();
-    });
+    fetchMock.mockRestore();
   });
 
-  describe('connection lookup', () => {
-    it('should find connection by UUID', async () => {
-      mcpConnectionRepository.findOne.mockResolvedValue(mockConnection);
-
-      const findMethod = (service as any).findConnection.bind(service);
-      const result = await findMethod('connection-uuid', 'server-uuid');
-
-      expect(result).toEqual(mockConnection);
-      expect(mcpConnectionRepository.findOne).toHaveBeenCalledWith({
-        where: { id: 'connection-uuid', serverId: 'server-uuid' },
-      });
+  it('rejects tokens missing grant-binding claims', async () => {
+    tokenVerifierService.verifyAndDecode.mockResolvedValue({
+      ...mockClaims,
+      authorization_journey_id: undefined,
     });
 
-    it('should find connection by providedId', async () => {
-      mcpConnectionRepository.findOne
-        .mockResolvedValueOnce(null) // First call with UUID fails
-        .mockResolvedValueOnce(mockConnection); // Second call with providedId succeeds
-
-      const findMethod = (service as any).findConnection.bind(service);
-      const result = await findMethod('test-connection', 'server-uuid');
-
-      expect(result).toEqual(mockConnection);
-      expect(mcpConnectionRepository.findOne).toHaveBeenCalledTimes(2);
-    });
-
-    it('should return null when connection is not found', async () => {
-      mcpConnectionRepository.findOne.mockResolvedValue(null);
-
-      const findMethod = (service as any).findConnection.bind(service);
-      const result = await findMethod('non-existent', 'server-uuid');
-
-      expect(result).toBeNull();
-    });
+    await expect(service.exchangeToken(request, 'test-server')).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(
+      connectionAuthorizationFlowRepository.createQueryBuilder,
+    ).not.toHaveBeenCalled();
   });
 
-  describe('UUID validation', () => {
-    it('should identify valid UUIDs', () => {
-      const isUuidMethod = (service as any).isUuid.bind(service);
-
-      expect(isUuidMethod('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
-      expect(isUuidMethod('123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+  it('rejects array audiences even when they include the expected server', async () => {
+    tokenVerifierService.verifyAndDecode.mockResolvedValue({
+      ...mockClaims,
+      aud: ['test-server'],
     });
 
-    it('should reject invalid UUIDs', () => {
-      const isUuidMethod = (service as any).isUuid.bind(service);
-
-      expect(isUuidMethod('test-connection')).toBe(false);
-      expect(isUuidMethod('not-a-uuid')).toBe(false);
-      expect(isUuidMethod('123456')).toBe(false);
-      expect(isUuidMethod('')).toBe(false);
-    });
+    await expect(service.exchangeToken(request, 'test-server')).rejects.toThrow(
+      UnauthorizedException,
+    );
   });
 
-  describe('expires_in calculation', () => {
-    it('should calculate correct expires_in from future date', () => {
-      const calculateMethod = (service as any).calculateExpiresIn.bind(service);
-      const futureDate = new Date(Date.now() + 3600000); // 1 hour from now
-
-      const result = calculateMethod(futureDate);
-
-      expect(result).toBeGreaterThan(3590); // Allow some time for test execution
-      expect(result).toBeLessThanOrEqual(3600);
-    });
-
-    it('should return 0 for past dates', () => {
-      const calculateMethod = (service as any).calculateExpiresIn.bind(service);
-      const pastDate = new Date(Date.now() - 3600000); // 1 hour ago
-
-      const result = calculateMethod(pastDate);
-
-      expect(result).toBe(0);
-    });
-
-    it('should return default 3600 when no expiration date provided', () => {
-      const calculateMethod = (service as any).calculateExpiresIn.bind(service);
-
-      const result = calculateMethod(undefined);
-
-      expect(result).toBe(3600);
-    });
-  });
-
-  describe('token refresh', () => {
-    it('should throw UnauthorizedException when no refresh token available', async () => {
-      const authFlowWithoutRefreshToken = {
-        ...mockAuthFlow,
-        refreshToken: undefined,
-      };
-
-      const refreshMethod = (service as any).refreshDownstreamToken.bind(
-        service,
-      );
-
-      await expect(
-        refreshMethod(authFlowWithoutRefreshToken, mockConnection),
-      ).rejects.toThrow(UnauthorizedException);
-    });
+  it('throws ForbiddenException when requested scope is not entitled', async () => {
+    await expect(
+      service.exchangeToken(
+        { ...request, scope: 'other.scope' },
+        'test-server',
+      ),
+    ).rejects.toThrow(ForbiddenException);
   });
 });

--- a/apps/backend/src/authorization-server/token-exchange.service.ts
+++ b/apps/backend/src/authorization-server/token-exchange.service.ts
@@ -12,12 +12,10 @@ import { McpConnectionEntity } from '../mcp-registry/entities/mcp-connection.ent
 import { McpScopeMappingEntity } from '../mcp-registry/entities/mcp-scope-mapping.entity';
 import { ConnectionAuthorizationFlowEntity } from '../auth-journeys/entities/connection-authorization-flow.entity';
 import { McpRegistryService } from '../mcp-registry/mcp-registry.service';
-import { JwksService } from '../auth/crypto/jwks.service';
 import { TokenExchangeRequestDto } from './dto/token-exchange-request.dto';
 import { TokenExchangeResponseDto } from './dto/token-exchange-response.dto';
 import { AccessTokenClaims } from 'src/auth/core/types/access-token-claims.type';
 import { TokenVerifierService } from 'src/auth/crypto/token-verifier.service';
-import { AuthJourneyStatus } from 'src/auth-journeys/enums/auth-journey-status.enum';
 import { ConnectionAuthorizationFlowStatus } from 'src/auth-journeys/enums/connection-authorization-flow-status.enum';
 
 interface DownstreamTokenInfo {
@@ -92,8 +90,8 @@ export class TokenExchangeService {
     // Step 7: Get or refresh downstream token
     const downstreamToken = await this.getDownstreamToken(
       connection,
-      mcpTokenPayload.client_id,
-      requestedScopes,
+      mcpTokenPayload,
+      serverIdentifier,
     );
 
     // Step 8: Return RFC 8693 response
@@ -120,12 +118,22 @@ export class TokenExchangeService {
       throw new UnauthorizedException('Token validation failed');
     }
 
-    // Additional checks: audience
     if (claims.aud !== expectedAudience) {
       this.logger.warn(
         `MCP JWT audience mismatch: expected ${expectedAudience}, got ${claims.aud}`,
       );
       throw new UnauthorizedException('MCP JWT audience mismatch');
+    }
+
+    if (
+      !claims.sub ||
+      !claims.client_id ||
+      !claims.resource ||
+      !claims.authorization_journey_id ||
+      !claims.mcp_authorization_flow_id
+    ) {
+      this.logger.warn('MCP JWT missing required grant-binding claims');
+      throw new UnauthorizedException('MCP JWT missing required claims');
     }
 
     return claims;
@@ -211,26 +219,46 @@ export class TokenExchangeService {
    */
   private async getDownstreamToken(
     connection: McpConnectionEntity,
-    clientId: string,
-    requestedScopes: string[],
+    claims: AccessTokenClaims,
+    serverIdentifier: string,
   ): Promise<DownstreamTokenInfo> {
-    // Find the authorization flow for this connection + client
-    const authFlow = await this.connectionAuthorizationFlowRepository.findOne({
-      where: {
-        mcpConnectionId: connection.id,
+    const authFlows = await this.connectionAuthorizationFlowRepository
+      .createQueryBuilder('connectionFlow')
+      .innerJoin('connectionFlow.authJourney', 'authJourney')
+      .innerJoin('authJourney.mcpAuthorizationFlow', 'mcpFlow')
+      .innerJoin('mcpFlow.client', 'client')
+      .innerJoin('mcpFlow.server', 'server')
+      .where('connectionFlow.mcpConnectionId = :connectionId', {
+        connectionId: connection.id,
+      })
+      .andWhere('connectionFlow.status = :status', {
         status: ConnectionAuthorizationFlowStatus.AUTHORIZED,
-      },
-      relations: ['authJourney', 'authJourney.mcpAuthorizationFlow'],
-    });
+      })
+      .andWhere(
+        'connectionFlow.authorizationJourneyId = :authorizationJourneyId',
+        { authorizationJourneyId: claims.authorization_journey_id },
+      )
+      .andWhere('authJourney.actorId = :actorId', { actorId: claims.sub })
+      .andWhere('mcpFlow.id = :mcpAuthorizationFlowId', {
+        mcpAuthorizationFlowId: claims.mcp_authorization_flow_id,
+      })
+      .andWhere('client.clientId = :clientId', { clientId: claims.client_id })
+      .andWhere('mcpFlow.resource = :resource', { resource: claims.resource })
+      .andWhere('server.providedId = :serverIdentifier', { serverIdentifier })
+      .take(2)
+      .getMany();
 
-    if (!authFlow || !authFlow.accessToken) {
+    const [authFlow] = authFlows;
+    if (authFlows.length !== 1 || !authFlow?.accessToken) {
       this.logger.warn(
-        `No authorized connection found for connection: ${connection.id}`,
+        `No uniquely bound authorized connection found for connection: ${connection.id}`,
       );
       throw new UnauthorizedException(
         'No authorized connection found for this client',
       );
     }
+
+    const accessToken = authFlow.accessToken;
 
     // Check if token is valid (not expired, has required scopes)
     const now = new Date();
@@ -248,7 +276,7 @@ export class TokenExchangeService {
 
     // Token is valid
     return {
-      accessToken: authFlow.accessToken,
+      accessToken,
       expiresAt: authFlow.tokenExpiresAt,
     };
   }

--- a/apps/backend/src/authorization-server/token.service.spec.ts
+++ b/apps/backend/src/authorization-server/token.service.spec.ts
@@ -1,0 +1,180 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+jest.mock('../auth-journeys/auth-journeys.service', () => ({
+  AuthJourneysService: class AuthJourneysService {},
+}));
+
+jest.mock('../auth/crypto/token-verifier.service', () => ({
+  TokenVerifierService: class TokenVerifierService {},
+}));
+
+jest.mock('../auth/crypto/token-signer.service', () => ({
+  TokenSignerService: class TokenSignerService {},
+}));
+
+jest.mock('./errors/token.errors', () => {
+  class TokenTestError extends Error {}
+
+  return {
+    InvalidGrantTypeError: TokenTestError,
+    MissingRequiredParametersError: TokenTestError,
+    InvalidAuthorizationCodeError: TokenTestError,
+    ClientIdMismatchError: TokenTestError,
+    AuthorizationCodeUsedError: TokenTestError,
+    AuthorizationCodeExpiredError: TokenTestError,
+    RedirectUriMismatchError: TokenTestError,
+    MissingPkceParametersError: TokenTestError,
+    InvalidCodeVerifierError: TokenTestError,
+    InvalidRefreshTokenError: TokenTestError,
+    RefreshTokenExpiredError: TokenTestError,
+    RefreshTokenRevokedError: TokenTestError,
+  };
+});
+
+import { TokenService } from './token.service';
+import { AuthJourneysService } from '../auth-journeys/auth-journeys.service';
+import { TokenVerifierService } from '../auth/crypto/token-verifier.service';
+import { TokenSignerService } from '../auth/crypto/token-signer.service';
+import { McpRefreshTokenEntity } from './entities/mcp-refresh-token.entity';
+import { GrantType } from './enums/grant-type.enum';
+import { McpAuthorizationFlowEntity } from '../auth-journeys/entities';
+import { ActorType } from 'src/identity-provider/enums';
+import { AccessTokenClaims } from 'src/auth/core/types/access-token-claims.type';
+import { createHash } from 'crypto';
+
+describe('TokenService', () => {
+  let service: TokenService;
+  let authJourneysService: jest.Mocked<AuthJourneysService>;
+  let tokenSignerService: jest.Mocked<TokenSignerService>;
+  let refreshTokenRepository: jest.Mocked<Repository<McpRefreshTokenEntity>>;
+  let signedClaims: AccessTokenClaims[];
+
+  const codeVerifier = 'plain-code-verifier-with-enough-length-1234567890';
+
+  const mcpAuthFlow = {
+    id: 'mcp-flow-uuid',
+    authorizationJourneyId: 'journey-uuid',
+    authorizationCode: 'authorization-code',
+    authorizationCodeUsed: false,
+    authorizationCodeExpiresAt: new Date(Date.now() + 3600000),
+    codeChallenge: codeVerifier,
+    codeChallengeMethod: 'plain',
+    redirectUri: 'http://localhost:6274/oauth/callback/debug',
+    resource: 'resource-uri',
+    scopes: ['tasks:read'],
+    client: {
+      clientId: 'registered-client-id',
+      scopes: ['tasks:read'],
+    },
+    server: {
+      providedId: 'test-server',
+    },
+    authJourney: {
+      actorId: 'actor-uuid',
+      actor: {
+        id: 'actor-uuid',
+        slug: 'actor',
+        type: ActorType.HUMAN,
+        displayName: 'Test Actor',
+        user: {
+          email: 'actor@example.com',
+        },
+      },
+    },
+  } as McpAuthorizationFlowEntity;
+
+  beforeEach(async () => {
+    signedClaims = [];
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TokenService,
+        {
+          provide: AuthJourneysService,
+          useValue: {
+            findMcpAuthFlowByAuthorizationCode: jest.fn(),
+            saveMcpAuthFlow: jest.fn(),
+            updateAuthJourneyStatus: jest.fn(),
+          },
+        },
+        {
+          provide: TokenVerifierService,
+          useValue: {
+            verifyAndDecode: jest.fn(),
+          },
+        },
+        {
+          provide: TokenSignerService,
+          useValue: {
+            signToken: jest.fn().mockImplementation(async (claims) => {
+              signedClaims.push(claims);
+              return 'signed-access-token';
+            }),
+          },
+        },
+        {
+          provide: getRepositoryToken(McpRefreshTokenEntity),
+          useValue: {
+            create: jest.fn().mockImplementation((value) => value),
+            save: jest.fn().mockImplementation(async (value) => value),
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(TokenService);
+    authJourneysService = module.get(AuthJourneysService);
+    tokenSignerService = module.get(TokenSignerService);
+    refreshTokenRepository = module.get(
+      getRepositoryToken(McpRefreshTokenEntity),
+    );
+  });
+
+  it('includes grant-binding claims in authorization-code access tokens', async () => {
+    authJourneysService.findMcpAuthFlowByAuthorizationCode.mockResolvedValue({
+      ...mcpAuthFlow,
+    });
+
+    await service.handleTokenRequest({
+      grant_type: GrantType.AUTHORIZATION_CODE,
+      client_id: 'registered-client-id',
+      code: 'authorization-code',
+      redirect_uri: 'http://localhost:6274/oauth/callback/debug',
+      code_verifier: codeVerifier,
+    });
+
+    expect(tokenSignerService.signToken).toHaveBeenCalledTimes(1);
+    expect(signedClaims[0]).toMatchObject({
+      authorization_journey_id: 'journey-uuid',
+      mcp_authorization_flow_id: 'mcp-flow-uuid',
+    });
+  });
+
+  it('preserves grant-binding claims in refresh-token access tokens', async () => {
+    const refreshToken = 'refresh-token';
+    refreshTokenRepository.findOne.mockResolvedValue({
+      tokenHash: createHash('sha256').update(refreshToken).digest('hex'),
+      clientId: 'registered-client-id',
+      expiresAt: new Date(Date.now() + 3600000),
+      revokedAt: null,
+      mcpAuthorizationFlow: {
+        ...mcpAuthFlow,
+      },
+    } as McpRefreshTokenEntity);
+
+    await service.handleTokenRequest({
+      grant_type: GrantType.REFRESH_TOKEN,
+      client_id: 'registered-client-id',
+      refresh_token: refreshToken,
+    });
+
+    expect(tokenSignerService.signToken).toHaveBeenCalledTimes(1);
+    expect(signedClaims[0]).toMatchObject({
+      authorization_journey_id: 'journey-uuid',
+      mcp_authorization_flow_id: 'mcp-flow-uuid',
+    });
+  });
+});

--- a/apps/backend/src/authorization-server/token.service.ts
+++ b/apps/backend/src/authorization-server/token.service.ts
@@ -330,6 +330,8 @@ export class TokenService {
       iat: now,
       jti: randomBytes(16).toString('hex'), // Unique token ID
       client_id: mcpAuthFlow.client.clientId,
+      authorization_journey_id: mcpAuthFlow.authorizationJourneyId,
+      mcp_authorization_flow_id: mcpAuthFlow.id,
       scope: mcpAuthFlow.scopes || [], // Handle null scopes
       mcp_server_identifier: mcpAuthFlow.server.providedId,
       resource: mcpAuthFlow.resource || '',


### PR DESCRIPTION
## Summary
- Add MCP authorization journey and flow identifiers to issued access-token claims.
- Require token exchange subject tokens to carry the grant-binding claims and a strict single MCP-server audience.
- Replace downstream authorization lookup with an explicit joined query that must match connection, actor, client, journey, MCP flow, resource, server, and authorized status exactly once before returning or refreshing a downstream token.
- Update token exchange tests and add token service tests for authorization-code and refresh-token claim preservation.

## Validation
- npm -w apps/backend test -- token-exchange.service.spec.ts token.service.spec.ts --runInBand
- npm -w apps/backend run typecheck
- npm run build:dev
- timeout 35s npm run dev:1 (backend started successfully; expected AppInitRunner prompt context block error appeared)

## Technical Debt
- Provider-granted downstream scopes are still not persisted/enforced here; that remains for the sibling scope-persistence task.