### PR TITLE
fix: release deleted thread state blocks

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -48,6 +48,7 @@ import { AddWorkerVersionFields1742700000000 } from './migrations/1742700000000-
 import { RemovePlannerPlanTagTrigger1742800000000 } from './migrations/1742800000000-RemovePlannerPlanTagTrigger';
 import { AddTransactionalOutbox1742900000000 } from './migrations/1742900000000-AddTransactionalOutbox';
 import { EnforceSingleActiveJwksKey1743000000000 } from './migrations/1743000000000-EnforceSingleActiveJwksKey';
+import { AllowDeletedThreadStateBlockRemoval1743100000000 } from './migrations/1743100000000-AllowDeletedThreadStateBlockRemoval';
 import { SecretsModule } from './secrets/secrets.module';
 import { ChatProvidersModule } from './chat-providers/chat-providers.module';
 import { ExecutionsModule } from './executions/executions.module';
@@ -96,6 +97,7 @@ import { OutboxModule } from './outbox/outbox.module';
         RemovePlannerPlanTagTrigger1742800000000,
         AddTransactionalOutbox1742900000000,
         EnforceSingleActiveJwksKey1743000000000,
+        AllowDeletedThreadStateBlockRemoval1743100000000,
       ],
     }),
     EventEmitterModule.forRoot(),

--- a/apps/backend/src/migrations/1743100000000-AllowDeletedThreadStateBlockRemoval.ts
+++ b/apps/backend/src/migrations/1743100000000-AllowDeletedThreadStateBlockRemoval.ts
@@ -1,0 +1,62 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AllowDeletedThreadStateBlockRemoval1743100000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.recreateThreadsTable(queryRunner, 'SET NULL');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await this.recreateThreadsTable(queryRunner, 'RESTRICT');
+  }
+
+  private async recreateThreadsTable(
+    queryRunner: QueryRunner,
+    onDelete: 'RESTRICT' | 'SET NULL',
+  ): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE threads_new (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        chat_session_id TEXT,
+        created_by_actor_id TEXT NOT NULL,
+        parent_task_id TEXT,
+        state_context_block_id TEXT,
+        row_version INTEGER NOT NULL DEFAULT 1,
+        created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+        updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+        deleted_at DATETIME,
+        FOREIGN KEY (created_by_actor_id) REFERENCES actors(id),
+        FOREIGN KEY (parent_task_id) REFERENCES tasks(id),
+        FOREIGN KEY (state_context_block_id) REFERENCES context_blocks(id) ON DELETE ${onDelete}
+      )
+    `);
+    await queryRunner.query(`
+      INSERT INTO threads_new (
+        id, title, chat_session_id, created_by_actor_id, parent_task_id,
+        state_context_block_id, row_version, created_at, updated_at, deleted_at
+      )
+      SELECT
+        id, title, chat_session_id, created_by_actor_id, parent_task_id,
+        state_context_block_id, row_version, created_at, updated_at, deleted_at
+      FROM threads
+    `);
+    await queryRunner.query(`DROP TABLE threads`);
+    await queryRunner.query(`ALTER TABLE threads_new RENAME TO threads`);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_threads_parent_task_id
+      ON threads(parent_task_id)
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_threads_state_context_block_id
+      ON threads(state_context_block_id)
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_threads_parent_task_id_non_null
+      ON threads(parent_task_id)
+      WHERE parent_task_id IS NOT NULL
+        AND deleted_at IS NULL
+    `);
+  }
+}

--- a/apps/backend/src/threads/thread.entity.ts
+++ b/apps/backend/src/threads/thread.entity.ts
@@ -43,10 +43,10 @@ export class ThreadEntity {
   @JoinColumn({ name: 'parent_task_id' })
   parentTask?: TaskEntity;
 
-  @Column({ type: 'uuid', nullable: false, name: 'state_context_block_id' })
+  @Column({ type: 'uuid', nullable: true, name: 'state_context_block_id' })
   stateContextBlockId!: string;
 
-  @ManyToOne(() => ContextBlockEntity, { onDelete: 'RESTRICT' })
+  @ManyToOne(() => ContextBlockEntity, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'state_context_block_id' })
   stateContextBlock?: ContextBlockEntity;
 

--- a/apps/backend/test/threads.e2e-spec.ts
+++ b/apps/backend/test/threads.e2e-spec.ts
@@ -444,25 +444,22 @@ describe('Threads E2E Tests - Parent Task ID', () => {
       expect(response.body.detail).toContain('thread');
     });
 
-    it('should still fail to delete state block after thread is soft-deleted', async () => {
+    it('should delete the state block after the thread is soft-deleted', async () => {
       // First, delete the thread (soft delete)
       await request(httpServer)
         .delete(`/api/v1/threads/${stateBlockThreadId}`)
         .set('Cookie', authCookies)
         .expect(204);
 
-      // The state block should still NOT be deletable because:
-      // 1. Soft-deleted threads still exist in the database
-      // 2. The FK constraint (onDelete: 'RESTRICT') still applies to soft-deleted rows
-      // 3. Our guard correctly checks for threads including soft-deleted ones
-      const response = await request(httpServer)
+      await request(httpServer)
         .delete(`/api/v1/context/blocks/${stateBlockId}`)
         .set('Cookie', authCookies)
-        .expect(400);
+        .expect(204);
 
-      expect(response.body).toHaveProperty('status', 400);
-      expect(response.body).toHaveProperty('type', '/errors/context/block-is-thread-state');
-      expect(response.body.detail).toContain('Cannot delete context block');
+      await request(httpServer)
+        .get(`/api/v1/context/blocks/${stateBlockId}`)
+        .set('Cookie', authCookies)
+        .expect(404);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add a SQLite migration that makes the thread state-block FK nullable with ON DELETE SET NULL.
- Retain the active-thread deletion guard while permitting removal after the thread is soft-deleted.
- Cover the full thread deletion followed by state-block deletion workflow with an e2e regression test.

## Validation
- npm run build:dev
- focused backend unit tests
- focused State Context Block Deletion Validation e2e test
- npm run dev:1

## Technical debt
The complete threads e2e suite has two pre-existing failing assertions that conflict with current behavior: it expects a missing parent task to return 400 and multiple threads for one parent task to succeed. The focused regression passes.