### PR TITLE
Fix durable task relay retries

### DIFF
--- a/apps/backend/src/executions/readiness/task-execution-queue-populator.service.spec.ts
+++ b/apps/backend/src/executions/readiness/task-execution-queue-populator.service.spec.ts
@@ -158,6 +158,64 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
     });
   });
 
+  describe('reconcileTask', () => {
+    const createMockTask = (): TaskEntity =>
+      ({
+        id: 'test-task-id',
+        name: 'Test Task',
+        status: TaskStatus.NOT_STARTED,
+        assigneeActorId: 'agent-actor-id',
+        tags: [],
+      }) as unknown as TaskEntity;
+
+    beforeEach(() => {
+      agentsService.getActiveAgentsByActorIds.mockResolvedValue([
+        {
+          actorId: 'agent-actor-id',
+          slug: 'test-agent',
+          statusTriggers: [TaskStatus.NOT_STARTED],
+          tagTriggers: [],
+          concurrencyLimit: null,
+        },
+      ] as any);
+      readinessCandidateRepository.countActiveExecutionsForAgent.mockResolvedValue(
+        0,
+      );
+      taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue(null);
+    });
+
+    it('emits one wake-up across repeated reconciliation after one insertion', async () => {
+      const queryBuilder = {
+        insert: jest.fn().mockReturnThis(),
+        into: jest.fn().mockReturnThis(),
+        values: jest.fn().mockReturnThis(),
+        orIgnore: jest.fn().mockReturnThis(),
+        execute: jest
+          .fn()
+          .mockResolvedValueOnce({ raw: { changes: 1 } })
+          .mockResolvedValueOnce({ raw: { changes: 0 } }),
+      };
+      queueRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+      const task = createMockTask();
+
+      await (service as any).reconcileTask(task);
+      await (service as any).reconcileTask(task);
+
+      expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes a stale queue entry instead of requeueing an active task', async () => {
+      readinessCandidateRepository.findCandidateTaskById.mockResolvedValue(null);
+
+      await service.populateTask('test-task-id');
+
+      expect(queueRepository.delete).toHaveBeenCalledWith({
+        taskId: 'test-task-id',
+      });
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+
   describe('shouldQueueTask - Delay Retry Logic', () => {
     const createMockTask = (overrides: Partial<TaskEntity> = {}): TaskEntity => {
       return {

--- a/apps/backend/src/outbox/outbox-dispatcher.service.spec.ts
+++ b/apps/backend/src/outbox/outbox-dispatcher.service.spec.ts
@@ -121,4 +121,61 @@ describe('OutboxDispatcherService', () => {
       }),
     );
   });
+
+  it('retains retry state when a durable task listener rejects', async () => {
+    const event = createEvent();
+    const selectBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      getOne: jest
+        .fn()
+        .mockResolvedValueOnce(event)
+        .mockResolvedValueOnce(null),
+    };
+    const updateBuilder = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    const repository = {
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValueOnce(selectBuilder)
+        .mockReturnValueOnce(updateBuilder)
+        .mockReturnValueOnce(selectBuilder),
+      findOne: jest.fn().mockResolvedValue(event),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+    } as Pick<
+      Repository<OutboxEventEntity>,
+      'createQueryBuilder' | 'findOne' | 'update'
+    >;
+    const eventEmitter = {
+      emitAsync: jest
+        .fn()
+        .mockRejectedValue(new Error('readiness reconciliation failed')),
+    } as Pick<EventEmitter2, 'emitAsync'>;
+    const dispatcher = new OutboxDispatcherService(
+      repository as Repository<OutboxEventEntity>,
+      eventEmitter as EventEmitter2,
+    );
+
+    await dispatcher.dispatchAvailableEvents();
+
+    expect(repository.update).toHaveBeenCalledWith(
+      expect.objectContaining({ id: event.id }),
+      expect.objectContaining({
+        processingStartedAt: null,
+        availableAt: expect.any(Date),
+        lastError: 'readiness reconciliation failed',
+      }),
+    );
+    expect(repository.update).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ processedAt: expect.any(Date) }),
+    );
+  });
 });

--- a/apps/backend/src/tasks/task-outbox-projector.service.spec.ts
+++ b/apps/backend/src/tasks/task-outbox-projector.service.spec.ts
@@ -2,7 +2,10 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Repository } from 'typeorm';
 import { OutboxEventEntity } from '../outbox/outbox-event.entity';
 import { OutboxEventTypes } from '../outbox/outbox-event-types';
-import { TaskCreatedEvent } from './events/tasks.events';
+import {
+  TaskCreatedEvent,
+  TaskStatusChangedEvent,
+} from './events/tasks.events';
 import { TaskEntity } from './task.entity';
 import { CommentEntity } from './comment.entity';
 import { InputRequestEntity } from './input-request.entity';
@@ -73,5 +76,40 @@ describe('TaskOutboxProjectorService', () => {
     });
 
     await expect(service.projectCreated(event)).rejects.toThrow(failure);
+  });
+
+  it('propagates a status-change readiness reconciliation failure for retry', async () => {
+    const task = Object.assign(new TaskEntity(), {
+      id: 'task-1',
+      createdByActorId: 'actor-1',
+    });
+    const taskRepository = Object.create(
+      Repository.prototype,
+    ) as Repository<TaskEntity>;
+    jest.spyOn(taskRepository, 'findOne').mockResolvedValue(task);
+    const eventEmitter = Object.create(
+      EventEmitter2.prototype,
+    ) as EventEmitter2;
+    const failure = new Error('readiness reconciliation failed');
+    const emitAsync = jest
+      .spyOn(eventEmitter, 'emitAsync')
+      .mockRejectedValue(failure);
+    const service = new TaskOutboxProjectorService(
+      taskRepository,
+      Object.create(Repository.prototype) as Repository<CommentEntity>,
+      Object.create(Repository.prototype) as Repository<InputRequestEntity>,
+      Object.create(Repository.prototype) as Repository<ArtefactEntity>,
+      eventEmitter,
+    );
+    const event = Object.assign(new OutboxEventEntity(), {
+      type: OutboxEventTypes.TASK_STATUS_CHANGED,
+      payload: { taskId: task.id, actorId: 'actor-1' },
+    });
+
+    await expect(service.projectStatusChanged(event)).rejects.toThrow(failure);
+    expect(emitAsync).toHaveBeenCalledWith(
+      TaskStatusChangedEvent.INTERNAL,
+      expect.objectContaining({ payload: task }),
+    );
   });
 });

--- a/apps/backend/src/tasks/task-outbox-projector.service.spec.ts
+++ b/apps/backend/src/tasks/task-outbox-projector.service.spec.ts
@@ -10,7 +10,7 @@ import { ArtefactEntity } from './artefact.entity';
 import { TaskOutboxProjectorService } from './task-outbox-projector.service';
 
 describe('TaskOutboxProjectorService', () => {
-  it('re-emits a created task only when the outbox dispatcher delivers it', async () => {
+  it('awaits a created task relay when the outbox dispatcher delivers it', async () => {
     const task = Object.assign(new TaskEntity(), {
       id: 'task-1',
       createdByActorId: 'actor-1',
@@ -22,7 +22,7 @@ describe('TaskOutboxProjectorService', () => {
     const eventEmitter = Object.create(
       EventEmitter2.prototype,
     ) as EventEmitter2;
-    const emit = jest.spyOn(eventEmitter, 'emit');
+    const emitAsync = jest.spyOn(eventEmitter, 'emitAsync').mockResolvedValue([]);
     const service = new TaskOutboxProjectorService(
       taskRepository,
       Object.create(Repository.prototype) as Repository<CommentEntity>,
@@ -37,12 +37,41 @@ describe('TaskOutboxProjectorService', () => {
 
     await service.projectCreated(event);
 
-    expect(emit).toHaveBeenCalledWith(
+    expect(emitAsync).toHaveBeenCalledWith(
       TaskCreatedEvent.INTERNAL,
       expect.objectContaining({
         actor: { id: 'actor-1' },
         payload: task,
       }),
     );
+  });
+
+  it('propagates a readiness reconciliation failure to the outbox dispatcher', async () => {
+    const task = Object.assign(new TaskEntity(), {
+      id: 'task-1',
+      createdByActorId: 'actor-1',
+    });
+    const taskRepository = Object.create(
+      Repository.prototype,
+    ) as Repository<TaskEntity>;
+    jest.spyOn(taskRepository, 'findOne').mockResolvedValue(task);
+    const eventEmitter = Object.create(
+      EventEmitter2.prototype,
+    ) as EventEmitter2;
+    const failure = new Error('readiness reconciliation failed');
+    jest.spyOn(eventEmitter, 'emitAsync').mockRejectedValue(failure);
+    const service = new TaskOutboxProjectorService(
+      taskRepository,
+      Object.create(Repository.prototype) as Repository<CommentEntity>,
+      Object.create(Repository.prototype) as Repository<InputRequestEntity>,
+      Object.create(Repository.prototype) as Repository<ArtefactEntity>,
+      eventEmitter,
+    );
+    const event = Object.assign(new OutboxEventEntity(), {
+      type: OutboxEventTypes.TASK_CREATED,
+      payload: { taskId: task.id, actorId: 'actor-1' },
+    });
+
+    await expect(service.projectCreated(event)).rejects.toThrow(failure);
   });
 });

--- a/apps/backend/src/tasks/task-outbox-projector.service.ts
+++ b/apps/backend/src/tasks/task-outbox-projector.service.ts
@@ -134,7 +134,7 @@ export class TaskOutboxProjectorService {
     const actorId = this.requiredString(event.payload.actorId, 'actorId');
     const task = await this.loadTask(taskId);
 
-    this.eventEmitter.emit(
+    await this.eventEmitter.emitAsync(
       TaskStatusChangedEvent.INTERNAL,
       new TaskStatusChangedEvent({ id: actorId }, task),
     );

--- a/apps/backend/src/tasks/task-outbox-projector.service.ts
+++ b/apps/backend/src/tasks/task-outbox-projector.service.ts
@@ -38,7 +38,7 @@ export class TaskOutboxProjectorService {
     const taskId = this.requiredString(event.payload.taskId, 'taskId');
     const actorId = this.requiredString(event.payload.actorId, 'actorId');
     const task = await this.loadTask(taskId);
-    this.eventEmitter.emit(
+    await this.eventEmitter.emitAsync(
       TaskCreatedEvent.INTERNAL,
       new TaskCreatedEvent({ id: actorId }, task),
     );
@@ -49,7 +49,7 @@ export class TaskOutboxProjectorService {
     const taskId = this.requiredString(event.payload.taskId, 'taskId');
     const actorId = this.requiredString(event.payload.actorId, 'actorId');
     const task = await this.loadTask(taskId);
-    this.eventEmitter.emit(
+    await this.eventEmitter.emitAsync(
       TaskUpdatedEvent.INTERNAL,
       new TaskUpdatedEvent({ id: actorId }, task),
     );
@@ -60,7 +60,7 @@ export class TaskOutboxProjectorService {
     const taskId = this.requiredString(event.payload.taskId, 'taskId');
     const actorId = this.requiredString(event.payload.actorId, 'actorId');
     const task = await this.loadTask(taskId);
-    this.eventEmitter.emit(
+    await this.eventEmitter.emitAsync(
       TaskAssignedEvent.INTERNAL,
       new TaskAssignedEvent({ id: actorId }, task),
     );
@@ -79,7 +79,7 @@ export class TaskOutboxProjectorService {
         `Outbox task event references missing comment ${commentId}`,
       );
     }
-    this.eventEmitter.emit(
+    await this.eventEmitter.emitAsync(
       CommentAddedEvent.INTERNAL,
       new CommentAddedEvent({ id: actorId }, comment),
     );
@@ -100,7 +100,7 @@ export class TaskOutboxProjectorService {
         `Outbox task event references missing input request ${inputRequestId}`,
       );
     }
-    this.eventEmitter.emit(
+    await this.eventEmitter.emitAsync(
       InputRequestAnsweredEvent.INTERNAL,
       new InputRequestAnsweredEvent({ id: actorId }, request),
     );
@@ -122,7 +122,7 @@ export class TaskOutboxProjectorService {
         `Outbox task event references missing artefact ${artefactId}`,
       );
     }
-    this.eventEmitter.emit(
+    await this.eventEmitter.emitAsync(
       ArtefactAddedEvent.INTERNAL,
       new ArtefactAddedEvent({ id: actorId }, artefact),
     );
@@ -141,10 +141,10 @@ export class TaskOutboxProjectorService {
   }
 
   @OnEvent(OutboxEventTypes.TASK_DELETED)
-  projectDeleted(event: OutboxEventEntity): void {
+  async projectDeleted(event: OutboxEventEntity): Promise<void> {
     const taskId = this.requiredString(event.payload.taskId, 'taskId');
     const actorId = this.requiredString(event.payload.actorId, 'actorId');
-    this.eventEmitter.emit(
+    await this.eventEmitter.emitAsync(
       TaskDeletedEvent.INTERNAL,
       new TaskDeletedEvent({ id: actorId }, taskId),
     );


### PR DESCRIPTION
## Summary\n- await internal durable task relays from the task outbox projector\n- preserve outbox retry state when readiness reconciliation rejects\n- cover relay await behavior and idempotent queue reconciliation\n\n## Validation\n- npx jest --config apps/backend/jest.config.js task-outbox-projector.service.spec.ts outbox-dispatcher.service.spec.ts task-execution-queue-populator.service.spec.ts --runInBand\n- npm run build:dev\n- timeout 45s npm run dev:5\n\n## Technical debt\nNone.