### PR TITLE
Rename mono theme to kindling

### DIFF
--- a/apps/ui/src/app/providers/ThemeProvider.tsx
+++ b/apps/ui/src/app/providers/ThemeProvider.tsx
@@ -10,7 +10,7 @@ export type Theme =
   | 'terminal'
   | 'ai-vibes'
   | 'halo'
-  | 'mono'
+  | 'kindling'
   | 'terminal-amber'
   | 'oceanic'
   | 'party'
@@ -30,7 +30,10 @@ export interface ThemeProviderProps {
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<Theme>(() => {
     // Try to load theme from localStorage
-    const stored = localStorage.getItem('theme') as Theme | null;
+    const stored = localStorage.getItem('theme') as Theme | 'mono' | null;
+    if (stored === 'mono') {
+      return 'kindling';
+    }
     return stored || 'light';
   });
 

--- a/apps/ui/src/features/home/settingsThemes.ts
+++ b/apps/ui/src/features/home/settingsThemes.ts
@@ -149,9 +149,9 @@ export const SETTINGS_THEME_OPTIONS: SettingsThemeOption[] = [
     },
   },
   {
-    value: 'mono',
-    label: 'Mono',
-    description: 'Black and white minimalism with restrained contrast.',
+    value: 'kindling',
+    label: 'Kindling',
+    description: 'Black and white minimalism inspired by e-reader focus.',
     preview: {
       background: '#ffffff',
       surface: '#f5f5f5',

--- a/apps/ui/src/ui/styles/tokens.css
+++ b/apps/ui/src/ui/styles/tokens.css
@@ -407,8 +407,8 @@
   --shadow-3: 0 8px 24px rgba(30, 36, 51, 0.18);
 }
 
-/* ===== MONO THEME (Black & white) ===== */
-[data-theme='mono'] {
+/* ===== KINDLING THEME (Black & white) ===== */
+[data-theme='kindling'] {
   /* Theme color values */
   --theme-bg: #ffffff;
   --theme-app-surface: #f0f0f0;


### PR DESCRIPTION
## Summary
- Rename the active UI black-and-white theme identifier from `mono` to `kindling`
- Update the settings label and description to the new Kindling name
- Migrate existing `localStorage.theme = mono` selections to `kindling` on load

## Validation
- `npm run build:dev`
- `npm run dev:1` startup observed; backend reached "Nest application successfully started". Expected AppInitRunner prompt-block error appeared during startup.

## Technical Debt
- None identified.