### PR TITLE
Fix deleted thread state block cleanup

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -48,6 +48,7 @@ import { AddWorkerVersionFields1742700000000 } from './migrations/1742700000000-
 import { RemovePlannerPlanTagTrigger1742800000000 } from './migrations/1742800000000-RemovePlannerPlanTagTrigger';
 import { AddTransactionalOutbox1742900000000 } from './migrations/1742900000000-AddTransactionalOutbox';
 import { EnforceSingleActiveJwksKey1743000000000 } from './migrations/1743000000000-EnforceSingleActiveJwksKey';
+import { PurgeSoftDeletedThreads1743100000000 } from './migrations/1743100000000-PurgeSoftDeletedThreads';
 import { SecretsModule } from './secrets/secrets.module';
 import { ChatProvidersModule } from './chat-providers/chat-providers.module';
 import { ExecutionsModule } from './executions/executions.module';
@@ -96,6 +97,7 @@ import { OutboxModule } from './outbox/outbox.module';
         RemovePlannerPlanTagTrigger1742800000000,
         AddTransactionalOutbox1742900000000,
         EnforceSingleActiveJwksKey1743000000000,
+        PurgeSoftDeletedThreads1743100000000,
       ],
     }),
     EventEmitterModule.forRoot(),

--- a/apps/backend/src/migrations/1743100000000-PurgeSoftDeletedThreads.ts
+++ b/apps/backend/src/migrations/1743100000000-PurgeSoftDeletedThreads.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PurgeSoftDeletedThreads1743100000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM threads
+      WHERE deleted_at IS NOT NULL
+    `);
+  }
+
+  public async down(): Promise<void> {}
+}

--- a/apps/backend/src/threads/use-cases/delete-thread.use-case.ts
+++ b/apps/backend/src/threads/use-cases/delete-thread.use-case.ts
@@ -17,7 +17,7 @@ export class DeleteThreadUseCase {
       const repository = manager.getRepository(ThreadEntity);
       const thread = await repository.findOne({ where: { id: threadId } });
       if (!thread) throw new ThreadNotFoundError(threadId);
-      await repository.softRemove(thread);
+      await repository.remove(thread);
       await this.outboxWriter.enqueue(manager, {
         type: OutboxEventTypes.THREAD_DELETED,
         actorId,

--- a/apps/backend/src/threads/use-cases/thread-mutation.use-cases.spec.ts
+++ b/apps/backend/src/threads/use-cases/thread-mutation.use-cases.spec.ts
@@ -22,8 +22,8 @@ describe('Thread mutation use cases', () => {
     ) as Repository<ThreadEntity>;
     jest.spyOn(repository, 'findOne').mockResolvedValue(thread);
     const save = jest.spyOn(repository, 'save').mockResolvedValue(thread);
-    const softRemove = jest
-      .spyOn(repository, 'softRemove')
+    const remove = jest
+      .spyOn(repository, 'remove')
       .mockResolvedValue(thread);
     const manager = Object.create(EntityManager.prototype) as EntityManager;
     jest.spyOn(manager, 'getRepository').mockReturnValue(repository);
@@ -49,7 +49,7 @@ describe('Thread mutation use cases', () => {
       dataSource,
       outboxWriter,
       save,
-      softRemove,
+      remove,
       enqueue,
     };
   }
@@ -73,14 +73,14 @@ describe('Thread mutation use cases', () => {
     );
   });
 
-  it('soft-deletes a thread and enqueues deletion in the same transaction', async () => {
-    const { thread, manager, dataSource, outboxWriter, softRemove, enqueue } =
+  it('deletes a thread and enqueues deletion in the same transaction', async () => {
+    const { thread, manager, dataSource, outboxWriter, remove, enqueue } =
       setup();
     const useCase = new DeleteThreadUseCase(dataSource, outboxWriter);
 
     await useCase.execute(thread.id, 'actor-1');
 
-    expect(softRemove).toHaveBeenCalledWith(thread);
+    expect(remove).toHaveBeenCalledWith(thread);
     expect(enqueue).toHaveBeenCalledWith(
       manager,
       expect.objectContaining({


### PR DESCRIPTION
## Summary\n- hard-delete threads so their state-block foreign keys are released\n- purge existing soft-deleted threads through a registered migration\n- retain transactional deletion event behavior and update its test\n\n## Validation\n- npm run build:dev\n- npx nx test @taico/taico --runInBand\n- timeout 40s npm run dev:1 (backend started at http://localhost:2003; expected AppInitRunner prompt setup error observed)\n\n## Technical debt\n- None.