### PR TITLE
fix: hard-delete threads and clean legacy records

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -48,6 +48,7 @@ import { AddWorkerVersionFields1742700000000 } from './migrations/1742700000000-
 import { RemovePlannerPlanTagTrigger1742800000000 } from './migrations/1742800000000-RemovePlannerPlanTagTrigger';
 import { AddTransactionalOutbox1742900000000 } from './migrations/1742900000000-AddTransactionalOutbox';
 import { EnforceSingleActiveJwksKey1743000000000 } from './migrations/1743000000000-EnforceSingleActiveJwksKey';
+import { HardDeleteSoftDeletedThreads1743100000000 } from './migrations/1743100000000-HardDeleteSoftDeletedThreads';
 import { SecretsModule } from './secrets/secrets.module';
 import { ChatProvidersModule } from './chat-providers/chat-providers.module';
 import { ExecutionsModule } from './executions/executions.module';
@@ -96,6 +97,7 @@ import { OutboxModule } from './outbox/outbox.module';
         RemovePlannerPlanTagTrigger1742800000000,
         AddTransactionalOutbox1742900000000,
         EnforceSingleActiveJwksKey1743000000000,
+        HardDeleteSoftDeletedThreads1743100000000,
       ],
     }),
     EventEmitterModule.forRoot(),

--- a/apps/backend/src/migrations/1743100000000-HardDeleteSoftDeletedThreads.spec.ts
+++ b/apps/backend/src/migrations/1743100000000-HardDeleteSoftDeletedThreads.spec.ts
@@ -1,0 +1,123 @@
+import { DataSource } from 'typeorm';
+import { HardDeleteSoftDeletedThreads1743100000000 } from './1743100000000-HardDeleteSoftDeletedThreads';
+
+describe('HardDeleteSoftDeletedThreads1743100000000', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({ type: 'sqlite', database: ':memory:' });
+    await dataSource.initialize();
+    await dataSource.query('PRAGMA foreign_keys = ON');
+
+    await dataSource.query('CREATE TABLE actors (id TEXT PRIMARY KEY)');
+    await dataSource.query('CREATE TABLE tasks (id TEXT PRIMARY KEY)');
+    await dataSource.query('CREATE TABLE context_blocks (id TEXT PRIMARY KEY)');
+    await dataSource.query('CREATE TABLE tags (id TEXT PRIMARY KEY)');
+    await dataSource.query(`
+      CREATE TABLE threads (
+        id TEXT PRIMARY KEY,
+        created_by_actor_id TEXT NOT NULL,
+        parent_task_id TEXT,
+        state_context_block_id TEXT NOT NULL,
+        deleted_at DATETIME,
+        FOREIGN KEY (created_by_actor_id) REFERENCES actors(id),
+        FOREIGN KEY (parent_task_id) REFERENCES tasks(id),
+        FOREIGN KEY (state_context_block_id) REFERENCES context_blocks(id) ON DELETE RESTRICT
+      )
+    `);
+    await dataSource.query(`
+      CREATE TABLE thread_messages (
+        id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE
+      )
+    `);
+    await dataSource.query(`
+      CREATE TABLE thread_tasks (
+        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+        task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE
+      )
+    `);
+    await dataSource.query(`
+      CREATE TABLE thread_context_blocks (
+        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+        context_block_id TEXT NOT NULL REFERENCES context_blocks(id) ON DELETE CASCADE
+      )
+    `);
+    await dataSource.query(`
+      CREATE TABLE thread_tags (
+        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+        tag_id TEXT NOT NULL REFERENCES tags(id) ON DELETE CASCADE
+      )
+    `);
+    await dataSource.query(`
+      CREATE TABLE thread_participants (
+        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+        actor_id TEXT NOT NULL REFERENCES actors(id) ON DELETE CASCADE
+      )
+    `);
+
+    await dataSource.query("INSERT INTO actors (id) VALUES ('actor')");
+    await dataSource.query("INSERT INTO tasks (id) VALUES ('task')");
+    await dataSource.query("INSERT INTO context_blocks (id) VALUES ('legacy-block'), ('active-block')");
+    await dataSource.query("INSERT INTO tags (id) VALUES ('tag')");
+    await dataSource.query(`
+      INSERT INTO threads (id, created_by_actor_id, parent_task_id, state_context_block_id, deleted_at)
+      VALUES ('legacy-thread', 'actor', 'task', 'legacy-block', datetime('now')),
+             ('active-thread', 'actor', 'task', 'active-block', NULL)
+    `);
+
+    for (const threadId of ['legacy-thread', 'active-thread']) {
+      await dataSource.query(`INSERT INTO thread_messages (id, thread_id) VALUES (?, ?)`, [
+        `${threadId}-message`,
+        threadId,
+      ]);
+      await dataSource.query(
+        'INSERT INTO thread_tasks (thread_id, task_id) VALUES (?, ?)',
+        [threadId, 'task'],
+      );
+      await dataSource.query(
+        'INSERT INTO thread_context_blocks (thread_id, context_block_id) VALUES (?, ?)',
+        [threadId, 'active-block'],
+      );
+      await dataSource.query(
+        'INSERT INTO thread_tags (thread_id, tag_id) VALUES (?, ?)',
+        [threadId, 'tag'],
+      );
+      await dataSource.query(
+        'INSERT INTO thread_participants (thread_id, actor_id) VALUES (?, ?)',
+        [threadId, 'actor'],
+      );
+    }
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('purges legacy soft-deleted threads and releases their state blocks', async () => {
+    const migration = new HardDeleteSoftDeletedThreads1743100000000();
+    await migration.up(dataSource.createQueryRunner());
+
+    await dataSource.query("DELETE FROM context_blocks WHERE id = 'legacy-block'");
+    await expect(dataSource.query("DELETE FROM context_blocks WHERE id = 'active-block'")).rejects.toThrow();
+
+    for (const table of [
+      'threads',
+      'thread_messages',
+      'thread_tasks',
+      'thread_context_blocks',
+      'thread_tags',
+      'thread_participants',
+    ]) {
+      const [row] = (await dataSource.query(
+        `SELECT COUNT(*) AS count FROM ${table} WHERE ${table === 'threads' ? 'id' : 'thread_id'} = 'legacy-thread'`,
+      )) as Array<{ count: number }>;
+      expect(row.count).toBe(0);
+    }
+
+    const [activeThread] = (await dataSource.query(
+      "SELECT id FROM threads WHERE id = 'active-thread'",
+    )) as Array<{ id: string }>;
+    expect(activeThread.id).toBe('active-thread');
+  });
+});

--- a/apps/backend/src/migrations/1743100000000-HardDeleteSoftDeletedThreads.ts
+++ b/apps/backend/src/migrations/1743100000000-HardDeleteSoftDeletedThreads.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class HardDeleteSoftDeletedThreads1743100000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Threads deleted before hard deletion retained a restrictive state-block FK.
+    // Removing those historical rows lets SQLite cascade their thread-owned data.
+    await queryRunner.query(`
+      DELETE FROM threads
+      WHERE deleted_at IS NOT NULL
+    `);
+  }
+
+  public async down(): Promise<void> {
+    // Historical soft-deleted rows cannot be restored after their data is purged.
+  }
+}

--- a/apps/backend/src/threads/use-cases/delete-thread.use-case.ts
+++ b/apps/backend/src/threads/use-cases/delete-thread.use-case.ts
@@ -17,7 +17,7 @@ export class DeleteThreadUseCase {
       const repository = manager.getRepository(ThreadEntity);
       const thread = await repository.findOne({ where: { id: threadId } });
       if (!thread) throw new ThreadNotFoundError(threadId);
-      await repository.softRemove(thread);
+      await repository.remove(thread);
       await this.outboxWriter.enqueue(manager, {
         type: OutboxEventTypes.THREAD_DELETED,
         actorId,

--- a/apps/backend/src/threads/use-cases/thread-mutation.use-cases.spec.ts
+++ b/apps/backend/src/threads/use-cases/thread-mutation.use-cases.spec.ts
@@ -22,9 +22,7 @@ describe('Thread mutation use cases', () => {
     ) as Repository<ThreadEntity>;
     jest.spyOn(repository, 'findOne').mockResolvedValue(thread);
     const save = jest.spyOn(repository, 'save').mockResolvedValue(thread);
-    const softRemove = jest
-      .spyOn(repository, 'softRemove')
-      .mockResolvedValue(thread);
+    const remove = jest.spyOn(repository, 'remove').mockResolvedValue(thread);
     const manager = Object.create(EntityManager.prototype) as EntityManager;
     jest.spyOn(manager, 'getRepository').mockReturnValue(repository);
     const dataSource = Object.create(DataSource.prototype) as DataSource;
@@ -49,7 +47,7 @@ describe('Thread mutation use cases', () => {
       dataSource,
       outboxWriter,
       save,
-      softRemove,
+      remove,
       enqueue,
     };
   }
@@ -73,14 +71,14 @@ describe('Thread mutation use cases', () => {
     );
   });
 
-  it('soft-deletes a thread and enqueues deletion in the same transaction', async () => {
-    const { thread, manager, dataSource, outboxWriter, softRemove, enqueue } =
+  it('hard-deletes a thread and enqueues deletion in the same transaction', async () => {
+    const { thread, manager, dataSource, outboxWriter, remove, enqueue } =
       setup();
     const useCase = new DeleteThreadUseCase(dataSource, outboxWriter);
 
     await useCase.execute(thread.id, 'actor-1');
 
-    expect(softRemove).toHaveBeenCalledWith(thread);
+    expect(remove).toHaveBeenCalledWith(thread);
     expect(enqueue).toHaveBeenCalledWith(
       manager,
       expect.objectContaining({

--- a/apps/backend/test/threads.e2e-spec.ts
+++ b/apps/backend/test/threads.e2e-spec.ts
@@ -444,25 +444,22 @@ describe('Threads E2E Tests - Parent Task ID', () => {
       expect(response.body.detail).toContain('thread');
     });
 
-    it('should still fail to delete state block after thread is soft-deleted', async () => {
-      // First, delete the thread (soft delete)
+    it('should delete the state block after its thread is deleted', async () => {
+      // Deleting the thread removes its FK reference to the state block.
       await request(httpServer)
         .delete(`/api/v1/threads/${stateBlockThreadId}`)
         .set('Cookie', authCookies)
         .expect(204);
 
-      // The state block should still NOT be deletable because:
-      // 1. Soft-deleted threads still exist in the database
-      // 2. The FK constraint (onDelete: 'RESTRICT') still applies to soft-deleted rows
-      // 3. Our guard correctly checks for threads including soft-deleted ones
-      const response = await request(httpServer)
+      await request(httpServer)
+        .get(`/api/v1/threads/${stateBlockThreadId}`)
+        .set('Cookie', authCookies)
+        .expect(404);
+
+      await request(httpServer)
         .delete(`/api/v1/context/blocks/${stateBlockId}`)
         .set('Cookie', authCookies)
-        .expect(400);
-
-      expect(response.body).toHaveProperty('status', 400);
-      expect(response.body).toHaveProperty('type', '/errors/context/block-is-thread-state');
-      expect(response.body.detail).toContain('Cannot delete context block');
+        .expect(204);
     });
   });
 });


### PR DESCRIPTION
## Summary
- hard-delete threads so their state-block FK is removed atomically
- purge pre-existing soft-deleted threads with a registered SQLite migration
- verify legacy dependent records cascade and their state blocks can be deleted

## Validation
- npm -w apps/backend run test -- --runInBand apps/backend/src/migrations/1743100000000-HardDeleteSoftDeletedThreads.spec.ts apps/backend/src/threads/use-cases/thread-mutation.use-cases.spec.ts apps/backend/src/context/use-cases/delete-context-block.use-case.spec.ts
- npm run build:dev
- npm run dev:1

## Technical debt
None.