### PR TITLE
Refine Taico task creation prompt

### DIFF
--- a/apps/backend/src/app-init/app-init.runner.ts
+++ b/apps/backend/src/app-init/app-init.runner.ts
@@ -18,7 +18,10 @@ import {
   AgentResult,
   CreateAgentInput,
 } from 'src/agents/dto/service/agents.service.types';
-import { AgentSlugConflictError } from 'src/agents/errors/agents.errors';
+import {
+  AgentNotFoundError,
+  AgentSlugConflictError,
+} from 'src/agents/errors/agents.errors';
 import { createContext, createContextScopes } from './mcp/context.mcp';
 import { getConfig } from 'src/config/env.config';
 import { devUser, devUserRole } from './user/dev.user';
@@ -174,7 +177,12 @@ export class AppInitRunner implements OnApplicationBootstrap {
   async ensureAgents() {
     // Create agents
     try {
-      await this.ensureAgentExists(createTaico);
+      const agent = await this.ensureAgentExists(createTaico);
+      if (agent && agent.systemPrompt !== createTaico.systemPrompt) {
+        await this.agentsService.patchAgent(agent.actorId, {
+          systemPrompt: createTaico.systemPrompt,
+        });
+      }
     } catch (error) {
       this.logger.error('Error ensuring taico Agent exists');
     }
@@ -279,14 +287,22 @@ export class AppInitRunner implements OnApplicationBootstrap {
   ): Promise<AgentResult | null> {
     let agent: AgentResult | null = null;
     try {
+      return await this.agentsService.getAgentBySlug({
+        slug: agentConfig.slug,
+      });
+    } catch (error) {
+      if (!(error instanceof AgentNotFoundError)) {
+        throw error;
+      }
+    }
+
+    try {
       agent = await this.agentsService.createAgent(agentConfig);
     } catch (error) {
       if (error instanceof AgentSlugConflictError) {
         agent = await this.agentsService.getAgentBySlug({
           slug: agentConfig.slug,
         });
-        // TODO: rework the update method
-        // agent = await this.agentsService.updateAgent(agent.id, createClaudeDev);
       } else {
         throw error;
       }

--- a/apps/backend/src/app-init/prompts/prompts.ts
+++ b/apps/backend/src/app-init/prompts/prompts.ts
@@ -305,6 +305,8 @@ Taico is a task execution platform where humans and AI agents collaborate on wor
 - **Tools** — MCP servers with full OAuth 2.1 auth that agents can call.
 
 You have tools available to interact with tasks and context and threads.
+
+If the user asks you to do work, create a task instead and attach it to the thread. Decide which agent should handle it. Before creating the task, briefly tell the user the task you plan to create and ask them to confirm.
 `;
 
 


### PR DESCRIPTION
## Summary
- Add concise guidance to the built-in Taico prompt for user work requests in threads
- Tell Taico to create and attach a task, choose the appropriate agent, and confirm the task with the user before creating it
- Reconcile the existing Taico agent prompt during app init so the prompt update takes effect on restart for existing installs
- Prefetch seeded agents by slug before create to avoid duplicate-slug init errors for existing seeded agents

## Validation
- npm run build:dev
- npm run dev:1 (startup verified; expected AppInitRunner prompt context block error appeared before successful startup)

## Technical Debt
- None