### PR TITLE
Generate child thread titles with CAS

### DIFF
--- a/apps/backend/src/threads/thread-outbox-projector.service.spec.ts
+++ b/apps/backend/src/threads/thread-outbox-projector.service.spec.ts
@@ -1,0 +1,36 @@
+import { ThreadEntity } from './thread.entity';
+import { ThreadOutboxProjectorService } from './thread-outbox-projector.service';
+import { ThreadTitleWorkflowService } from './thread-title-workflow.service';
+
+describe('ThreadOutboxProjectorService', () => {
+  it('generates a title from the parent task before relaying a created child thread', async () => {
+    const parentTask = { id: 'task-1', name: 'Parent' } as never;
+    const thread = {
+      id: 'thread-1',
+      parentTaskId: 'task-1',
+      parentTask,
+    } as unknown as ThreadEntity;
+    const threadRepository = { findOne: jest.fn().mockResolvedValue(thread) };
+    const eventEmitter = { emit: jest.fn() };
+    const titleWorkflow = {
+      generateFromParentTask: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ThreadTitleWorkflowService;
+    const service = new ThreadOutboxProjectorService(
+      threadRepository as never,
+      eventEmitter as never,
+      {} as never,
+      titleWorkflow,
+    );
+
+    await service.projectCreated({
+      payload: { threadId: thread.id, actorId: 'actor-1' },
+    } as never);
+
+    expect(titleWorkflow.generateFromParentTask).toHaveBeenCalledWith(
+      thread,
+      'actor-1',
+      parentTask,
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/threads/thread-outbox-projector.service.ts
+++ b/apps/backend/src/threads/thread-outbox-projector.service.ts
@@ -12,6 +12,7 @@ import {
 } from './events/threads.events';
 import { ThreadMessageEntity } from './thread-message.entity';
 import { ThreadEntity } from './thread.entity';
+import { ThreadTitleWorkflowService } from './thread-title-workflow.service';
 
 @Injectable()
 export class ThreadOutboxProjectorService {
@@ -21,6 +22,7 @@ export class ThreadOutboxProjectorService {
     private readonly eventEmitter: EventEmitter2,
     @InjectRepository(ThreadMessageEntity)
     private readonly messageRepository: Repository<ThreadMessageEntity>,
+    private readonly threadTitleWorkflow: ThreadTitleWorkflowService,
   ) {}
 
   @OnEvent(OutboxEventTypes.THREAD_CREATED)
@@ -28,6 +30,18 @@ export class ThreadOutboxProjectorService {
     const threadId = this.requiredString(event.payload.threadId, 'threadId');
     const actorId = this.requiredString(event.payload.actorId, 'actorId');
     const thread = await this.loadThread(threadId);
+    if (thread.parentTaskId) {
+      if (!thread.parentTask) {
+        throw new Error(
+          `Thread ${threadId} is missing parent task ${thread.parentTaskId}`,
+        );
+      }
+      await this.threadTitleWorkflow.generateFromParentTask(
+        thread,
+        actorId,
+        thread.parentTask,
+      );
+    }
     this.eventEmitter.emit(
       ThreadCreatedEvent.INTERNAL,
       new ThreadCreatedEvent({ id: actorId }, thread),
@@ -68,6 +82,7 @@ export class ThreadOutboxProjectorService {
       where: { id: threadId },
       relations: [
         'createdByActor',
+        'parentTask',
         'tasks',
         'referencedContextBlocks',
         'tags',

--- a/apps/backend/src/threads/thread-title-workflow.service.spec.ts
+++ b/apps/backend/src/threads/thread-title-workflow.service.spec.ts
@@ -1,0 +1,113 @@
+import { ContextService } from '../context/context.service';
+import { TaskEntity } from '../tasks/task.entity';
+import { ThreadEntity } from './thread.entity';
+import { ThreadTitleService } from './thread-title.service';
+import { ThreadTitleWorkflowService } from './thread-title-workflow.service';
+
+describe('ThreadTitleWorkflowService', () => {
+  const thread = Object.assign(new ThreadEntity(), {
+    id: 'thread-1',
+    title: 'New thread',
+    stateContextBlockId: 'state-block-1',
+  });
+  const task = Object.assign(new TaskEntity(), { id: 'task-1', name: 'Parent' });
+  let queryBuilder: {
+    update: jest.Mock;
+    set: jest.Mock;
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    execute: jest.Mock;
+  };
+  let threadRepository: { createQueryBuilder: jest.Mock; findOneBy: jest.Mock };
+  let titleService: jest.Mocked<Pick<ThreadTitleService, 'generateFromParentTask' | 'generateFromMessage'>>;
+  let contextService: jest.Mocked<Pick<ContextService, 'updateBlock'>>;
+  let eventEmitter: { emit: jest.Mock };
+  let service: ThreadTitleWorkflowService;
+
+  beforeEach(() => {
+    thread.title = 'New thread';
+    queryBuilder = {
+      update: jest.fn(),
+      set: jest.fn(),
+      where: jest.fn(),
+      andWhere: jest.fn(),
+      execute: jest.fn(),
+    };
+    queryBuilder.update.mockReturnValue(queryBuilder);
+    queryBuilder.set.mockReturnValue(queryBuilder);
+    queryBuilder.where.mockReturnValue(queryBuilder);
+    queryBuilder.andWhere.mockReturnValue(queryBuilder);
+    threadRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+      findOneBy: jest.fn().mockResolvedValue({ ...thread, title: 'Parent title' }),
+    };
+    titleService = {
+      generateFromParentTask: jest.fn(),
+      generateFromMessage: jest.fn(),
+    };
+    contextService = { updateBlock: jest.fn().mockResolvedValue(undefined) };
+    eventEmitter = { emit: jest.fn() };
+    service = new ThreadTitleWorkflowService(
+      threadRepository as never,
+      titleService as never,
+      contextService as never,
+      eventEmitter as never,
+    );
+  });
+
+  it('generates from the parent task and updates the title, state block, and event after winning the CAS', async () => {
+    titleService.generateFromParentTask.mockResolvedValue('Parent title');
+    queryBuilder.execute.mockResolvedValue({ affected: 1 });
+
+    await service.generateFromParentTask(thread, 'actor-1', task);
+
+    expect(titleService.generateFromParentTask).toHaveBeenCalledWith(task);
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'LOWER(TRIM(title)) = :placeholder',
+      { placeholder: 'new thread' },
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      expect.any(Symbol),
+      expect.objectContaining({ payload: { threadId: thread.id, title: 'Parent title' } }),
+    );
+    expect(contextService.updateBlock).toHaveBeenCalledWith(thread.stateContextBlockId, {
+      title: 'Thread State: Parent title',
+    });
+  });
+
+  it.each([null, ' New thread '])('does not update for a %p candidate', async (candidate) => {
+    titleService.generateFromParentTask.mockResolvedValue(candidate);
+
+    await service.generateFromParentTask(thread, 'actor-1', task);
+
+    expect(queryBuilder.execute).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).not.toHaveBeenCalled();
+    expect(contextService.updateBlock).not.toHaveBeenCalled();
+  });
+
+  it('propagates generation failures so the durable outbox projection retries', async () => {
+    titleService.generateFromParentTask.mockRejectedValue(new Error('LLM unavailable'));
+
+    await expect(service.generateFromParentTask(thread, 'actor-1', task)).rejects.toThrow(
+      'LLM unavailable',
+    );
+    expect(queryBuilder.execute).not.toHaveBeenCalled();
+  });
+
+  it('allows exactly one winner when parent and first-message generation race', async () => {
+    titleService.generateFromParentTask.mockResolvedValue('Parent title');
+    titleService.generateFromMessage.mockResolvedValue('Message title');
+    queryBuilder.execute
+      .mockResolvedValueOnce({ affected: 1 })
+      .mockResolvedValueOnce({ affected: 0 });
+
+    await Promise.all([
+      service.generateFromParentTask(thread, 'actor-1', task),
+      service.generateFromFirstMessage(thread, 'actor-2', 'Hello'),
+    ]);
+
+    expect(queryBuilder.execute).toHaveBeenCalledTimes(2);
+    expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+    expect(contextService.updateBlock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/threads/thread-title-workflow.service.ts
+++ b/apps/backend/src/threads/thread-title-workflow.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ContextService } from '../context/context.service';
+import { TaskEntity } from '../tasks/task.entity';
+import { ThreadTitleUpdatedEvent } from './events/threads.events';
+import { ThreadEntity } from './thread.entity';
+import { ThreadTitleService } from './thread-title.service';
+
+@Injectable()
+export class ThreadTitleWorkflowService {
+  private readonly logger = new Logger(ThreadTitleWorkflowService.name);
+  private static readonly PLACEHOLDER_TITLE = 'new thread';
+
+  constructor(
+    @InjectRepository(ThreadEntity)
+    private readonly threadRepository: Repository<ThreadEntity>,
+    private readonly threadTitleService: ThreadTitleService,
+    private readonly contextService: ContextService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async generateFromParentTask(
+    thread: ThreadEntity,
+    actorId: string,
+    parentTask: TaskEntity,
+  ): Promise<void> {
+    if (!this.isPlaceholderTitle(thread.title)) return;
+
+    const title = await this.threadTitleService.generateFromParentTask(parentTask);
+    await this.applyGeneratedTitle(thread, actorId, title);
+  }
+
+  async generateFromFirstMessage(
+    thread: ThreadEntity,
+    actorId: string,
+    message: string,
+  ): Promise<void> {
+    const title = await this.threadTitleService.generateFromMessage(message);
+    await this.applyGeneratedTitle(thread, actorId, title);
+  }
+
+  private async applyGeneratedTitle(
+    thread: ThreadEntity,
+    actorId: string,
+    title: string | null,
+  ): Promise<void> {
+    if (!title || this.isPlaceholderTitle(title)) return;
+
+    const result = await this.threadRepository
+      .createQueryBuilder()
+      .update(ThreadEntity)
+      .set({ title })
+      .where('id = :threadId', { threadId: thread.id })
+      .andWhere('LOWER(TRIM(title)) = :placeholder', {
+        placeholder: ThreadTitleWorkflowService.PLACEHOLDER_TITLE,
+      })
+      .execute();
+    if (result.affected !== 1) return;
+
+    const updatedThread = await this.threadRepository.findOneBy({ id: thread.id });
+    if (!updatedThread) {
+      throw new Error(`Thread ${thread.id} disappeared after title update`);
+    }
+    thread.title = updatedThread.title;
+
+    this.eventEmitter.emit(
+      ThreadTitleUpdatedEvent.INTERNAL,
+      new ThreadTitleUpdatedEvent(
+        { id: actorId },
+        { threadId: updatedThread.id, title: updatedThread.title },
+      ),
+    );
+
+    try {
+      await this.contextService.updateBlock(updatedThread.stateContextBlockId, {
+        title: `Thread State: ${updatedThread.title}`,
+      });
+    } catch (error) {
+      this.logger.warn({
+        message:
+          'Failed to update thread state block title after generating thread title',
+        threadId: updatedThread.id,
+        stateContextBlockId: updatedThread.stateContextBlockId,
+        error:
+          error instanceof Error
+            ? { message: error.message, stack: error.stack }
+            : String(error),
+      });
+    }
+  }
+
+  private isPlaceholderTitle(title: string): boolean {
+    return (
+      title.trim().toLowerCase() ===
+      ThreadTitleWorkflowService.PLACEHOLDER_TITLE
+    );
+  }
+}

--- a/apps/backend/src/threads/threads.module.ts
+++ b/apps/backend/src/threads/threads.module.ts
@@ -19,6 +19,7 @@ import { AgentsModule } from 'src/agents/agents.module';
 import { AuthorizationServerModule } from 'src/authorization-server/authorization-server.module';
 import { OpenAiMcpServerFactoryService } from './openai-mcp-server-factory.service';
 import { ThreadTitleService } from './thread-title.service';
+import { ThreadTitleWorkflowService } from './thread-title-workflow.service';
 import { ThreadStateReconcilerService } from './thread-state-reconciler.service';
 import { ChatProvidersModule } from '../chat-providers/chat-providers.module';
 import { ThreadTaskAssignmentProjectorService } from './thread-task-assignment-projector.service';
@@ -59,6 +60,7 @@ import { CreateThreadMessageUseCase } from './use-cases/create-thread-message.us
     OpenAiBackend,
     OpenAiMcpServerFactoryService,
     ThreadTitleService,
+    ThreadTitleWorkflowService,
     ThreadStateReconcilerService,
     ThreadTaskAssignmentProjectorService,
     UpdateThreadUseCase,

--- a/apps/backend/src/threads/threads.service.ts
+++ b/apps/backend/src/threads/threads.service.ts
@@ -37,13 +37,12 @@ import {
   ThreadAgentActivityEvent,
   ThreadAgentActivityKind,
   ThreadAgentResponseDeltaEvent,
-  ThreadTitleUpdatedEvent,
 } from './events/threads.events';
 import { ChatService } from './chat.service';
 import { ChatStreamEvent } from './backends/chat-backend.interface';
 import { NoActiveChatProviderError } from '../chat-providers/errors/chat-providers.errors';
 import { ActorType } from '../identity-provider/enums';
-import { ThreadTitleService } from './thread-title.service';
+import { ThreadTitleWorkflowService } from './thread-title-workflow.service';
 import { UpdateThreadUseCase } from './use-cases/update-thread.use-case';
 import { DeleteThreadUseCase } from './use-cases/delete-thread.use-case';
 import { CreateThreadUseCase } from './use-cases/create-thread.use-case';
@@ -94,7 +93,7 @@ export class ThreadsService {
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
     private readonly chatService: ChatService,
-    private readonly threadTitleService: ThreadTitleService,
+    private readonly threadTitleWorkflow: ThreadTitleWorkflowService,
     private readonly updateThreadUseCase: UpdateThreadUseCase,
     private readonly deleteThreadUseCase: DeleteThreadUseCase,
     private readonly createThreadUseCase: CreateThreadUseCase,
@@ -607,41 +606,11 @@ export class ThreadsService {
       return;
     }
 
-    const generatedTitle =
-      await this.threadTitleService.generateFromMessage(content);
-    if (!generatedTitle || this.isPlaceholderTitle(generatedTitle)) {
-      return;
-    }
-
-    input.thread.title = generatedTitle;
-    await this.threadRepository.save(input.thread);
-    this.eventEmitter.emit(
-      ThreadTitleUpdatedEvent.INTERNAL,
-      new ThreadTitleUpdatedEvent(
-        { id: input.actor.id },
-        {
-          threadId: input.thread.id,
-          title: generatedTitle,
-        },
-      ),
+    await this.threadTitleWorkflow.generateFromFirstMessage(
+      input.thread,
+      input.actor.id,
+      content,
     );
-
-    try {
-      await this.contextService.updateBlock(input.thread.stateContextBlockId, {
-        title: `Thread State: ${generatedTitle}`,
-      });
-    } catch (error) {
-      this.logger.warn({
-        message:
-          'Failed to update thread state block title after generating thread title',
-        threadId: input.thread.id,
-        stateContextBlockId: input.thread.stateContextBlockId,
-        error:
-          error instanceof Error
-            ? { message: error.message, stack: error.stack }
-            : String(error),
-      });
-    }
   }
 
   private async buildThreadResult(thread: ThreadEntity): Promise<ThreadResult> {

--- a/apps/backend/src/threads/use-cases/create-thread.use-case.spec.ts
+++ b/apps/backend/src/threads/use-cases/create-thread.use-case.spec.ts
@@ -1,8 +1,4 @@
 jest.mock('@taico/errors', () => ({ ErrorCodes: {} }));
-jest.mock('../thread-title.service', () => ({
-  ThreadTitleService: jest.fn(),
-}));
-
 import { DataSource, EntityManager, Repository } from 'typeorm';
 import { ActorEntity } from '../../identity-provider/actor.entity';
 import { ContextBlockEntity } from '../../context/block.entity';
@@ -12,7 +8,6 @@ import { OutboxEventEntity } from '../../outbox/outbox-event.entity';
 import { OutboxEventTypes } from '../../outbox/outbox-event-types';
 import { OutboxWriterService } from '../../outbox/outbox-writer.service';
 import { TaskEntity } from '../../tasks/task.entity';
-import { ThreadTitleService } from '../thread-title.service';
 import { ThreadEntity } from '../thread.entity';
 import { CreateThreadUseCase } from './create-thread.use-case';
 
@@ -110,14 +105,10 @@ describe('CreateThreadUseCase', () => {
       .mockResolvedValue(
         Object.assign(new OutboxEventEntity(), { id: 'event-1' }),
       );
-    const titleService = Object.create(
-      ThreadTitleService.prototype,
-    ) as ThreadTitleService;
     const useCase = new CreateThreadUseCase(
       dataSource,
       tagWriter,
       outboxWriter,
-      titleService,
     );
 
     await useCase.execute({

--- a/apps/backend/src/threads/use-cases/create-thread.use-case.ts
+++ b/apps/backend/src/threads/use-cases/create-thread.use-case.ts
@@ -6,7 +6,6 @@ import { TransactionalTagWriterService } from '../../meta/transactional-tag-writ
 import { OutboxEventTypes } from '../../outbox/outbox-event-types';
 import { OutboxWriterService } from '../../outbox/outbox-writer.service';
 import { TaskEntity } from '../../tasks/task.entity';
-import { ThreadTitleService } from '../thread-title.service';
 import { CreateThreadInput } from '../dto/service/threads.service.types';
 import {
   ActorNotFoundForThreadError,
@@ -24,22 +23,10 @@ export class CreateThreadUseCase {
     private readonly dataSource: DataSource,
     private readonly tagWriter: TransactionalTagWriterService,
     private readonly outboxWriter: OutboxWriterService,
-    private readonly threadTitleService: ThreadTitleService,
   ) {}
 
   async execute(input: CreateThreadInput): Promise<ThreadEntity> {
-    const parentForTitle = input.parentTaskId
-      ? await this.dataSource.getRepository(TaskEntity).findOne({
-          where: { id: input.parentTaskId },
-        })
-      : null;
-    const title =
-      input.title ??
-      (parentForTitle
-        ? ((await this.threadTitleService.generateFromParentTask(
-            parentForTitle,
-          )) ?? DEFAULT_THREAD_TITLE)
-        : DEFAULT_THREAD_TITLE);
+    const title = input.title ?? DEFAULT_THREAD_TITLE;
 
     try {
       return await this.dataSource.transaction(async (manager) => {


### PR DESCRIPTION
## Summary
- Generate parent-task thread titles after the creation transaction through the durable THREAD_CREATED projection.
- Share a placeholder-only conditional title update workflow with first human messages.
- Update title events and state block names only for the winning compare-and-swap update.
- Retry transient generation failures through existing outbox dispatch retries.

## Validation
- Focused backend title and thread-creation tests.
- npm run build:dev.
- npm run dev:1: backend started successfully; the expected AppInitRunner prompt-block error was logged.

## Technical debt
- None.