### PR TITLE
Add Socket badges to release packages

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,5 +1,7 @@
 # Backend
 
+[![Socket Badge](https://badge.socket.dev/npm/package/@taico/taico/0.3.4)](https://badge.socket.dev/npm/package/@taico/taico/0.3.4)
+
 NestJS backend for Taico.
 
 This app owns:

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,5 +1,7 @@
 # @taico/worker
 
+[![Socket Badge](https://badge.socket.dev/npm/package/@taico/worker/0.3.4)](https://badge.socket.dev/npm/package/@taico/worker/0.3.4)
+
 Runtime for the current Taico worker.
 
 The worker connects to an existing Taico server, claims eligible work, starts executions, prepares workspaces, and launches the configured agent runtime.

--- a/packages/adk-session-store/README.md
+++ b/packages/adk-session-store/README.md
@@ -1,5 +1,7 @@
 # @taico/adk-session-store
 
+[![Socket Badge](https://badge.socket.dev/npm/package/@taico/adk-session-store/0.3.4)](https://badge.socket.dev/npm/package/@taico/adk-session-store/0.3.4)
+
 SQLite-backed session storage for Google ADK.
 
 `SqliteSessionService` extends ADK `BaseSessionService` and is intended as a drop-in replacement for `InMemorySessionService` when you need persistence.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,3 @@
+# @taico/client
+
+[![Socket Badge](https://badge.socket.dev/npm/package/@taico/client/0.3.4)](https://badge.socket.dev/npm/package/@taico/client/0.3.4)

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,0 +1,3 @@
+# @taico/errors
+
+[![Socket Badge](https://badge.socket.dev/npm/package/@taico/errors/0.3.4)](https://badge.socket.dev/npm/package/@taico/errors/0.3.4)

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -1,0 +1,3 @@
+# @taico/events
+
+[![Socket Badge](https://badge.socket.dev/npm/package/@taico/events/0.3.4)](https://badge.socket.dev/npm/package/@taico/events/0.3.4)

--- a/packages/openapi-sdkgen/README.md
+++ b/packages/openapi-sdkgen/README.md
@@ -1,5 +1,7 @@
 # @taico/openapi-sdkgen
 
+[![Socket Badge](https://badge.socket.dev/npm/package/@taico/openapi-sdkgen/0.3.4)](https://badge.socket.dev/npm/package/@taico/openapi-sdkgen/0.3.4)
+
 A TypeScript SDK generator from OpenAPI specs with focus on developer ergonomics and maintainability.
 
 ## Install

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,3 @@
+# @taico/shared
+
+[![Socket Badge](https://badge.socket.dev/npm/package/@taico/shared/0.3.4)](https://badge.socket.dev/npm/package/@taico/shared/0.3.4)

--- a/scripts/release-taico.mjs
+++ b/scripts/release-taico.mjs
@@ -28,6 +28,7 @@ const packageReleaseOrder = [
 ];
 
 const appReleaseOrder = ["apps/backend", "apps/worker"];
+const socketBadgeMarker = "[![Socket Badge]";
 
 const releaseVersionTextTargets = [
   {
@@ -181,6 +182,67 @@ function bumpTextFile(target, fromVersion, toVersion) {
   return { changed: true, relativePath };
 }
 
+function socketBadgeMarkdown(name, version) {
+  const badgeUrl = `https://badge.socket.dev/npm/package/${name}/${version}`;
+  return `[![Socket Badge](${badgeUrl})](${badgeUrl})`;
+}
+
+function defaultReadmeTitle(manifest) {
+  return `# ${manifest.name}\n`;
+}
+
+function syncSocketBadge(workspace) {
+  const packageJsonPath = path.join(repoRoot, workspace, "package.json");
+  const readmePath = path.join(repoRoot, workspace, "README.md");
+  const manifest = readJson(packageJsonPath);
+  const badge = socketBadgeMarkdown(manifest.name, manifest.version);
+  const current = existsSync(readmePath)
+    ? readFileSync(readmePath, "utf8")
+    : defaultReadmeTitle(manifest);
+  const lines = current.split("\n");
+  const existingBadgeIndex = lines.findIndex((line) =>
+    line.startsWith(socketBadgeMarker),
+  );
+
+  let next;
+  if (existingBadgeIndex >= 0) {
+    lines[existingBadgeIndex] = badge;
+    next = lines.join("\n");
+  } else {
+    const insertAt = lines[0]?.startsWith("# ") ? 1 : 0;
+    lines.splice(insertAt, 0, "", badge);
+    next = lines.join("\n");
+  }
+
+  if (!next.endsWith("\n")) {
+    next = `${next}\n`;
+  }
+
+  if (next !== current) {
+    writeFileSync(readmePath, next);
+    return { changed: true, relativePath: path.relative(repoRoot, readmePath) };
+  }
+
+  return { changed: false, relativePath: path.relative(repoRoot, readmePath) };
+}
+
+function syncSocketBadges() {
+  const results = [...packageReleaseOrder, ...appReleaseOrder].map((workspace) =>
+    syncSocketBadge(workspace),
+  );
+  const changed = results.filter((result) => result.changed);
+
+  if (changed.length === 0) {
+    console.log("Socket badges already up to date.");
+    return;
+  }
+
+  console.log("Updated Socket badges:");
+  for (const result of changed) {
+    console.log(`- ${result.relativePath}`);
+  }
+}
+
 function parseFlag(name, fallback) {
   const prefix = `--${name}=`;
   const match = process.argv.find((arg) => arg.startsWith(prefix));
@@ -231,6 +293,7 @@ function bump(fromVersion, toVersion) {
   );
   if (changed.length === 0) {
     console.log(`No @taico versions or dependencies matched ${fromVersion}.`);
+    syncSocketBadges();
     return;
   }
 
@@ -238,6 +301,8 @@ function bump(fromVersion, toVersion) {
   for (const result of changed) {
     console.log(`- ${result.relativePath}`);
   }
+
+  syncSocketBadges();
 }
 
 function printPlan() {
@@ -283,11 +348,14 @@ async function release() {
 function usage() {
   console.log(`Usage:
   node scripts/release-taico.mjs bump [--from=${defaultFromVersion}] [--to=${defaultToVersion}]
+  node scripts/release-taico.mjs socket-badges
   node scripts/release-taico.mjs release
   node scripts/release-taico.mjs all [--from=${defaultFromVersion}] [--to=${defaultToVersion}]
 
 Commands:
   bump     Update every @taico package version and @taico dependency range.
+  socket-badges
+           Update Socket badge URLs from release target package manifests.
   release  Login, build, then publish packages followed by backend and worker.
   all      Run bump and then release.
 `);
@@ -300,6 +368,9 @@ try {
   switch (commandName()) {
     case "bump":
       bump(fromVersion, toVersion);
+      break;
+    case "socket-badges":
+      syncSocketBadges();
       break;
     case "release":
       await release();


### PR DESCRIPTION
## Summary
- Add Socket scan badges to README files for every npm-published Taico release target
- Create minimal README files for release packages that did not have one
- Add a release helper command to regenerate Socket badge URLs from package names and versions, and run it during version bumps

## Validation
- npm run build:dev
- timeout 35s npm run dev:1 (started successfully; expected AppInitRunner prompt-context error appeared before timeout shutdown)

## Technical Debt
- None identified