### PR TITLE
Document current GitHub issues

### DIFF
--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -1,0 +1,14 @@
+# GitHub Issues
+
+Current issue inventory for `galarzafrancisco/ai-monorepo`, retrieved with `gh issue list --state all --limit 1000` on 2026-08-14.
+
+| Issue | State | Title | Assignees | Updated |
+| --- | --- | --- | --- | --- |
+| [#341](https://github.com/galarzafrancisco/ai-monorepo/issues/341) | Open | Issue title | galarzafrancisco | 2026-01-19 |
+| [#330](https://github.com/galarzafrancisco/ai-monorepo/issues/330) | Open | fart | Unassigned | 2026-01-17 |
+| [#94](https://github.com/galarzafrancisco/ai-monorepo/issues/94) | Open | Map MCP token exp to downstream tokens? | Unassigned | 2025-11-08 |
+| [#93](https://github.com/galarzafrancisco/ai-monorepo/issues/93) | Open | Exchange auth code for access token + refresh token | Unassigned | 2025-11-08 |
+| [#92](https://github.com/galarzafrancisco/ai-monorepo/issues/92) | Open | Callback endpoint for downstream systems | Unassigned | 2025-11-08 |
+| [#91](https://github.com/galarzafrancisco/ai-monorepo/issues/91) | Open | Intercept MCP Auth flow and initiate downstream auth | Unassigned | 2025-11-08 |
+| [#90](https://github.com/galarzafrancisco/ai-monorepo/issues/90) | Open | Mint JWT from refresh token | Unassigned | 2025-11-08 |
+| [#89](https://github.com/galarzafrancisco/ai-monorepo/issues/89) | Open | Mint JWT from access code | Unassigned | 2025-11-08 |


### PR DESCRIPTION
## Summary
- Add a docs page listing all current GitHub issues for the Taico repository
- Include issue number, state, title, assignee, updated date, and links

## Validation
- npm run build:dev
- timeout 90s npm run dev:5 (started successfully; stopped by timeout)

## Technical Debt
- The issue inventory is a point-in-time snapshot and will need manual refreshes when GitHub issues change.