### PR TITLE
Flag potentially stale runs in UI

### DIFF
--- a/apps/ui/src/features/executions/ExecutionsPage.css
+++ b/apps/ui/src/features/executions/ExecutionsPage.css
@@ -103,6 +103,28 @@
   justify-items: start;
 }
 
+.executions-feed-row__status-line {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.executions-stale-badge {
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  border: 1px solid color-mix(in srgb, var(--warning) 42%, var(--border));
+  border-radius: 999px;
+  padding: 1px var(--space-2);
+  background: color-mix(in srgb, var(--warning) 12%, var(--surface));
+  color: var(--text);
+  font-size: var(--fs-1);
+  font-weight: var(--fw-semibold);
+  cursor: help;
+}
+
 .executions-feed-row__actions {
   display: flex;
   justify-content: flex-end;
@@ -194,6 +216,15 @@
 .executions-detail-list {
   display: grid;
   gap: var(--space-2);
+}
+
+.executions-stale-callout {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--warning) 45%, var(--border));
+  border-radius: var(--r-3);
+  background: color-mix(in srgb, var(--warning) 12%, var(--surface));
 }
 
 .executions-detail-row {

--- a/apps/ui/src/features/executions/ExecutionsPage.tsx
+++ b/apps/ui/src/features/executions/ExecutionsPage.tsx
@@ -14,6 +14,9 @@ import { useToast } from "../../shared/context/ToastContext";
 import { useExecutions } from "./useExecutions";
 import "./ExecutionsPage.css";
 
+const POTENTIALLY_STALE_THRESHOLD_MS = 10 * 60 * 1000;
+const POTENTIALLY_STALE_MESSAGE = "We haven't seen activity in a while. If the worker doesn't report back, we'll mark this run as stale and revert the task to its previous state, where another agent will pick it";
+
 type ExecutionDetailResult =
   | { kind: "queue"; entry: TaskExecutionQueueEntryResponseDto }
   | { kind: "active"; entry: ActiveTaskExecutionResponseDto }
@@ -268,6 +271,7 @@ function RunFeedRow({
   const statusDetail = getRunStatusDetail(feedEntry);
   const timeDetail = getRunTimeDetail(feedEntry);
   const agentDetail = actor ? `picked by @${actor.slug ?? actor.displayName ?? actor.id}` : "waiting to be picked";
+  const isPotentiallyStale = isPotentiallyStaleRun(feedEntry);
 
   return (
     <div
@@ -289,7 +293,10 @@ function RunFeedRow({
         <Text as="div" size="2" tone="muted" wrap>{agentDetail}</Text>
       </div>
       <div className="executions-feed-row__meta">
-        <Text as="div" size="2" weight="medium">{statusDetail}</Text>
+        <div className="executions-feed-row__status-line">
+          <Text as="span" size="2" weight="medium">{statusDetail}</Text>
+          {isPotentiallyStale ? <PotentiallyStaleBadge /> : null}
+        </div>
         <Text as="div" size="1" tone="muted">{timeDetail}</Text>
       </div>
       <div className="executions-feed-row__stats">
@@ -336,11 +343,18 @@ function RunExecutionDetails({ execution, actor }: { execution: ActiveTaskExecut
   const endTime = isHistory ? new Date(execution.transitionedAt) : new Date();
   const durationText = formatDuration(endTime.getTime() - claimedAt.getTime());
   const stats = execution.stats;
+  const isPotentiallyStale = !isHistory && isActiveExecutionPotentiallyStale(execution);
 
   return (
     <>
       <section className="executions-detail-section">
         <Text as="div" size="1" weight="semibold" tone="muted" className="executions-detail-section__title">Timing</Text>
+        {isPotentiallyStale ? (
+          <div className="executions-stale-callout" role="status">
+            <Text as="div" size="2" weight="semibold">Potentially stale</Text>
+            <Text as="div" size="2" wrap>{POTENTIALLY_STALE_MESSAGE}</Text>
+          </div>
+        ) : null}
         <div className="executions-detail-list">
           <DetailRow label="Claimed at" value={formatDateTime(execution.claimedAt)} />
           {isHistory ? <DetailRow label="Finished at" value={formatDateTime(execution.transitionedAt)} /> : null}
@@ -391,6 +405,23 @@ function DetailRow({ label, value, mono }: { label: string; value: string; mono?
       <Text as="span" size="2" style={mono ? "mono" : "sans"} wrap>{value}</Text>
     </div>
   );
+}
+
+function PotentiallyStaleBadge() {
+  return (
+    <span className="executions-stale-badge" title={POTENTIALLY_STALE_MESSAGE}>
+      Potentially stale
+    </span>
+  );
+}
+
+function isPotentiallyStaleRun(feedEntry: RunFeedEntry | ExecutionDetailResult) {
+  return feedEntry.kind === "active" && isActiveExecutionPotentiallyStale(feedEntry.entry);
+}
+
+function isActiveExecutionPotentiallyStale(execution: ActiveTaskExecutionResponseDto) {
+  const activityAt = execution.lastHeartbeatAt ?? execution.claimedAt;
+  return Date.now() - new Date(activityAt).getTime() >= POTENTIALLY_STALE_THRESHOLD_MS;
 }
 
 function getActorForRun(feedEntry: RunFeedEntry | ExecutionDetailResult, actors: ActorSummary[]) {

--- a/apps/ui/src/features/tasks/TaskDetailPage.css
+++ b/apps/ui/src/features/tasks/TaskDetailPage.css
@@ -251,6 +251,10 @@
   color: var(--danger);
 }
 
+.task-detail-page__section .chip[title] {
+  cursor: help;
+}
+
 @keyframes task-detail-activity-in {
   from {
     opacity: 0;

--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -61,6 +61,7 @@ type TaskExecutionListItem = {
   status: 'ACTIVE' | TaskExecutionHistoryResponseDto['status'];
   source: 'active' | 'history';
   timestamp: string;
+  lastActivityAt: string;
   runnerSessionId: string | null;
   toolCallCount: number;
   errorCode: TaskExecutionHistoryResponseDto['errorCode'] | null;
@@ -69,6 +70,8 @@ type TaskExecutionListItem = {
 
 const COLLAPSED_TIMELINE_COUNT = 3;
 const COLLAPSED_EXECUTION_COUNT = 3;
+const POTENTIALLY_STALE_THRESHOLD_MS = 10 * 60 * 1000;
+const POTENTIALLY_STALE_MESSAGE = "We haven't seen activity in a while. If the worker doesn't report back, we'll mark this run as stale and revert the task to its previous state, where another agent will pick it";
 
 export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask = false, activityByTaskId = {}, handlers, allTasks }: TaskDetailViewProps) {
   const navigate = useNavigate();
@@ -490,6 +493,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
           status: 'ACTIVE',
           source: 'active',
           timestamp: entry.claimedAt,
+          lastActivityAt: entry.lastHeartbeatAt ?? entry.claimedAt,
           runnerSessionId: entry.runnerSessionId,
           toolCallCount: entry.toolCallCount,
           errorCode: null,
@@ -504,6 +508,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
           status: entry.status,
           source: 'history',
           timestamp: entry.transitionedAt,
+          lastActivityAt: entry.transitionedAt,
           runnerSessionId: entry.runnerSessionId,
           toolCallCount: entry.toolCallCount,
           errorCode: entry.errorCode,
@@ -958,17 +963,23 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
             execution.status === 'FAILED' && Boolean(execution.errorCode || execution.errorMessage);
           const isFailureDetailsExpanded = expandedExecutionErrorIds.has(execution.id);
           const isActive = execution.source === 'active';
+          const isPotentiallyStale = isActive && isExecutionPotentiallyStale(execution);
           const isInterrupting = interruptingExecutions.has(execution.executionId);
           const sourceTag: DataRowTag = {
             label: isActive ? 'active' : 'history',
             color: 'gray',
           };
+          const staleTag: DataRowTag | null = isPotentiallyStale ? {
+            label: 'Potentially stale',
+            color: 'orange',
+            title: POTENTIALLY_STALE_MESSAGE,
+          } : null;
 
           return (
             <DataRow
               key={execution.id}
               leading={<Avatar size={'sm'} name={actorName} src={actor?.avatarUrl || undefined} />}
-              tags={[statusTag, sourceTag]}
+              tags={staleTag ? [statusTag, sourceTag, staleTag] : [statusTag, sourceTag]}
               topRight={
                 isActive ? (
                   <Button
@@ -1018,7 +1029,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
                     {isActive ? (
                       <>
                         <span className='task-detail-page__execution-stats-separator'>|</span>
-                        {elapsedTime(execution.timestamp)}
+                        heartbeat {elapsedTime(execution.lastActivityAt)}
                       </>
                     ) : null}
                   </span>
@@ -1341,6 +1352,10 @@ function getExecutionStatusTag(
   }
 
   return { label: 'cancelled', color: 'gray' };
+}
+
+function isExecutionPotentiallyStale(execution: TaskExecutionListItem): boolean {
+  return Date.now() - new Date(execution.lastActivityAt).getTime() >= POTENTIALLY_STALE_THRESHOLD_MS;
 }
 
 function shortId(value: string): string {

--- a/apps/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/apps/ui/src/features/tasks/TaskDetailPage.tsx
@@ -273,6 +273,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
   const [executions, setExecutions] = useState<TaskExecutionListItem[]>([]);
   const [isLoadingExecutions, setIsLoadingExecutions] = useState(false);
   const [executionsError, setExecutionsError] = useState<string | null>(null);
+  const [stalenessNow, setStalenessNow] = useState(() => Date.now());
   const [expandedExecutionErrorIds, setExpandedExecutionErrorIds] = useState<Set<string>>(new Set());
   const [interruptingExecutions, setInterruptingExecutions] = useState<Set<string>>(new Set());
 
@@ -564,6 +565,19 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
     ? executions
     : executions.slice(0, COLLAPSED_EXECUTION_COUNT);
   const hasMoreExecutions = executions.length > COLLAPSED_EXECUTION_COUNT;
+
+  useEffect(() => {
+    if (!executions.some((execution) => execution.source === 'active')) {
+      return;
+    }
+
+    setStalenessNow(Date.now());
+    const intervalId = window.setInterval(() => {
+      setStalenessNow(Date.now());
+    }, 30 * 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [executions]);
 
   useEffect(() => {
     if (!task) {
@@ -963,7 +977,7 @@ export function TaskDetailView({ task, backPath, setSectionTitle, isLoadingTask 
             execution.status === 'FAILED' && Boolean(execution.errorCode || execution.errorMessage);
           const isFailureDetailsExpanded = expandedExecutionErrorIds.has(execution.id);
           const isActive = execution.source === 'active';
-          const isPotentiallyStale = isActive && isExecutionPotentiallyStale(execution);
+          const isPotentiallyStale = isActive && isExecutionPotentiallyStale(execution, stalenessNow);
           const isInterrupting = interruptingExecutions.has(execution.executionId);
           const sourceTag: DataRowTag = {
             label: isActive ? 'active' : 'history',
@@ -1354,8 +1368,8 @@ function getExecutionStatusTag(
   return { label: 'cancelled', color: 'gray' };
 }
 
-function isExecutionPotentiallyStale(execution: TaskExecutionListItem): boolean {
-  return Date.now() - new Date(execution.lastActivityAt).getTime() >= POTENTIALLY_STALE_THRESHOLD_MS;
+function isExecutionPotentiallyStale(execution: TaskExecutionListItem, now: number): boolean {
+  return now - new Date(execution.lastActivityAt).getTime() >= POTENTIALLY_STALE_THRESHOLD_MS;
 }
 
 function shortId(value: string): string {

--- a/apps/ui/src/ui/primitives/Chip.tsx
+++ b/apps/ui/src/ui/primitives/Chip.tsx
@@ -15,6 +15,8 @@ export interface ChipProps {
 
   clickLabel?: string;
 
+  title?: string;
+
   onRemove?: () => void;
 
   removeLabel?: string;
@@ -34,6 +36,7 @@ export function Chip(props: ChipProps) {
         type="button"
         className={chipClassName}
         style={props.style}
+        title={props.title}
         aria-label={props.clickLabel}
         onClick={(event) => {
           event.stopPropagation();
@@ -46,7 +49,7 @@ export function Chip(props: ChipProps) {
   }
 
   return (
-    <span className={chipClassName} style={props.style}>
+    <span className={chipClassName} style={props.style} title={props.title}>
       {props.children}
       {props.onRemove ? (
         <button

--- a/apps/ui/src/ui/primitives/DataRow.tsx
+++ b/apps/ui/src/ui/primitives/DataRow.tsx
@@ -7,6 +7,7 @@ export type DataRowTag = {
   color?: ChipProps["color"];
   onClick?: () => void;
   clickLabel?: string;
+  title?: string;
   onRemove?: () => void;
   removeLabel?: string;
 };
@@ -81,6 +82,7 @@ export function DataRow({
                   color={t.color}
                   onClick={t.onClick}
                   clickLabel={t.clickLabel ?? t.label}
+                  title={t.title}
                   onRemove={t.onRemove}
                   removeLabel={t.removeLabel ?? `Remove ${t.label}`}
                 >


### PR DESCRIPTION
## Summary
- Add potentially stale indicators for active runs on task detail and runs list views
- Show the full stale-run message on run detail timing section
- Add tooltip support to DataRow/Chip tags so compact stale badges can explain the behavior

## Validation
- npm run build:dev
- npm run dev:1 (reached backend startup on http://localhost:2003; stopped by validation timeout, expected AppInitRunner prompt-context error observed)

## Technical debt
- The frontend mirrors the backend's default 10-minute staleness threshold because that value is not exposed through the API.