### PR TITLE
Deduplicate worker task claim attempts

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "start": "tsx src/index.ts",
-    "test": "tsx src/test.ts",
+    "test": "tsx --test src/*.spec.ts",
     "build": "tsc -p tsconfig.build.json",
     "build:prod": "npm run build",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",

--- a/apps/worker/src/task-claim-worker.spec.ts
+++ b/apps/worker/src/task-claim-worker.spec.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { claimIfNotInFlight } from './task-claim-worker.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+test('deduplicates duplicate socket notifications while a claim is in flight', async () => {
+  const pending = deferred();
+  let calls = 0;
+  const claim = () => {
+    calls += 1;
+    return pending.promise;
+  };
+
+  const socketNotification = claimIfNotInFlight('socket-task', claim);
+  await claimIfNotInFlight('socket-task', claim);
+  assert.equal(calls, 1);
+
+  pending.resolve();
+  await socketNotification;
+});
+
+test('deduplicates overlapping polling and socket claim attempts', async () => {
+  const pending = deferred();
+  let calls = 0;
+  const claim = () => {
+    calls += 1;
+    return pending.promise;
+  };
+
+  const pollAttempt = claimIfNotInFlight('overlap-task', claim);
+  await claimIfNotInFlight('overlap-task', claim);
+  assert.equal(calls, 1);
+
+  pending.resolve();
+  await pollAttempt;
+});
+
+test('releases a task after successful and failed claim attempts', async () => {
+  let calls = 0;
+  const claim = async () => {
+    calls += 1;
+  };
+
+  await claimIfNotInFlight('cleanup-success-task', claim);
+  await claimIfNotInFlight('cleanup-success-task', claim);
+  await assert.rejects(
+    claimIfNotInFlight('cleanup-failure-task', async () => {
+      throw new Error('claim failed');
+    }),
+  );
+  await claimIfNotInFlight('cleanup-failure-task', claim);
+
+  assert.equal(calls, 3);
+});
+
+test('allows claims for different tasks to run concurrently', async () => {
+  const first = deferred();
+  const second = deferred();
+  let calls = 0;
+
+  const firstAttempt = claimIfNotInFlight('first-task', () => {
+    calls += 1;
+    return first.promise;
+  });
+  const secondAttempt = claimIfNotInFlight('second-task', () => {
+    calls += 1;
+    return second.promise;
+  });
+
+  assert.equal(calls, 2);
+  first.resolve();
+  second.resolve();
+  await Promise.all([firstAttempt, secondAttempt]);
+});

--- a/apps/worker/src/task-claim-worker.ts
+++ b/apps/worker/src/task-claim-worker.ts
@@ -1,10 +1,32 @@
 import { setTimeout as sleep } from 'timers/promises';
-import { ApiClient } from '@taico/client/v2';
-import { pickTask } from './task-picker.js';
-import { ExecutionActivityGatewayClient } from './execution-activity-gateway-client.js';
+import type { ApiClient } from '@taico/client/v2';
+import type { ExecutionActivityGatewayClient } from './execution-activity-gateway-client.js';
 import { isTaskClaimDeferred } from './task-claim-deferral.js';
 
 const QUEUE_POLL_INTERVAL_MS = 60_000;
+const inFlightTaskClaims = new Set<string>();
+
+export async function claimIfNotInFlight(
+  taskId: string,
+  claimTask: () => Promise<void>,
+): Promise<void> {
+  if (isTaskClaimDeferred(taskId)) {
+    console.log(`[worker] Skipping task ${taskId}; recently unclaimed by this worker.`);
+    return;
+  }
+
+  if (inFlightTaskClaims.has(taskId)) {
+    console.debug(`[worker] Skipping duplicate claim attempt for task ${taskId}; already in flight.`);
+    return;
+  }
+
+  inFlightTaskClaims.add(taskId);
+  try {
+    await claimTask();
+  } finally {
+    inFlightTaskClaims.delete(taskId);
+  }
+}
 
 export async function runTaskClaimWorker(
   client: ApiClient,
@@ -42,22 +64,27 @@ export async function attemptClaimTask(
 ): Promise<void> {
   console.log(`[worker] Received queue notification for task ${taskId}, attempting to claim...`);
 
-  if (isTaskClaimDeferred(taskId)) {
-    console.log(`[worker] Skipping task ${taskId}; recently unclaimed by this worker.`);
-    return;
-  }
-
   try {
-    await pickTask({
-      client,
-      taskId,
-      baseDir: workingDirectory,
-      baseUrl,
-      activityGatewayClient,
-    });
+    await claimIfNotInFlight(taskId, () =>
+      pickQueuedTask({
+        client,
+        taskId,
+        baseDir: workingDirectory,
+        baseUrl,
+        activityGatewayClient,
+      }),
+    );
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.log(`[worker] Failed to claim task ${taskId}: ${message}`);
+    logClaimFailure(taskId, error);
+  }
+}
+
+function logClaimFailure(taskId: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/\b(404|409)\b|conflict|not found|queue entry/i.test(message)) {
+    console.info(`[worker] Task ${taskId} was claimed by another worker: ${message}`);
+  } else {
+    console.error(`[worker] Failed to claim task ${taskId}: ${message}`);
   }
 }
 
@@ -77,17 +104,26 @@ async function processNextQueuedTask(
     return;
   }
 
-  void pickTask({
-    client,
-    taskId: nextTask.taskId,
-    baseDir: workingDirectory,
-    baseUrl,
-    activityGatewayClient,
-  })
-    .catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(
-        `[worker] Task processing failed for ${nextTask.taskId}: ${message}`,
-      );
-    });
+  void claimIfNotInFlight(nextTask.taskId, () =>
+    pickQueuedTask({
+      client,
+      taskId: nextTask.taskId,
+      baseDir: workingDirectory,
+      baseUrl,
+      activityGatewayClient,
+    }),
+  ).catch((error) => {
+    logClaimFailure(nextTask.taskId, error);
+  });
+}
+
+async function pickQueuedTask(params: {
+  client: ApiClient;
+  taskId: string;
+  baseDir: string;
+  baseUrl: string;
+  activityGatewayClient: ExecutionActivityGatewayClient;
+}): Promise<void> {
+  const { pickTask } = await import('./task-picker.js');
+  await pickTask(params);
 }


### PR DESCRIPTION
## Summary\n- guard worker task claims by task ID across socket wake-ups and queue polling\n- clear guards after completion or failure while retaining deferred-claim behavior\n- add node:test coverage for duplicate notifications, overlap, cleanup, and concurrent distinct tasks\n\n## Validation\n- npm test --workspace=@taico/worker\n- npm run build:dev\n- npm run dev:1\n\n## Technical debt\n- None.