### PR TITLE
Fix deletion of state blocks for deleted threads

### DIFF
--- a/apps/backend/src/context/use-cases/delete-context-block.use-case.spec.ts
+++ b/apps/backend/src/context/use-cases/delete-context-block.use-case.spec.ts
@@ -6,6 +6,7 @@ import { OutboxEventTypes } from '../../outbox/outbox-event-types';
 import { OutboxWriterService } from '../../outbox/outbox-writer.service';
 import { ThreadEntity } from '../../threads/thread.entity';
 import { ContextBlockEntity } from '../block.entity';
+import { BlockIsThreadStateError } from '../errors/context.errors';
 import { DeleteContextBlockUseCase } from './delete-context-block.use-case';
 
 describe('DeleteContextBlockUseCase', () => {
@@ -53,6 +54,9 @@ describe('DeleteContextBlockUseCase', () => {
     await useCase.execute(block.id);
 
     expect(count).toHaveBeenCalledWith({ where: { parentId: block.id } });
+    expect(threadRepository.count).toHaveBeenCalledWith({
+      where: { stateContextBlockId: block.id },
+    });
     expect(remove).toHaveBeenCalledWith(block.id);
     expect(enqueue).toHaveBeenCalledWith(
       manager,
@@ -61,5 +65,45 @@ describe('DeleteContextBlockUseCase', () => {
         payload: { blockId: block.id, actorId: block.createdByActorId },
       }),
     );
+  });
+
+  it('prevents deletion while an active thread uses the block as state', async () => {
+    const block = Object.assign(new ContextBlockEntity(), {
+      id: 'block-1',
+      createdByActorId: 'actor-1',
+    });
+    const blockRepository = Object.create(
+      Repository.prototype,
+    ) as Repository<ContextBlockEntity>;
+    jest.spyOn(blockRepository, 'findOne').mockResolvedValue(block);
+    jest.spyOn(blockRepository, 'count').mockResolvedValue(0);
+    const remove = jest.spyOn(blockRepository, 'delete');
+    const threadRepository = Object.create(
+      Repository.prototype,
+    ) as Repository<ThreadEntity>;
+    jest.spyOn(threadRepository, 'count').mockResolvedValue(1);
+    const manager = Object.create(EntityManager.prototype) as EntityManager;
+    Object.defineProperty(manager, 'getRepository', {
+      value: (entity: typeof ContextBlockEntity | typeof ThreadEntity) =>
+        entity === ContextBlockEntity ? blockRepository : threadRepository,
+    });
+    const dataSource = Object.create(DataSource.prototype) as DataSource;
+    Object.defineProperty(dataSource, 'transaction', {
+      value: jest.fn(
+        async (
+          callback: (transactionManager: EntityManager) => Promise<unknown>,
+        ) => callback(manager),
+      ),
+    });
+    const outboxWriter = Object.create(
+      OutboxWriterService.prototype,
+    ) as OutboxWriterService;
+    const useCase = new DeleteContextBlockUseCase(dataSource, outboxWriter);
+
+    await expect(useCase.execute(block.id)).rejects.toBeInstanceOf(
+      BlockIsThreadStateError,
+    );
+
+    expect(remove).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/context/use-cases/delete-context-block.use-case.ts
+++ b/apps/backend/src/context/use-cases/delete-context-block.use-case.ts
@@ -28,7 +28,6 @@ export class DeleteContextBlockUseCase {
       if (childCount > 0) throw new BlockHasChildrenError(blockId, childCount);
       const threadCount = await manager.getRepository(ThreadEntity).count({
         where: { stateContextBlockId: blockId },
-        withDeleted: true,
       });
       if (threadCount > 0)
         throw new BlockIsThreadStateError(blockId, threadCount);


### PR DESCRIPTION
## Summary\n- exclude soft-deleted threads from the state-block deletion guard\n- retain the guard for active threads\n- add regression coverage for both behaviors\n\n## Validation\n- npm run build:dev\n- npm -w apps/backend test -- --runInBand src/context/use-cases/delete-context-block.use-case.spec.ts\n- npm run dev:1\n\n## Technical debt\nNone.