### PR TITLE
Upgrade Gemini Flash backend model

### DIFF
--- a/apps/backend/src/app-init/models/models.ts
+++ b/apps/backend/src/app-init/models/models.ts
@@ -56,6 +56,6 @@ export const ANTHROPIC_CLAUDE: MODEL_CONFIG = {
 // Good for ADK runner
 export const GEMINI_FLASH: MODEL_CONFIG = {
   providerId: '',
-  modelId: 'gemini-2.5-flash',
+  modelId: 'gemini-3.6-flash',
   name: 'gemini',
 };

--- a/apps/backend/src/threads/backends/adk.backend.ts
+++ b/apps/backend/src/threads/backends/adk.backend.ts
@@ -53,7 +53,7 @@ export class AdkBackend implements ChatBackend, OnModuleDestroy {
       });
       const runner = await this.createRunner(
         args.token,
-        args.modelId ?? 'gemini-2.5-flash',
+        args.modelId ?? 'gemini-3.6-flash',
         instructions,
       );
       const stream = runner.runAsync({
@@ -122,7 +122,7 @@ export class AdkBackend implements ChatBackend, OnModuleDestroy {
 
       const agent = new LlmAgent({
         name: 'text_generator',
-        model: modelId ?? 'gemini-2.5-flash',
+        model: modelId ?? 'gemini-3.6-flash',
         description: '',
         instruction: '',
         tools: [],
@@ -181,7 +181,7 @@ export class AdkBackend implements ChatBackend, OnModuleDestroy {
 
     const runner = await this.createRunner(
       args.token,
-      args.modelId ?? 'gemini-2.5-flash',
+      args.modelId ?? 'gemini-3.6-flash',
       args.instructions,
     );
 

--- a/apps/worker-v1/src/runners/ADKAgentRunner.ts
+++ b/apps/worker-v1/src/runners/ADKAgentRunner.ts
@@ -71,7 +71,7 @@ export class ADKAgentRunner extends BaseAgentRunner {
 
   constructor(modelConfig: AgentModelConfig = {}) {
     super();
-    this.modelId = modelConfig.modelId ?? 'gemini-2.5-flash';
+    this.modelId = modelConfig.modelId ?? 'gemini-3.6-flash';
   }
 
   protected async runInternal(

--- a/apps/worker/src/runners/ADKAgentRunner.ts
+++ b/apps/worker/src/runners/ADKAgentRunner.ts
@@ -77,7 +77,7 @@ export class ADKAgentRunner extends BaseAgentRunner {
 
   constructor(modelConfig: AgentModelConfig = {}) {
     super();
-    this.modelId = modelConfig.modelId ?? 'gemini-2.5-flash';
+    this.modelId = modelConfig.modelId ?? 'gemini-3.6-flash';
   }
 
   override getModel() {

--- a/packages/adk-session-store/examples/basic.ts
+++ b/packages/adk-session-store/examples/basic.ts
@@ -3,7 +3,7 @@ import { SqliteSessionService } from '../src/index.js';
 
 const agent = new LlmAgent({
   name: 'assistant',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-3.6-flash',
   instruction: 'You are helpful.',
 });
 


### PR DESCRIPTION
## Summary
- Update backend Gemini seed/default model to gemini-3.6-flash
- Update thread ADK backend fallbacks for streaming, text generation, and task runs
- Update worker and legacy worker ADK runner defaults
- Update the ADK session store example model reference

## Validation
- npm run build:dev
- timeout 60s npm run dev:5, confirmed backend reached 'Nest application successfully started' on http://localhost:2016; existing AppInitRunner prompt-block startup error appeared before shutdown

## Technical debt
- Gemini defaults are duplicated across backend and worker packages; this PR keeps the model upgrade minimal rather than adding cross-package shared config.