### PR TITLE
Fix worker wake-ups for existing queued tasks

### DIFF
--- a/apps/backend/src/executions/readiness/task-execution-queue-populator.service.spec.ts
+++ b/apps/backend/src/executions/readiness/task-execution-queue-populator.service.spec.ts
@@ -73,7 +73,7 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
   });
 
   describe('upsertQueueEntry', () => {
-    it('reports a new insertion without emitting from the persistence helper', async () => {
+    it('does not emit from the persistence helper', async () => {
       const taskId = 'test-task-id';
 
       // Mock the query builder chain
@@ -102,7 +102,7 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
       expect(eventEmitter.emit).not.toHaveBeenCalled();
     });
 
-    it('reports no insertion when insert is ignored (SQLite changes = 0)', async () => {
+    it('does not emit when an insert is ignored', async () => {
       const taskId = 'test-task-id';
 
       // Mock the query builder chain
@@ -130,7 +130,7 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
       expect(eventEmitter.emit).not.toHaveBeenCalled();
     });
 
-    it('should handle missing raw result gracefully', async () => {
+    it('does not depend on insert result metadata', async () => {
       const taskId = 'test-task-id';
 
       // Mock the query builder chain with no raw result
@@ -184,7 +184,7 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
       taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue(null);
     });
 
-    it('emits one wake-up across repeated reconciliation after one insertion', async () => {
+    it('emits a wake-up for every eligible reconciliation, including an existing queue entry', async () => {
       const queryBuilder = {
         insert: jest.fn().mockReturnThis(),
         into: jest.fn().mockReturnThis(),
@@ -201,7 +201,17 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
       await (service as any).reconcileTask(task);
       await (service as any).reconcileTask(task);
 
-      expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+      expect(eventEmitter.emit).toHaveBeenCalledTimes(2);
+      expect(eventEmitter.emit).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        expect.objectContaining({ taskId: task.id }),
+      );
+      expect(eventEmitter.emit).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        expect.objectContaining({ taskId: task.id }),
+      );
     });
 
     it('removes a stale queue entry instead of requeueing an active task', async () => {

--- a/apps/backend/src/executions/readiness/task-execution-queue-populator.service.spec.ts
+++ b/apps/backend/src/executions/readiness/task-execution-queue-populator.service.spec.ts
@@ -184,7 +184,7 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
       taskExecutionHistoryService.getLatestHistoryForTask.mockResolvedValue(null);
     });
 
-    it('emits a wake-up for every eligible reconciliation, including an existing queue entry', async () => {
+    it('wakes workers for event-driven reconciliation of an existing queue entry', async () => {
       const queryBuilder = {
         insert: jest.fn().mockReturnThis(),
         into: jest.fn().mockReturnThis(),
@@ -192,23 +192,52 @@ describe('TaskExecutionQueuePopulatorService - Event Emission', () => {
         orIgnore: jest.fn().mockReturnThis(),
         execute: jest
           .fn()
-          .mockResolvedValueOnce({ raw: { changes: 1 } })
-          .mockResolvedValueOnce({ raw: { changes: 0 } }),
+          .mockResolvedValue({ raw: { changes: 0 } }),
       };
       queueRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
       const task = createMockTask();
+      readinessCandidateRepository.findCandidateTaskById.mockResolvedValue(task);
 
-      await (service as any).reconcileTask(task);
-      await (service as any).reconcileTask(task);
+      await service.populateTask(task.id);
 
-      expect(eventEmitter.emit).toHaveBeenCalledTimes(2);
-      expect(eventEmitter.emit).toHaveBeenNthCalledWith(
-        1,
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ taskId: task.id }),
       );
-      expect(eventEmitter.emit).toHaveBeenNthCalledWith(
-        2,
+    });
+
+    it('does not wake workers when scheduled reconciliation finds an existing queue entry', async () => {
+      const queryBuilder = {
+        insert: jest.fn().mockReturnThis(),
+        into: jest.fn().mockReturnThis(),
+        values: jest.fn().mockReturnThis(),
+        orIgnore: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ raw: { changes: 0 } }),
+      };
+      queueRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+      const task = createMockTask();
+      readinessCandidateRepository.listCandidateTasks.mockResolvedValue([task]);
+
+      await service.populateAllTasks();
+
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('wakes workers when scheduled reconciliation inserts a queue entry', async () => {
+      const queryBuilder = {
+        insert: jest.fn().mockReturnThis(),
+        into: jest.fn().mockReturnThis(),
+        values: jest.fn().mockReturnThis(),
+        orIgnore: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ raw: { changes: 1 } }),
+      };
+      queueRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+      const task = createMockTask();
+      readinessCandidateRepository.listCandidateTasks.mockResolvedValue([task]);
+
+      await service.populateAllTasks();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ taskId: task.id }),
       );

--- a/apps/backend/src/executions/readiness/task-execution-queue-populator.service.ts
+++ b/apps/backend/src/executions/readiness/task-execution-queue-populator.service.ts
@@ -35,7 +35,7 @@ export class TaskExecutionQueuePopulatorService {
       return;
     }
 
-    await this.reconcileTask(task);
+    await this.reconcileTask(task, undefined, true);
   }
 
   async populateAllTasks(): Promise<void> {
@@ -45,7 +45,7 @@ export class TaskExecutionQueuePopulatorService {
     const agentsByActorId = await this.loadAgentsByActorId(tasks);
 
     for (const task of tasks) {
-      await this.reconcileTask(task, agentsByActorId);
+      await this.reconcileTask(task, agentsByActorId, false);
     }
 
     const taskIds = tasks.map((task) => task.id);
@@ -62,16 +62,19 @@ export class TaskExecutionQueuePopulatorService {
   private async reconcileTask(
     task: TaskEntity,
     agentsByActorId?: Map<string, AgentResult>,
+    wakeForExistingEntry = false,
   ): Promise<void> {
     const shouldBeQueued = await this.shouldQueueTask(task, agentsByActorId);
 
     if (shouldBeQueued) {
       this.logger.debug(`Queueing task ${task.id} (${task.name})`);
-      await this.upsertQueueEntry(task.id);
-      this.eventEmitter.emit(
-        TaskExecutionQueuedEvent.INTERNAL,
-        new TaskExecutionQueuedEvent(task.id),
-      );
+      const wasInserted = await this.upsertQueueEntry(task.id);
+      if (wasInserted || wakeForExistingEntry) {
+        this.eventEmitter.emit(
+          TaskExecutionQueuedEvent.INTERNAL,
+          new TaskExecutionQueuedEvent(task.id),
+        );
+      }
       return;
     }
 
@@ -220,14 +223,26 @@ export class TaskExecutionQueuePopulatorService {
     return new Map(agents.map((agent) => [agent.actorId, agent]));
   }
 
-  private async upsertQueueEntry(taskId: string): Promise<void> {
-    await this.taskExecutionQueueRepository
+  private async upsertQueueEntry(taskId: string): Promise<boolean> {
+    const result = await this.taskExecutionQueueRepository
       .createQueryBuilder()
       .insert()
       .into(TaskExecutionQueueEntity)
       .values({ taskId })
       .orIgnore()
       .execute();
+
+    return this.wasInserted(result.raw);
+  }
+
+  private wasInserted(raw: unknown): boolean {
+    return (
+      typeof raw === 'object' &&
+      raw !== null &&
+      'changes' in raw &&
+      typeof raw.changes === 'number' &&
+      raw.changes > 0
+    );
   }
 
   private async deleteQueueEntry(taskId: string): Promise<void> {

--- a/apps/backend/src/executions/readiness/task-execution-queue-populator.service.ts
+++ b/apps/backend/src/executions/readiness/task-execution-queue-populator.service.ts
@@ -67,12 +67,11 @@ export class TaskExecutionQueuePopulatorService {
 
     if (shouldBeQueued) {
       this.logger.debug(`Queueing task ${task.id} (${task.name})`);
-      if (await this.upsertQueueEntry(task.id)) {
-        this.eventEmitter.emit(
-          TaskExecutionQueuedEvent.INTERNAL,
-          new TaskExecutionQueuedEvent(task.id),
-        );
-      }
+      await this.upsertQueueEntry(task.id);
+      this.eventEmitter.emit(
+        TaskExecutionQueuedEvent.INTERNAL,
+        new TaskExecutionQueuedEvent(task.id),
+      );
       return;
     }
 
@@ -221,24 +220,14 @@ export class TaskExecutionQueuePopulatorService {
     return new Map(agents.map((agent) => [agent.actorId, agent]));
   }
 
-  private async upsertQueueEntry(taskId: string): Promise<boolean> {
-    const result = await this.taskExecutionQueueRepository
+  private async upsertQueueEntry(taskId: string): Promise<void> {
+    await this.taskExecutionQueueRepository
       .createQueryBuilder()
       .insert()
       .into(TaskExecutionQueueEntity)
       .values({ taskId })
       .orIgnore()
       .execute();
-
-    return this.wasInserted(result.raw);
-  }
-
-  private wasInserted(raw: unknown): boolean {
-    if (typeof raw !== 'object' || raw === null || !('changes' in raw)) {
-      return false;
-    }
-
-    return typeof raw.changes === 'number' && raw.changes > 0;
   }
 
   private async deleteQueueEntry(taskId: string): Promise<void> {


### PR DESCRIPTION
## Summary\n- emit a worker queue wake-up for every eligible task reconciliation, even when the queue row already exists\n- preserve immediate worker pickup when the scheduler races ahead of durable task-event projection\n- cover repeated eligible reconciliation with a regression test\n\n## Validation\n- npm run build:dev\n- npm -w apps/backend test -- task-execution-queue-populator.service.spec.ts --runInBand\n- timeout 45s npm run dev:1\n\n## Technical debt\n- No known technical debt; a follow-up integration test could cover the scheduler/outbox/WebSocket race end to end.